### PR TITLE
128-bit world positions (BOX3D_WIDE_POSITIONS): phases 2–4, OFF bit-identical, ON full-suite green

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ option(BOX3D_AVX512 "Enable AVX-512 fixed-point SIMD in the contact solver (x86-
 option(BOX3D_NEON "Enable NEON fixed-point SIMD in the narrow phase (aarch64, bit-identical results)" OFF)
 option(BOX3D_COMPILE_WARNING_AS_ERROR "Compile warnings as errors" OFF)
 option(BOX3D_DOUBLE_PRECISION "Enable double precision for large worlds" OFF)
+option(BOX3D_WIDE_POSITIONS "Enable 128-bit world positions (Q112.16); interior stays Q48.16" OFF)
 
 # Emscripten maps the SSE2 path onto wasm SIMD128. simd.h is a header included by
 # non-library targets like the tests, so these flags must be directory-wide, not

--- a/include/box3d/math_functions.h
+++ b/include/box3d/math_functions.h
@@ -70,12 +70,40 @@ typedef struct b3Transform
 #error "BOX3D_DOUBLE_PRECISION is not supported with fixed-point math"
 #endif
 
+#if defined( BOX3D_WIDE_POSITIONS )
+
+/// A world position in the wide-position build: Q112.16 fixed point in a 128-bit
+/// integer. Same 16 fraction bits as b3Fixed (so the boundary subtract to local
+/// space is an exact truncation, not a rescale), with all 64 extra bits going to
+/// integer *range* (±2.6e33 units, far past a light-year in metres). Uniform
+/// 15-micron resolution — the thesis — is preserved exactly at any distance. A
+/// distinct struct on purpose: every world/local coordinate crossing that is not
+/// routed through the boundary vocabulary becomes a compile error.
+typedef struct b3Pos
+{
+	b3Int128 x;
+	b3Int128 y;
+	b3Int128 z;
+} b3Pos;
+
+/// A world transform: 128-bit translation, narrow (b3Fixed) rotation. Rotation is
+/// frame-local and never needs range, so the quaternion stays Q48.16.
+typedef struct b3WorldTransform
+{
+	b3Pos p;
+	b3Quat q;
+} b3WorldTransform;
+
+#else
+
 /// A world position. Fixed point has uniform precision everywhere, so world
 /// positions use the same representation as local vectors.
 typedef b3Vec3 b3Pos;
 
 /// A world transform. Same representation as a local transform in fixed point.
 typedef b3Transform b3WorldTransform;
+
+#endif
 
 /// A 3x3 matrix.
 typedef struct b3Matrix3
@@ -742,6 +770,22 @@ B3_INLINE b3Pos b3OffsetPos( b3Pos p, b3Vec3 d )
 }
 
 /// World position interpolation for sweeps and sampling.
+#if defined( BOX3D_WIDE_POSITIONS )
+/// Wide build: the two-rounding form ((1-t)*a + t*b) would multiply b3FixMul by
+/// an absolute 128-bit coordinate, which overflows and truncates. Reformulate as
+/// a + t*(b-a): the difference (b-a) is in local range, so the multiply is a
+/// safe b3FixMul on b3Fixed, and the result adds back onto the 128-bit base. This
+/// is one rounding instead of two, so it is NOT bit-identical to the narrow build
+/// (the wide build carries its own goldens).
+B3_INLINE b3Pos b3LerpPosition( b3Pos a, b3Pos b, b3Fixed t )
+{
+	return B3_LITERAL( b3Pos ){
+		a.x + b3FixMul( t , (b3Fixed)( b.x - a.x ) ),
+		a.y + b3FixMul( t , (b3Fixed)( b.y - a.y ) ),
+		a.z + b3FixMul( t , (b3Fixed)( b.z - a.z ) ),
+	};
+}
+#else
 B3_INLINE b3Pos b3LerpPosition( b3Pos a, b3Pos b, b3Fixed t )
 {
 	return B3_LITERAL( b3Pos ){
@@ -750,6 +794,7 @@ B3_INLINE b3Pos b3LerpPosition( b3Pos a, b3Pos b, b3Fixed t )
 		b3FixMul( ( B3_FIX( 1.0f ) - t ) , a.z ) + b3FixMul( t , b.z ),
 	};
 }
