### PR TITLE
Wide-positions follow-ups: CI job, recording precision guard, ABI guard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,10 @@ jobs:
   samples:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 8
+    # macOS runners: the Release sample build plus the 102-TU conversion audit runs
+    # ~8+ min and was intermittently killed at the old 8-minute cap (a 8m21s run
+    # tripped it). Headroom, not a hang — the audit is bounded and exits on findings.
+    timeout-minutes: 15
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,15 @@ jobs:
             os: ubuntu-latest
             args: '-DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18 -DBOX3D_AVX512=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo'
             test: 'sh -c "if grep -q avx512dq /proc/cpuinfo; then ./bin/test; else echo runner lacks AVX-512, compile-only; fi"'
+          # 128-bit world positions: build the wide b3Pos path under Debug+VALIDATE
+          # and ASan/UBSan (the int128 boundary, wire, and lerp reformulation are
+          # exercised here) so it cannot silently regress as upstream ports land.
+          # Carries its own determinism golden; OFF coverage is every other job.
+          - name: ubuntu-wide-positions
+            os: ubuntu-latest
+            timeout: 10
+            args: '-DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18 -DBOX3D_WIDE_POSITIONS=ON -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"'
+            test: ./bin/test
     steps:
     - uses: actions/checkout@v6
 

--- a/docs/design/wide-world-positions.md
+++ b/docs/design/wide-world-positions.md
@@ -1,0 +1,299 @@
+# Design: 128-bit world positions with high-precision local space
+
+Status: **IMPLEMENTED** as the opt-in `BOX3D_WIDE_POSITIONS` build (Rowan,
+2026-07-15). Phases 2–4 landed in #2 and the follow-up PR; OFF is bit-identical,
+ON passes the full suite in Release and Debug+VALIDATE+ASan/UBSan. This document
+is the design of record — a few points below read differently in hindsight, and
+the notable one is called out where it mattered. Built on the four-lens
+precision-architecture survey (preserved in the private rowan repo,
+`investigations/precision-architecture/`).
+
+> **Hindsight note (2026-07-15).** The build confirmed the central thesis
+> (the interior needs zero changes) and the Q112.16 boundary decision. Two
+> claims below were corrected by the implementation: (1) there are **seven**
+> `b3Pos_zero` demote sites, not three; and (2) they do **not** overflow at the
+> 0.8 AU scene origin — that coordinate (~7.9e15 raw) fits int64 comfortably, so
+> the demote is exact within the ±1.4e14 collision-active radius, which
+> `LargeWorldTest` confirms empirically. The demote sites only fail *beyond*
+> ±1.4e14, which Option A does not support for collision by design.
+
+## The question
+
+Fixed3D today uses one number format everywhere: Q48.16 in `int64_t`
+(`b3Fixed`), resolution 1/65536 ≈ 1.5e-5, range ±1.4e14. That uniform
+precision is the whole thesis — a body at 0.8 AU has the same 15-micron
+resolution as one at the origin. But it leaves two things on the table:
+
+1. **Range.** ±1.4e14 units is enormous, but it is still a wall. A
+   solar-system-scale world in metres (Neptune ≈ 4.5e12 m; a light-year ≈
+   9.5e15 m) runs out inside Q48.16.
+2. **Local precision.** 15 microns is coarse for the *small* end. It forces
+   the resolution-floor workarounds this codebase is full of: the 4-ULP
+   inertia floor (rule 6), the raw-128 normalize rewrite (rule 3), the
+   determinant-underflow 128-bit paths (rule 1), the `d > 0` squared-tolerance
+   fix (rule 7). All of these exist because 1.5e-5 is not fine enough near
+   zero.
+
+Upstream Box3D solved the mirror-image problem in float with
+`BOX3D_DOUBLE_PRECISION`: widen *only* world positions (to double), keep the
+hot interior in float, convert at a thin boundary. The survey confirms that
+architecture ports to fixed point almost 1:1 — and buys us **both** things at
+once, because a wider position type plus a finer local type is the same
+boundary with two different formats on its two sides.
+
+## The proposal in one sentence
+
+Make `b3Pos` a distinct **128-bit** fixed-point world coordinate; keep the
+entire simulation interior in `int64` fixed point exactly as it is today;
+convert between them at the ~13-function boundary that already exists.
+
+## What the survey settles (so we don't relitigate it)
+
+The single most important finding: **the boundary already exists, as a
+~13-function vocabulary in `math_functions.h`**, and outside that file the
+`src/` tree touches absolute world coordinates *only* through it —
+`b3SubPos`, `b3OffsetPos`, `b3InvMulWorldTransforms`, `b3ToRelativeTransform`,
+`b3TransformWorldPoint`, and friends. Upstream introduced this exact vocabulary
+for double precision; fixed3d inherited it and currently has each function
+collapse to a trivial `int64` op because `b3Pos` aliases `b3Vec3`. Widening
+`b3Pos` changes only these inlines and the three body fields behind them.
+
+The equally important negative finding: **the local format cannot be pushed
+to Q16.48** (the tempting "32 extra fraction bits" idea). The range audit is
+decisive — impulses reach 5.8M units, effective masses 32k–65k, inertia
+tensors 3e9, and `INT64_MAX`-as-infinity sentinels are load-bearing
+throughout. A Q16.48 local format (±32768 range) breaks masses, impulses,
+inertia, the sentinel convention, the SIMD bit-identity proofs, the int32
+narrow storage, and the NEON escape hatch — each independently fatal. So the
+interior **stays Q48.16**. This design widens the *world* end, not the *local*
+end. (Finer local precision, if we ever want it, is a separate and much harder
+project — noted in "Rejected / deferred" below.)
+
+## The two-format architecture
+
+```
+        WORLD (absolute)                    LOCAL (relative)
+        b3Pos = int128 fixed                b3Vec3 = int64 Q48.16
+        ─────────────────────               ────────────────────────
+        b3BodySim.transform.p               everything the solver sees
+        b3BodySim.center, center0           b3BodyState (deltas, velocities)
+        dynamic-tree AABBs (option A/B)     all narrow-phase math
+        public API positions                all joint math
+        query origins, event points         GJK / SAT / TOI / distance
+                                            mass properties, impulses, masses
+                    │                                    ▲
+                    └──────── the boundary ──────────────┘
+                     b3SubPos / b3OffsetPos / b3InvMul...
+                     int128 subtract → int64 (exact when
+                     the operands are within local range)
+```
+
+**Format for `b3Pos`: Q112.16 in `int128`** — the same **16 fraction bits**
+as `b3Fixed`, with the extra 64 bits going entirely to *integer* range
+(112 integer bits, ±2.6e33 units — far past a light-year in metres). This is
+the load-bearing decision, and matching the local fraction count is *why the
+whole design works*, not an incidental choice:
+
+- **The boundary subtract stays exact and shift-free.** When `b3Pos` and
+  `b3Fixed` share 16 fraction bits, an `int128 − int128` position difference
+  that fits Q48.16's range **is** the exact Q48.16 value in its low 64 bits —
+  no rescale, no rounding, just a range check and a truncation to `int64`.
+  Likewise the once-per-step delta-fold is `int128 += (int128)int64`, exact,
+  because the fraction points already align.
+- **Extra *fraction* bits in the world type would be worse than useless.** The
+  interior is Q48.16 and (per the survey) must stay there, so any fraction
+  bits beyond 16 are *thrown away at the boundary* the instant a position is
+  differenced into local space — while forcing every boundary op to rescale
+  (`>>N`) instead of truncate. Finer world resolution buys nothing the
+  interior can consume and costs the exactness that makes this elegant.
+- **Range, not resolution, is the only thing widening the type can add.** So
+  put all 64 new bits into range. Uniform 15-micron resolution — the repo's
+  thesis — is *preserved exactly*: a body at any representable distance has
+  the identical resolution it has today.
+
+The translation is 128-bit; **rotation stays a Q48.16 quaternion** — rotation
+is frame-local and never needs range (the same split Jolt uses for `DMat44`,
+and the same split upstream uses: wide translation, narrow rotation).
+
+**The boundary operation is exact.** In float, `b3SubPos` is "subtract then
+round to float" — lossy by nature, which is why upstream needs the entire
+`b3RoundDownFloat`/`b3RoundUpFloat` directed-rounding apparatus. In fixed
+point, `b3SubPos` is an **integer subtract**: `int128 − int128`, then narrow
+to `int64`. It is *exact* whenever the result fits Q48.16's ±1.4e14 range —
+which it always does for a contact pair, a joint, or a query, because those
+are AABB-adjacent or reach-bounded. The only failure mode is a range
+violation, so the helper needs a **range assert** (debug) / **saturate**
+(release), not rounding care. This deletes upstream's entire directed-rounding
+subsystem.
+
+## Why the interior needs zero changes
+
+The survey's subsystem census is the proof, and it rests on a design fixed3d
+already inherited from Erin: **the solver runs in delta space.** `b3BodyState`
+— the only per-body view the solver, the wide SIMD path, and the gather/scatter
+transposes ever touch — carries `deltaPosition`/`deltaRotation`, not absolute
+pose. Integration accumulates `h·v` into the delta; the absolute `int128`
+position is touched exactly **once per body per step**, at finalize
+(`solver.c` ~710), where the delta folds into `center` (an `int128 + int64`
+widening add). Sleep logic measures delta magnitude, never absolute position.
+
+Consequently, everything that makes fixed3d fast is out of scope:
+- the AVX-512 wide solver and its bit-identity multiply decomposition,
+- the NEON narrow-phase int32 path,
+- the `b3Vec3WN` int32 Q16.16 narrow constraint storage,
+- the gather/scatter transposes pinned by `_Static_assert`,
+- GJK / SAT / manifolds / TOI / distance,
+- mass properties, joint solving.
+
+None of them see a `b3Pos`. They see `int64` locals, exactly as today. This is
+the entire reason the design is viable rather than a rewrite.
+
+## The per-step / per-pair conversion budget (preserve these numbers)
+
+- **1 int128 add per body per step** — the finalize delta-fold.
+- **1 int128 subtract per contact manifold per update** — `anchorB = anchorA
+  + (posA − posB)`, then COM re-centering keeps anchor magnitudes at body
+  scale.
+- **1 int128 subtract per joint per step** — `deltaCenter` at prepare; all
+  sub-step solving is `int64` thereafter.
+- **1 int128 subtract per candidate per CCD sweep** — re-based on the fast
+  body's `center0`.
+- **1 int128 subtract per shape per query** — the origin-relative
+  re-differencing.
+
+All O(bodies/pairs/joints/queries) per step, never O(iterations). The hot
+inner loops stay pure `int64`.
+
+## The migration surface (what actually changes)
+
+1. **Three `b3BodySim` fields** widen: `transform.p`, `center`, `center0` —
+   three coordinate triples going from `int64` to `int128`, so +8 bytes per
+   coordinate × 9 = **+72 bytes/body** (before alignment). `b3BodyState`
+   untouched.
+2. **~13 boundary inlines** in `math_functions.h` gain real int128↔int64
+   bodies. `b3LerpPosition` is the one that currently does `b3FixMul` on
+   absolute coordinates — reformulate as `a + t·b3SubPos(b,a)` so the
+   multiply happens on the in-range difference (mind the round-half-up
+   asymmetry lessons from the scalar-fusion work).
+3. **The three "demote at `b3Pos_zero`" sites** (`broad_phase.c` compound
+   query, `mesh_contact.c` triangle query, `sensor.c` overlap) must re-base
+   on a nearby origin instead of world zero. Today they work because
+   `b3Pos==b3Vec3` makes absolute representation exact; with a distinct
+   `int128` `b3Pos` at the 0.8 AU scene origin they would overflow the demote.
+   **This is the highest-risk change** — it has no float analog to crib from,
+   and it is a silent-overflow class, not a compile error. Each re-bases on
+   the query AABB centre / body A position / sensor shape position
+   respectively.
+4. **Dynamic-tree AABBs** — decision, see Open question 2.
+5. **Public API + events** — every `b3Pos`/`b3WorldTransform` in `types.h`
+   and `box3d.h` (the survey enumerates the complete list: `b3BodyDef.position`,
+   `b3ContactHitEvent.point`, `b3RayResult.point`, the debug-draw callbacks,
+   the getters/setters). This re-opens the migration list that fixed3d closed
+   when it aliased `b3Pos == b3Vec3`.
+6. **Serialization / recording / determinism hash** — widen the wire to two
+   64-bit words per axis (recording already widened once, for `b3Fixed`), add
+   the snapshot precision flag + load-time refusal, and mix the **full** 128
+   bits into the determinism hash (else the gate silently validates only low
+   bits). New per-mode goldens.
+7. **ABI guard** — the `#define b3CreateWorld b3CreateWorldWidePositions`
+   link-error trick, PUBLIC compile definition, `b3IsWidePrecision()` runtime
+   query, widened `B3_HUGE`. All transfer literally from upstream's pattern.
+
+## Build model: opt-in, diffable, zero-cost when off
+
+Mirror upstream exactly: a CMake option (`BOX3D_WIDE_POSITIONS`) that, when
+**off**, makes `b3Pos` a `typedef` for `b3Vec3` and every boundary helper
+collapse to today's trivial `int64` ops — i.e. the current engine, bit-for-bit,
+goldens unchanged. When **on**, `b3Pos` is the distinct `int128` struct and the
+compiler enumerates every migration site for us (making it distinct rather than
+a wider typedef is what turns silent puns into compile errors — we *want* that).
+This keeps the default build and its performance table untouched, and makes the
+whole feature reviewable as a diff.
+
+## Acceptance suite (writes itself from upstream's, but stronger)
+
+Upstream's `test_large_world.c` patterns, ported — but where upstream asserts
+relative trajectories match "to 1e-3" (an honest float artifact), the fixed
+version asserts **bit-identical**, because exact integer subtraction makes the
+tolerance unnecessary (we already proved the 100 km → 0.8 AU origin shifts are
+bit-exact rigid translations, sleepStep unchanged):
+- same-sleep-step stack at a far base vs at the origin,
+- no-tunnel fast bullet caught by a thin wall far from origin,
+- fat-AABB containment far from origin,
+- query parity (overlap/cast/mover) at a far base,
+- hull manifold at a far base equals the origin manifold **exactly**.
+
+Plus a new class upstream can't test: **beyond ±1.4e14** (past old Q48.16
+range) to prove the widening actually extends reach, and an explicit
+**range-assert** test on `b3SubPos` for a pair separated by more than local
+range (the failure the design deliberately makes loud).
+
+## Open questions for review (Glenn)
+
+1. **`b3Pos` fraction bits — decided in the body of this doc: Q112.16**
+   (16 frac, matching `b3Fixed`). This is not really open; I'm flagging it
+   only because my first draft got it backwards (recommended more fraction
+   bits) and the correction is the crux of the whole design, so it's worth
+   your explicit sign-off. Sharing the local fraction count makes the boundary
+   a truncating range-check rather than an arithmetic rescale, and makes the
+   position difference *bit-identical* to the local value — extra world
+   fraction bits would be discarded at the boundary anyway while costing that
+   exactness. All 64 new bits go to range.
+2. **Dynamic-tree AABBs: stay Q48.16-world, or widen to int128?** Option A
+   (stay `int64` world): tree traversal is compare/min/max only, works at any
+   magnitude, and `b3AABB_Center`'s `lower+upper` sum only overflows past
+   ~7e13 — so a Q48.16 tree covers the *current* range for free and only shape
+   AABB *generation* changes. But it caps the *broadphase* world at ±1.4e14
+   even though positions now go further, so the extra range would be
+   body-position-only, not collision-active. Option B (widen tree to int128):
+   full range everywhere, but doubles the 48-byte node AABB field and the SAH
+   rebuild arrays, and touches the one hot subsystem this design otherwise
+   spares. **Recommendation: start with A** (positions widen, broadphase stays
+   Q48.16, document the "collision-active radius" as ±1.4e14 which is already
+   past any real content), measure, and only do B if a real world needs
+   collision past 1.4e14 units. This keeps phase 1 entirely out of the tree.
+3. **Is the extra *range* even the goal, or is it insurance?** The honest
+   framing: fixed3d at 0.8 AU already exceeds any shipped need. Q48.16's ±1.4e14
+   is not currently a constraint anyone has hit. So this feature is (a) future
+   insurance for solar-system-plus worlds, and (b) — more interestingly — the
+   *architecture* that a future finer-local-precision project would require.
+   Worth being clear-eyed that it may be built for elegance and headroom rather
+   than a present need. Your call on priority.
+
+## Rejected / deferred (with reasons, so nobody re-runs them)
+
+- **Q16.48 local format** (finer interior precision). Rejected by measurement:
+  breaks masses (32k–65k), impulses (5.8M), inertia (3e9), the
+  INT64_MAX-infinity sentinel convention (becomes 32768 units — smaller than
+  real impulses), the AVX-512 bit-identity proofs, the int32 narrow storage,
+  and the NEON int32 gate. The four "resolution-floor" bug classes it would
+  fix (rules 1/3/6/7) are already fixed by the raw-128 patterns. Not worth
+  reopening without a fundamentally different impulse representation.
+- **Mixed Q16.48-local + Q48.16-dynamic-quantities.** The hazard matrix shows
+  this makes the solver inner loop mixed-format at every line, with silent
+  format-alchemy through `b3FixMul` (both formats are the same bare `int64`
+  typedef, so even `conversion_audit.py` is blind). Strictly worse than the
+  raw-fixed-through-float class we just finished sweeping. Only viable with
+  distinct wrapper types and per-site shift annotations — a large, risky,
+  low-payoff project.
+- **Widening the local/interior format at all.** The interior is where all the
+  performance work lives (2.07× geomean, the convex_pile-beats-float result);
+  it stays `int64` Q48.16 untouched. This design deliberately confines all
+  change to the world boundary.
+
+## Phasing (if approved)
+
+- **Phase 2:** the `BOX3D_WIDE_POSITIONS`-off scaffold — introduce distinct
+  `b3Pos`/`b3WorldTransform` types that `typedef`-collapse to today's, land the
+  boundary-vocabulary indirection with zero behavior change, confirm goldens
+  bit-identical. (All the migration-site churn, none of the risk.)
+- **Phase 3:** the int128 bodies behind the option — three `b3BodySim` fields,
+  the boundary inlines, the three re-basing fixes, ABI guard. Tree stays
+  Q48.16 (Option A).
+- **Phase 4:** serialization/recording/hash widening + per-mode goldens +
+  the acceptance suite.
+- **Phase 5 (optional):** int128 tree (Option B) if a world needs
+  collision-active range past 1.4e14.
+
+Each phase is independently landable and the off-path stays bit-identical
+throughout.

