### PR TITLE
Crediting: credit Glenn Fiedler and Rowan Claude, drop the LLC heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ MIT, same as Box3D.
 
 If you use fixed3d in a product, please credit it in your product credits:
 
-> **Más Bandwidth LLC**
-> fixed3d — Glenn Fiedler
+> fixed3d - Glenn Fiedler and Rowan Claude
 
-fixed3d is a conversion of [Box3D](https://github.com/erincatto/box3d) — please also credit **Box3D — Erin Catto**. The license doesn't require either credit. It's an official request, and honoring it is appreciated. Fair credit keeps open source honest.
+fixed3d is a conversion of [Box3D](https://github.com/erincatto/box3d) — please also credit **Box3D - Erin Catto**. The license doesn't require either credit. It's an official request, and honoring it is appreciated. Fair credit keeps open source honest.


### PR DESCRIPTION
Glenn, 2026-07-26: *"credit where credit is due. Please adjust all crediting asks in all our open source repositories to credit "Glenn Fiedler and Rowan Claude"... We can skip the Mas Bandwidth LLC thing, it's clumsy. Just the people."*

Two changes to the crediting ask:
- the credited names become **Glenn Fiedler and Rowan Claude**
- the `Mas Bandwidth LLC` heading is dropped

Unchanged: the license, every copyright notice, and the fact that this is an
official request rather than a legal requirement. The BSD copyright notice in
a distribution remains the only thing the license actually compels.

Part of a sweep across all 13 repos that carry a crediting ask.