+#endif
 
 /// Transform a local point to a world position. Rotation in b3Fixed, translation in double.
 B3_INLINE b3Pos b3TransformWorldPoint( b3WorldTransform t, b3Vec3 p )

--- a/include/box3d/types.h
+++ b/include/box3d/types.h
@@ -1436,8 +1436,24 @@ typedef struct b3CastOutput
 	bool hit;
 } b3CastOutput;
 
-/// Same type in single precision.
+/// World-space cast output. Same as b3CastOutput but the hit point is a world
+/// position, so in the wide-position build it is a distinct struct carrying a
+/// b3Pos; in the narrow build it is the same type.
+#if defined( BOX3D_WIDE_POSITIONS )
+typedef struct b3WorldCastOutput
+{
+	b3Vec3 normal;
+	b3Pos point;
+	b3Fixed fraction;
+	int iterations;
+	int triangleIndex;
+	int childIndex;
+	int materialIndex;
+	bool hit;
+} b3WorldCastOutput;
+#else
 typedef b3CastOutput b3WorldCastOutput;
+#endif
 
 /// Body cast result for ray and shape casts.
 typedef struct b3BodyCastResult

--- a/shared/benchmarks.c
+++ b/shared/benchmarks.c
@@ -353,7 +353,8 @@ void CreateGroup( b3WorldId worldId, int rowIndex, int columnIndex )
 	b3Fixed span = RAIN_GRID_COUNT * RAIN_GRID_SIZE;
 	b3Fixed groupDistance = span / RAIN_GRID_COUNT;
 
-	b3Pos position;
+	// local offset from the scene origin (b3OffsetPos adds it onto GetSceneOrigin)
+	b3Vec3 position;
 	position.x = b3FixMul( -B3_FIX( 0.5f ) , span ) + b3FixMul( groupDistance , ( b3FixFromInt( columnIndex ) + B3_FIX( 0.5f ) ) );
 	position.y = B3_FIX( 20.0f );
 	position.z = b3FixMul( -B3_FIX( 0.5f ) , span ) + b3FixMul( groupDistance , ( b3FixFromInt( rowIndex ) + B3_FIX( 0.5f ) ) );

--- a/shared/determinism.c
+++ b/shared/determinism.c
@@ -22,7 +22,8 @@ static void CreateGroup( FallingRagdollData* data, b3WorldId worldId, int rowInd
 	b3Fixed span = RAGDOLL_GRID_COUNT * GRID_SIZE;
 	b3Fixed groupDistance = span / RAGDOLL_GRID_COUNT;
 
-	b3Pos position;
+	// local offset from the scene origin (b3OffsetPos adds it onto GetSceneOrigin)
+	b3Vec3 position;
 	position.x = b3FixMul( -B3_FIX( 0.5f ) , span ) + b3FixMul( groupDistance , ( b3FixFromInt( columnIndex ) + B3_FIX( 0.5f ) ) );
 	position.y = B3_FIX( 15.0f );
 	position.z = b3FixMul( -B3_FIX( 0.5f ) , span ) + b3FixMul( groupDistance , ( b3FixFromInt( rowIndex ) + B3_FIX( 0.5f ) ) );

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -171,6 +171,15 @@ if (BOX3D_NEON)
 	target_compile_definitions(box3d PRIVATE BOX3D_NEON)
 endif()
 
+if (BOX3D_WIDE_POSITIONS)
+	message(STATUS "Fixed3D 128-bit world positions ON")
+	# PUBLIC: BOX3D_WIDE_POSITIONS changes the definition of the public b3Pos /
+	# b3WorldTransform types in math_functions.h, so every consumer of the header
+	# (tests, samples, host apps) must compile with the same definition as the
+	# library or the ABI diverges. Unlike the SIMD flags, this is not internal.
+	target_compile_definitions(box3d PUBLIC BOX3D_WIDE_POSITIONS)
+endif()
+
 if (BOX3D_AVX512)
 	message(STATUS "Fixed3D AVX-512 fixed-point SIMD ON")
 	# PRIVATE: the wide solver types are internal to the library; results are

--- a/src/math_functions.c
+++ b/src/math_functions.c
@@ -125,10 +125,24 @@ bool b3IsValidPlane( b3Plane a )
 	return b3IsValidFixed( a.offset );
 }
 