--- a/include/box3d/box3d.h
+++ b/include/box3d/box3d.h
@@ -22,10 +22,22 @@
  * @{
  */
 
+/// ABI guard: BOX3D_WIDE_POSITIONS changes the size of b3Pos / b3WorldTransform, so a wide app
+/// linked against a narrow library (or vice versa) would pass structs of the wrong size across
+/// the boundary and corrupt silently. Decorating b3CreateWorld's symbol with the mode turns that
+/// mismatch into a link-time undefined-symbol error instead. Every program calls b3CreateWorld.
+#if defined( BOX3D_WIDE_POSITIONS )
+#define b3CreateWorld b3CreateWorld_widePositions
+#endif
+
 /// Create a world for rigid body simulation. A world contains bodies, shapes, and constraints. You may create
 /// up to 128 worlds. Each world is completely independent and may be simulated in parallel.
 /// @return the world id.
 B3_API b3WorldId b3CreateWorld( const b3WorldDef* def );
+
+/// True if this build uses 128-bit world positions (BOX3D_WIDE_POSITIONS). Lets a host confirm
+/// the library's precision mode at runtime; the link-time guard above catches ABI mismatches.
+B3_API bool b3IsWidePrecision( void );
 
 /// Destroy a world
 B3_API void b3DestroyWorld( b3WorldId worldId );

--- a/src/physics_world.c
+++ b/src/physics_world.c
@@ -202,6 +202,15 @@ static void b3DestroyWorkerContexts( b3World* world )
 	b3Array_Destroy( world->sensorTaskContexts );
 }
 
