### PR TITLE
Bump the vendored `fixed` pin to v1.1.0

### DIFF
--- a/extern/fixed/NOTES.md
+++ b/extern/fixed/NOTES.md
@@ -4,7 +4,7 @@ This directory is a **generated copy** of [mas-bandwidth/fixed](https://github.c
 the deterministic fixed-point math library that Fixed3D's own fixed-point core was
 extracted into.
 
-    Pinned at: v1.0.0  (1c23e3d2418a755afd31a276c7a78687650a1b84)
+    Pinned at: v1.1.0  (af73ce22eb5d8459c541c5178c6ef157aefb1b88)
 
 ## Do not edit anything in this directory
 

--- a/extern/fixed/include/fixed/fixed.h
+++ b/extern/fixed/include/fixed/fixed.h
@@ -175,13 +175,14 @@ FIX_ALWAYS_INLINE fixInt128 fixInt128Div( fixInt128 a, fixInt128 b )
 /// Multiply two fixed-point numbers with round-to-nearest.
 /// By default the product is not checked for overflow: simulation quantities are
 /// far below the +/-1.4e14 range and the checks cost real time in the solver.
-/// Define BOX3D_FIXED_SATURATE to saturate on overflow instead of wrapping.
+/// Define FIX_SATURATE to saturate on overflow instead of wrapping. (box3d passes its
+/// own BOX3D_FIXED_SATURATE down through its compatibility header.)
 FIX_ALWAYS_INLINE fixed_t fixMul( fixed_t a, fixed_t b )
 {
 	fixInt128 product = (fixInt128)a * b;
 	// Round half up, then shift out the fraction bits (arithmetic shift)
 	fixInt128 r = ( product + FIX_HALF ) >> FIX_FRACTION_BITS;
-#if defined( BOX3D_FIXED_SATURATE )
+#if defined( FIX_SATURATE )
 	if ( r > (fixInt128)INT64_MAX )
 	{
 		return FIX_MAX;

--- a/extern/fixed/include/fixed/fixed_vec.h
+++ b/extern/fixed/include/fixed/fixed_vec.h
@@ -167,7 +167,7 @@ FIX_INLINE fixInt128 fixDotRaw( fixVec3 a, fixVec3 b )
 FIX_INLINE fixed_t fixFromDotRaw( fixInt128 raw )
 {
 	fixInt128 r = ( raw + FIX_HALF ) >> FIX_FRACTION_BITS;
-#if defined( BOX3D_FIXED_SATURATE )
+#if defined( FIX_SATURATE )
 	if ( r > (fixInt128)INT64_MAX )
 	{
 		return FIX_MAX;
@@ -751,11 +751,17 @@ FIX_INLINE fixInt128 fixCofactor128( fixed_t a, fixed_t b, fixed_t c, fixed_t d 
 /// of this header. The bodies are byte-equivalent.
 ///
 /// Deliberately NOT extracted, and the reason matters:
-///   - fixIsValidPosition / fixIsValidWorldTransform have TWO definitions in fixed3d,
-///     selected by BOX3D_LUDICROUS_MODE, because fixPos changes shape under that flag.
-///     They cannot move until the narrow/wide fixPos design fork is resolved.
-///   - fixIsValidAABB / fixIsValidPlane / fixIsValidRay take collision types (fixAABB,
-///     fixPlane, fixRayCastInput). Those are physics, not fixed-point math, and stay.
+///   - b3IsValidRay takes b3RayCastInput, a box3d collision type. Physics, not
+///     fixed-point math; it stays with the solver.
+///   - b3IsBoundedAABB / b3IsSaneAABB resolve B3_HUGE through box3d's mutable
+///     b3GetLengthUnitsPerMeter() global. They encode world-scale POLICY, and a math
+///     library should hold no opinion about how big a world is.
+///
+/// The position and bounds validators DID move, and the design fork that once blocked
+/// them is resolved: this library exports BOTH widths unconditionally (fixIsValidVec3
+/// and fixIsValidPosWide, fixIsValidAABB and fixIsValidAABBWide), so nothing here is
+/// selected by a compile flag. box3d picks a width in its own compatibility header,
+/// where its own flag belongs.
 
 /// True if a is a representable fixed-point quantity.
 ///
@@ -1157,7 +1163,7 @@ FIX_INLINE fixMatrix3 fixAbsMatrix3( fixMatrix3 m )
 
 /// Make a matrix from a quaternion. This is useful if you need to
 /// rotate many vectors.
-/// The force inline improves the performance of fixShapeDistance.
+/// The force inline improves the performance of b3ShapeDistance (box3d).
 FIX_FORCE_INLINE fixMatrix3 fixMakeMatrixFromQuat( fixQuat q )
 {
 	fixed_t xx = fixMul( q.v.x , q.v.x );

--- a/extern/fixed/include/fixed/fixed_wide.h
+++ b/extern/fixed/include/fixed/fixed_wide.h
@@ -296,6 +296,42 @@ FIX_ALWAYS_INLINE fixVec3 fixClosestPointToAABBWide( fixVec3 point, fixAABBWide 
 	return fixVecClamp( point, lo, hi );
 }
 
+/// Build a wide box from LOCAL points placed at a wide origin.
+///
+/// The companion to fixMakeAABBWide, and the shape box3d actually needs: mesh and hull
+/// vertices are local (Q48.16) even when the body sits a light-year out, so the common
+/// case is narrow points plus a wide base, not an array of wide points. Building the box
+/// narrow first and widening once is also exact and cheaper than widening every point.
+FIX_ALWAYS_INLINE fixAABBWide fixMakeAABBWideAt( const fixVec3* points, int count, fixed_t radius, fixPosWide origin )
+{
+	fixAABB local = fixMakeAABB( points, count, radius );
+	return fixOffsetAABBWide( local, origin );
+}
+
+/// Transform a wide box by a local transform.
+///
+/// Ported from box3d's ludicrous build, and it is the same conservative-bound algorithm
+/// as the narrow fixAABB_Transform: rotate the extents through the absolute matrix, then
+/// rebuild around the transformed center. The centre is computed and re-widened rather
+/// than rotated in place, because the rotation is a local operation and only the extents
+/// need it -- the wide part of the coordinate is a translation the rotation does not see.
+///
+/// NOTE the inherited limitation, stated rather than papered over: the centre narrows to
+/// local range, so a box whose CENTRE exceeds Q48.16 saturates. Extents survive at any
+/// distance (that is the fixAABBWide_Extents fix), but a transform about a distant centre
+/// does not. box3d has the same limitation today; fixing it needs a wide-centre
+/// formulation and belongs in its own change with its own goldens.
+FIX_ALWAYS_INLINE fixAABBWide fixAABBWide_Transform( fixTransform transform, fixAABBWide a )
+{
+	fixVec3 center = fixTransformPoint( transform, fixAABBWide_Center( a ) );
+	fixMatrix3 m = fixMakeMatrixFromQuat( transform.q );
+	fixVec3 extent = fixMulMV( fixAbsMatrix3( m ), fixAABBWide_Extents( a ) );
+	fixVec3 lo = fixVecSub( center, extent );
+	fixVec3 hi = fixVecAdd( center, extent );
+	fixAABBWide out = { fixPosWideFromVec3( lo ), fixPosWideFromVec3( hi ) };
+	return out;
+}
+
 /// Is this a valid wide AABB? Both bounds valid, and lower <= upper on every axis.
 FIX_ALWAYS_INLINE bool fixIsValidAABBWide( fixAABBWide a )
 {

--- a/tools/revendor-fixed.sh
+++ b/tools/revendor-fixed.sh
@@ -20,8 +20,8 @@ set -euo pipefail
 FIXED_REPO="https://github.com/mas-bandwidth/fixed.git"
 # v1.0.0. Pinned as a SHA rather than the tag name on purpose: a tag can be moved,
 # a commit cannot, and "vendored at v1.0.0" should mean one specific tree forever.
-FIXED_PIN="1c23e3d2418a755afd31a276c7a78687650a1b84"
-FIXED_VERSION="v1.0.0"
+FIXED_PIN="af73ce22eb5d8459c541c5178c6ef157aefb1b88"
+FIXED_VERSION="v1.1.0"
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DEST="$ROOT/extern/fixed"


### PR DESCRIPTION
Brings in `fixMakeAABBWideAt` and `fixAABBWide_Transform` — the two wide AABB operations box3d's ludicrous build needs and the library did not have. **Nothing consumes them yet**; this is the pin move on its own, so the AABB migration lands as its own diff.

Both were added upstream because wiring ludicrous mode to the library *failed to compile*, not because the API looked thin. `fixMakeAABBWide` takes **wide** points; box3d builds boxes from **local** mesh vertices at a wide origin, which is a different function.

Pin moves to `af73ce22eb5d`, tagged `v1.1.0` upstream with a real release. The drift check and the `NOTES.md` pin line move with it, and CI asserts the two agree.

### Why the AABB itself is not in this PR

I tried it and it does not compile under ludicrous. The wide `b3AABB` is *built from* `b3Pos`, and #15 deliberately kept box3d's own `b3Pos` behind because the library's world-position functions take the **narrow** `fixPos`:

```
assigning to 'fixPosWide' from incompatible type 'b3Pos'
```

The narrow build was fine — which is why this needed the ludicrous configuration to surface at all. **The AABB and the world-position family have to cross together**, and that needs wide variants of eleven world-position functions upstream first. Tracked with the specific list.

### Verification

CI's flags, both configurations: narrow and ludicrous build and pass.