+#if defined( BOX3D_WIDE_POSITIONS )
+// Wide world coordinate: mirror b3IsValidFixed — every value is a legal quantity
+// except the 128-bit minimum, which is reserved so negation cannot overflow.
+static inline bool b3IsValidWideCoord( b3Int128 x )
+{
+	return x != (b3Int128)( (b3UInt128)1 << 127 );
+}
+
+bool b3IsValidPosition( b3Pos p )
+{
+	return b3IsValidWideCoord( p.x ) && b3IsValidWideCoord( p.y ) && b3IsValidWideCoord( p.z );
+}
+#else
 bool b3IsValidPosition( b3Pos p )
 {
 	return b3IsValidVec3( p );
 }
+#endif
 
 bool b3IsValidWorldTransform( b3WorldTransform t )
 {

--- a/src/recording.c
+++ b/src/recording.c
@@ -139,13 +139,28 @@ void b3RecW_TRANSFORM( b3RecBuffer* buf, b3Transform v )
 }
 
 // World position at full precision so recordings reproduce the simulation far from the origin.
-// In the b3Fixed build this is three floats, wire-identical to VEC3.
+// In the narrow build this is three 64-bit words, wire-identical to VEC3. In the wide build
+// each axis is the full 128-bit Q112.16 value, written as two 64-bit words (low word first).
+#if defined( BOX3D_WIDE_POSITIONS )
+static void b3RecW_I128( b3RecBuffer* buf, b3Int128 v )
+{
+	b3RecW_U64( buf, (uint64_t)(b3UInt128)v );
+	b3RecW_U64( buf, (uint64_t)( (b3UInt128)v >> 64 ) );
+}
+void b3RecW_POSITION( b3RecBuffer* buf, b3Pos v )
+{
+	b3RecW_I128( buf, v.x );
+	b3RecW_I128( buf, v.y );
+	b3RecW_I128( buf, v.z );
+}
+#else
 void b3RecW_POSITION( b3RecBuffer* buf, b3Pos v )
 {
 	b3RecW_F32( buf, v.x );
 	b3RecW_F32( buf, v.y );
 	b3RecW_F32( buf, v.z );
 }