+bool b3IsWidePrecision( void )
+{
+#if defined( BOX3D_WIDE_POSITIONS )
+	return true;
+#else
+	return false;
+#endif
+}
+
 b3WorldId b3CreateWorld( const b3WorldDef* def )
 {
 	B3_CHECK_DEF( def );

--- a/src/recording.c
+++ b/src/recording.c
@@ -1071,6 +1071,9 @@ void b3StartRecordingIntoBuffer( b3World* world, b3Recording* recording )
 	hdr.versionMajor = B3_REC_VERSION_MAJOR;
 	hdr.versionMinor = B3_REC_VERSION_MINOR;
 	hdr.pointerWidth = (uint8_t)sizeof( void* );
+	// 8 in the narrow build, 16 in the wide-position build. b3RecW_POSITION writes one word
+	// per axis when this is 8 and two when it is 16, so replay must match the build.
+	hdr.positionWidth = (uint8_t)sizeof( ( (b3Pos*)0 )->x );
 	hdr.bigEndian = 0;
 	hdr.validationEnabled = B3_ENABLE_VALIDATION ? 1u : 0u;
 	hdr.lengthScale = b3GetLengthUnitsPerMeter();

--- a/src/recording.h
+++ b/src/recording.h
@@ -58,7 +58,8 @@ typedef struct b3RecHeader
 	uint8_t pointerWidth;	   // sizeof(void*), gates POD-def struct layout
 	uint8_t bigEndian;		   // 0 on all supported targets
 	uint8_t validationEnabled; // 1 if built with BOX3D_VALIDATE, diagnostic only
-	uint8_t reserved;
+	uint8_t positionWidth;	   // sizeof a world-position axis: 8 (Q48.16) or 16 (wide Q112.16).
+							   // 0 in legacy recordings, read as 8. Gates the position wire layout.
 	uint32_t reserved2;	 // explicit pad so the 64-bit fields align with no implicit gap
 	b3Fixed lengthScale; // b3GetLengthUnitsPerMeter(), Q48.16
 	uint64_t snapshotSize;		// bytes of snapshot blob after the header (0 in Phase 1)

--- a/src/recording.h
+++ b/src/recording.h
@@ -18,10 +18,29 @@
 #define B3_SNAP_FNV_INIT 14695981039346656037ull
 #define B3_SNAP_FNV_PRIME 1099511628211ull
 
-// Mix a world position at full width so the determinism gate validates past b3Fixed precision
-// when the body is far from the origin.
+// Mix a world position into the recording's state hash.
 static inline uint64_t b3FnvMixPosition( uint64_t hash, b3Pos p )
 {
+#if defined( BOX3D_WIDE_POSITIONS )
+	// Wide positions are 128-bit. Hash the FULL width of each axis as 64-bit chunks (matching
+	// B3_HASH_FLOAT for the other fields), so the determinism gate covers all 128 bits rather
+	// than silently validating only the low word.
+	const b3Int128 axes[3] = { p.x, p.y, p.z };
+	for ( int c = 0; c < 3; ++c )
+	{
+		uint64_t lo, hi;
+		memcpy( &lo, (const uint8_t*)&axes[c], 8 );
+		memcpy( &hi, (const uint8_t*)&axes[c] + 8, 8 );
+		hash = ( hash ^ lo ) * B3_SNAP_FNV_PRIME;
+		hash = ( hash ^ hi ) * B3_SNAP_FNV_PRIME;
+	}
+	return hash;
+#else
+	// Narrow build, unchanged (byte-stable). NOTE: this mixes only the low 4 bytes of each
+	// int64 axis, so the recording state hash under-covers a body far from the origin (its high
+	// integer bits go unhashed). Pre-existing and low-impact — a real divergence also perturbs
+	// the fully-hashed velocities/quaternion — but a genuine gap, tracked as a separate narrow-build follow-up. Left byte-stable
+	// here so the narrow recording gate does not shift with the wide-position work.
 	uint32_t fx, fy, fz;
 	memcpy( &fx, &p.x, 4 );
 	memcpy( &fy, &p.y, 4 );
@@ -31,6 +50,7 @@ static inline uint64_t b3FnvMixPosition( uint64_t hash, b3Pos p )
 	hash = ( hash ^ by ) * B3_SNAP_FNV_PRIME;
 	hash = ( hash ^ bz ) * B3_SNAP_FNV_PRIME;
 	return hash;
+#endif
 }
 
 typedef struct b3World b3World;

--- a/src/recording_replay.c
+++ b/src/recording_replay.c
@@ -2762,6 +2762,19 @@ b3RecPlayer* b3RecPlayer_Create( const void* data, int size, int workerCount )
 		printf( "b3RecPlayer_Create: pointer width mismatch %u vs %u\n", hdr.pointerWidth, (unsigned)sizeof( void* ) );
 		return NULL;
 	}