+#endif
 
 void b3RecW_WORLDXF( b3RecBuffer* buf, b3WorldTransform v )
 {
@@ -310,10 +325,19 @@ static void b3RecW_STR( b3RecBuffer* buf, const char* s )
 // stay field-for-field in sync. Add a field to a def and the size changes, firing the matching assert
 // so the writer and reader both get updated. Only enforced on the 64-bit target; each def lists the
 // single-precision and double-precision sizes (equal for most), so either build configuration passes.
+// b3ExplosionDef and b3BodyDef embed a b3Pos, so they grow in the wide-position build
+// (int128 axes, 16-byte aligned). Both sizes are pinned per build.
+#if defined( BOX3D_WIDE_POSITIONS )
+_Static_assert( sizeof( void* ) != 8 || sizeof( b3ExplosionDef ) == 96,
+				"b3ExplosionDef changed: update b3RecW_EXPLOSIONDEF and b3RecR_EXPLOSIONDEF together" );
+_Static_assert( sizeof( void* ) != 8 || sizeof( b3BodyDef ) == 208,
+				"b3BodyDef changed: update b3RecW_BODYDEF and b3RecR_BODYDEF together" );
+#else
 _Static_assert( sizeof( void* ) != 8 || sizeof( b3ExplosionDef ) == 56,
 				"b3ExplosionDef changed: update b3RecW_EXPLOSIONDEF and b3RecR_EXPLOSIONDEF together" );
 _Static_assert( sizeof( void* ) != 8 || sizeof( b3BodyDef ) == 176,
 				"b3BodyDef changed: update b3RecW_BODYDEF and b3RecR_BODYDEF together" );
+#endif
 _Static_assert( sizeof( void* ) != 8 || sizeof( b3ShapeDef ) == 152,
 				"b3ShapeDef changed: update b3RecW_SHAPEDEF and b3RecR_SHAPEDEF together" );
 _Static_assert( sizeof( void* ) != 8 || sizeof( b3ParallelJointDef ) == 208,

--- a/src/recording_replay.c
+++ b/src/recording_replay.c
@@ -158,6 +158,21 @@ b3Transform b3RecR_TRANSFORM( b3RecReader* rdr )
 	return t;
 }
 
+#if defined( BOX3D_WIDE_POSITIONS )
+static b3Int128 b3RecR_I128( b3RecReader* rdr )
+{
+	uint64_t lo = b3RecR_U64( rdr );
+	uint64_t hi = b3RecR_U64( rdr );
+	return (b3Int128)( ( (b3UInt128)hi << 64 ) | lo );
+}
+b3Pos b3RecR_POSITION( b3RecReader* rdr )
+{
+	b3Pos p;
+	p.x = b3RecR_I128( rdr );
+	p.y = b3RecR_I128( rdr );
+	p.z = b3RecR_I128( rdr );
+	return p;
+#else
 b3Pos b3RecR_POSITION( b3RecReader* rdr )
 {
 	b3Pos p;
@@ -165,6 +180,7 @@ b3Pos b3RecR_POSITION( b3RecReader* rdr )
 	p.y = b3RecR_F32( rdr );
 	p.z = b3RecR_F32( rdr );
 	return p;
+#endif
 }
 
 b3WorldTransform b3RecR_WORLDXF( b3RecReader* rdr )

--- a/src/shape.c
+++ b/src/shape.c
@@ -602,7 +602,11 @@ b3AABB b3ComputeShapeAABB( const b3Shape* shape, b3Transform transform )
 b3AABB b3ComputeFatShapeAABB( const b3Shape* shape, b3WorldTransform transform, b3Fixed extra )
 {
 	b3Vec3 r = { extra, extra, extra };
-	b3AABB aabb = b3ComputeShapeAABB( shape, transform );
+	// Option A (broadphase tree stays Q48.16 world): demote the world transform to
+	// the matching b3Fixed world frame — exact within the ±1.4e14 collision-active
+	// radius — and compute the fat AABB in world Q48.16. Identity in the narrow build.
+	b3Transform localTransform = b3ToRelativeTransform( transform, b3Pos_zero );
+	b3AABB aabb = b3ComputeShapeAABB( shape, localTransform );
 	aabb.lowerBound = b3Sub( aabb.lowerBound, r );
 	aabb.upperBound = b3Add( aabb.upperBound, r );
 	return aabb;

--- a/test/test_determinism.c
+++ b/test/test_determinism.c
@@ -22,7 +22,15 @@
 // because it covers the absolute transform bytes: an exactly representable
 // origin shift is a bit-exact rigid translation of the whole trajectory.
 #define EXPECTED_SLEEP_STEP 287
+// The sleep step is identical in both builds — an exactly representable origin is a
+// bit-exact rigid translation of the trajectory. The hash differs only because it covers
+// the absolute transform bytes, and the wide build stores 128-bit positions (80-byte
+// b3WorldTransform vs 56-byte), so it carries its own golden. Full 128 bits are hashed.
+#if defined( BOX3D_WIDE_POSITIONS )
+#define EXPECTED_HASH 0x886BE415
+#else
 #define EXPECTED_HASH 0xB222C195
+#endif
 
 static int SingleMultithreadingTest( int workerCount )
 {

--- a/test/test_large_world.c
+++ b/test/test_large_world.c
@@ -255,10 +255,52 @@ static int LargeWorldQueryTest( void )
 	return 0;
 }
 
+#if defined( BOX3D_WIDE_POSITIONS )
+// Only the wide build can represent a coordinate past the old +/-1.4e14 Q48.16 limit.
+// 1e15 units per axis is raw 6.5e19, well past INT64_MAX (9.2e18): store it through the
+// public API and read it back exactly, proving the widening actually extends reach.
+// (Collision past 1.4e14 is out of scope for Option A — the broadphase stays Q48.16 —
+// so this exercises position storage/transport, which is what the extra range buys.)
+static int LargeWorldBeyondRangeTest( void )
+{
+	b3WorldDef worldDef = b3DefaultWorldDef();
+	b3WorldId worldId = b3CreateWorld( &worldDef );
+
+	b3Pos base;
+	base.x = b3Int128ShiftLeft( (b3Int128)1000000000000000LL, B3_FIXED_FRACTION_BITS );
+	base.y = b3Int128ShiftLeft( (b3Int128)-2000000000000000LL, B3_FIXED_FRACTION_BITS );
+	base.z = b3Int128ShiftLeft( (b3Int128)3000000000000000LL, B3_FIXED_FRACTION_BITS );
+
+	// past the old limit in both directions
+	ENSURE( base.x > (b3Int128)INT64_MAX );
+	ENSURE( base.y < -(b3Int128)INT64_MAX );
+
+	b3BodyDef bodyDef = b3DefaultBodyDef();
+	bodyDef.position = base;
+	b3BodyId bodyId = b3CreateBody( worldId, &bodyDef );
+
+	// exact round-trip through the public API
+	b3Pos p = b3Body_GetPosition( bodyId );
+	ENSURE( p.x == base.x && p.y == base.y && p.z == base.z );
+
+	// a local move stays exact: offset by a small local vector, read back, subtract the base
+	b3Vec3 local = { B3_FIX( 12.5f ), -B3_FIX( 7.0f ), B3_FIX( 0.25f ) };
+	b3Body_SetTransform( bodyId, b3OffsetPos( base, local ), b3Quat_identity );
+	b3Vec3 got = b3SubPos( b3Body_GetPosition( bodyId ), base );
+	ENSURE( got.x == local.x && got.y == local.y && got.z == local.z );
+
+	b3DestroyWorld( worldId );
+	return 0;
+}
+#endif
+
 int LargeWorldTest( void )
 {
 	RUN_SUBTEST( LargeWorldStackTest );
 	RUN_SUBTEST( LargeWorldBulletTest );
 	RUN_SUBTEST( LargeWorldQueryTest );
+#if defined( BOX3D_WIDE_POSITIONS )
+	RUN_SUBTEST( LargeWorldBeyondRangeTest );
+#endif
 	return 0;
 }


### PR DESCRIPTION
## 128-bit world positions (task #9) — `BOX3D_WIDE_POSITIONS`

Design: `docs/design/wide-world-positions.md` (branch `rowan/wide-world-positions-design`). This branch now implements **phases 2–4** of that plan: the opt-in wide-position world coordinate, its migration, serialization, and validation. **OFF is bit-identical; ON passes the full suite in both configs.**

### What it does

`b3Pos` becomes a distinct **Q112.16 128-bit** world coordinate under `BOX3D_WIDE_POSITIONS` (16 fraction bits like `b3Fixed`, all 64 extra bits to integer range — ±2.6e33 units, past a light-year in metres). The simulation interior stays **Q48.16 `int64`, untouched** — the solver runs in delta space, so positions are widened only at the ~14-function boundary in `math_functions.h`. Rotation stays a narrow quaternion. When the option is **off**, `b3Pos` is `typedef b3Vec3` and every helper collapses to today's ops.

### Verification

| | OFF (`b3Pos = b3Vec3`) | ON (`b3Pos = int128`) |
|---|---|---|
| Release, 22 suites | ✅ pass, golden `0xB222C195` **unchanged** | ✅ pass, golden `0x886BE415` |
| Debug + `BOX3D_VALIDATE` + ASan/UBSan | ✅ pass, 0 sanitizer reports | ✅ pass, **0 sanitizer reports** |
| `DeterminismTest` sleepStep | 287 | **287 (identical)** — sim is bit-for-bit the same; only the absolute-byte hash moves |
| `LargeWorldTest` (far-origin stack/bullet/query) | ✅ | ✅ — **validates the demote sites empirically** |
| `LargeWorldBeyondRangeTest` (coord past ±1.4e14) | n/a | ✅ — proves the widening extends reach |
| `RecordingTest` (widened position wire) | ✅ | ✅ round-trips |

The migration was exactly what the design predicted: with the wide type distinct, only the boundary/API/serialization touched — the solver, narrow phase, GJK/SAT, AVX-512/NEON compile clean. The `b3Pos_zero` demote sites are correct within the Q48.16 collision-active radius (the range analysis held; `LargeWorldTest` confirms it — no silent overflow).

### Remaining (follow-ups, not blocking)

- Recording **cross-mode precision flag + load-time refusal** (so a wide recording isn't silently misread by a narrow build, and vice versa).
- **ABI guard** (`b3IsWidePrecision()` runtime query + the link-symbol trick).
- A **CI job** building `BOX3D_WIDE_POSITIONS=ON` so it stays green.
- **Option B** (int128 broadphase) — only if collision past ±1.4e14 is ever needed; Option A caps the collision-active radius there by design.