+	// The position wire is one word per axis at 8, two at 16; a mismatch would silently misread
+	// every world coordinate. Legacy recordings carry 0, which means the narrow layout (8).
+	{
+		unsigned fileAxis = hdr.positionWidth == 0 ? 8u : hdr.positionWidth;
+		unsigned buildAxis = (unsigned)sizeof( ( (b3Pos*)0 )->x );
+		if ( fileAxis != buildAxis )
+		{
+			printf( "b3RecPlayer_Create: position precision mismatch (recording %u-byte axis, build %u-byte). "
+					"A wide-position recording needs a BOX3D_WIDE_POSITIONS build and vice versa.\n",
+					fileAxis, buildAxis );
+			return NULL;
+		}
+	}
 	if ( hdr.bigEndian != 0 )
 	{
 		printf( "b3RecPlayer_Create: big-endian recording not supported\n" );

--- a/test/test_recording.c
+++ b/test/test_recording.c
@@ -1635,13 +1635,13 @@ static int ReservedHeaderBytes( void )
 	int recSize = b3Recording_GetSize( rec );
 	ENSURE( recSize >= (int)sizeof( b3RecHeader ) );
 
-	// Patch reserved fields at their byte offsets in b3RecHeader:
-	//   byte 11 : reserved  (uint8_t at offset 11)
+	// Patch the still-reserved header fields at their byte offsets in b3RecHeader and confirm
+	// replay ignores them. Byte 11 is NO LONGER reserved — it is positionWidth (validated on
+	// load, checked in the mismatch block below), so it is left intact here.
 	//   bytes 16-19 : reserved2 (uint32_t at offset 16)
 	//   bytes 20-23 : reserved3 (uint32_t at offset 20)
 	uint8_t* patched = (uint8_t*)b3Alloc( (size_t)recSize );
 	memcpy( patched, recData, (size_t)recSize );
-	patched[11] = 0xAB;
 	patched[16] = 0xCD;
 	patched[17] = 0xEF;
 	patched[18] = 0x12;
@@ -1652,6 +1652,14 @@ static int ReservedHeaderBytes( void )
 	patched[23] = 0xBC;
 	ENSURE( b3ValidateReplay( patched, recSize, 1 ) );
 	b3Free( patched, (size_t)recSize );
+
+	// positionWidth (byte 11) IS load-bearing: forge the other precision and confirm replay
+	// refuses rather than silently misreading every world coordinate. 8 <-> 16 either way.
+	uint8_t* wrongPrecision = (uint8_t*)b3Alloc( (size_t)recSize );
+	memcpy( wrongPrecision, recData, (size_t)recSize );
+	wrongPrecision[11] = wrongPrecision[11] == 16 ? 8 : 16;
+	ENSURE( b3ValidateReplay( wrongPrecision, recSize, 1 ) == false );
+	b3Free( wrongPrecision, (size_t)recSize );
 
 	b3DestroyRecording( rec );
 	return 0;


### PR DESCRIPTION
## Wide-positions follow-ups (post-#2)

The three non-blocking follow-ups flagged when 128-bit positions merged, so the feature can't silently regress and can't be mis-linked or mis-loaded.

- **CI job.** New `ubuntu-wide-positions` matrix job: clang-18, Debug + `BOX3D_VALIDATE` + ASan/UBSan, `BOX3D_WIDE_POSITIONS=ON`, full suite. Exercises the int128 boundary, the widened position wire, and the `b3LerpPosition` reformulation on every push/PR. (OFF coverage is every other job.)
- **Recording precision guard.** The header's spare `reserved` byte becomes `positionWidth` (8 narrow / 16 wide; legacy `0` reads as narrow). The writer stamps it and `b3RecPlayer_Create` **refuses** a recording whose precision doesn't match the build — the position wire is one 64-bit word per axis at 8 and two at 16, so a mismatch would silently misread every world coordinate. `ReservedHeaderBytes` now also forges the wrong precision and asserts the refusal.
- **ABI guard.** In the wide build, `b3CreateWorld`'s exported symbol is decorated `b3CreateWorld_widePositions` (verified in the archive). A wide app linked against a narrow library — or vice versa — then fails at **link time** instead of passing wrong-sized `b3Pos` structs across the boundary and corrupting silently. Plus a `b3IsWidePrecision()` runtime query.

**Verified:** OFF suite + golden `0xB222C195` unchanged; ON suite in Release and Debug+VALIDATE+ASan/UBSan. Recordings round-trip within a build and are refused across precisions.

Remaining after this: only Option B (int128 broadphase), and only if collision past ±1.4e14 is ever needed — deferred by design.
