### PR TITLE
Take the world-position and AABB families from `fixed` — the mandate is complete

### DIFF
--- a/extern/fixed/NOTES.md
+++ b/extern/fixed/NOTES.md
@@ -4,7 +4,7 @@ This directory is a **generated copy** of [mas-bandwidth/fixed](https://github.c
 the deterministic fixed-point math library that Fixed3D's own fixed-point core was
 extracted into.
 
-    Pinned at: v1.1.0  (af73ce22eb5d8459c541c5178c6ef157aefb1b88)
+    Pinned at: v1.2.0  (ba88f94cb9cc03951533daf7678d8980d4118163)
 
 ## Do not edit anything in this directory
 

--- a/extern/fixed/include/fixed/fixed_wide.h
+++ b/extern/fixed/include/fixed/fixed_wide.h
@@ -143,6 +143,86 @@ FIX_ALWAYS_INLINE bool fixIsValidWorldTransformWide( fixWorldTransformWide t )
 	return fixIsValidPosWide( t.p ) && fixIsValidQuat( t.q );
 }
 
+// ---- the wide world-position family ------------------------------------------------
+//
+// Ported from box3d's ludicrous build. The narrow forms live in fixed_vec.h and take
+// fixPos; these take fixPosWide, which is the whole reason they exist -- a consumer whose
+// world positions are 128-bit cannot call the narrow ones, and that gap is what stopped
+// box3d's wide configuration from consuming this library at all.
+//
+// Note what is NOT here because it already exists above: fixPosWideSub is the wide
+// SubPos, fixPosWideOffset is the wide OffsetPos, and fixPosWideFromVec3/ToVec3 are the
+// wide ToPos/ToVec3. Adding second names for them would be two spellings of one truth.
+
+/// World position interpolation, wide.
+///
+/// NOT a mechanical widening of the narrow form, and the difference is load-bearing.
+/// The narrow build computes (1-t)*a + t*b. Widened directly that multiplies an
+/// ABSOLUTE 128-bit coordinate, which overflows and truncates. Reformulated as
+/// a + t*(b-a): the difference is in local range, so the multiply is a safe fixMul on
+/// fixed_t and the result adds back onto the 128-bit base.
+///
+/// That is ONE rounding instead of two, so it is deliberately NOT bit-identical to the
+/// narrow build. A consumer running both widths carries separate goldens for this, and
+/// no amount of care will make them agree -- the wide answer is the more accurate one.
+FIX_ALWAYS_INLINE fixPosWide fixLerpPositionWide( fixPosWide a, fixPosWide b, fixed_t t )
+{
+	fixPosWide out = {
+		a.x + fixMul( t, fixWideSubToFixed( b.x, a.x ) ),
+		a.y + fixMul( t, fixWideSubToFixed( b.y, a.y ) ),
+		a.z + fixMul( t, fixWideSubToFixed( b.z, a.z ) ),
+	};
+	return out;
+}
+
+/// Transform a local point into wide world space. Rotation is narrow; only the
+/// translation is wide.
+FIX_ALWAYS_INLINE fixPosWide fixTransformWorldPointWide( fixWorldTransformWide t, fixVec3 p )
+{
+	fixVec3 r = fixRotateVector( t.q, p );
+	return fixPosWideOffset( t.p, r );
+}
+
+/// Transform a wide world position into local space. One wide subtraction, then narrow.
+FIX_ALWAYS_INLINE fixVec3 fixInvTransformWorldPointWide( fixWorldTransformWide t, fixPosWide p )
+{
+	return fixInvRotateVector( t.q, fixPosWideSub( p, t.p ) );
+}
+
+/// Promote a local transform to a wide world transform. Lossless.
+FIX_ALWAYS_INLINE fixWorldTransformWide fixMakeWorldTransformWide( fixTransform t )
+{
+	fixWorldTransformWide w = { fixPosWideFromVec3( t.p ), t.q };
+	return w;
+}
+
+/// Compose a wide world transform with a local transform.
+FIX_ALWAYS_INLINE fixWorldTransformWide fixMulWorldTransformsWide( fixWorldTransformWide A, fixTransform B )
+{
+	fixWorldTransformWide C;
+	C.q = fixMulQuat( A.q, B.q );
+	C.p = fixPosWideOffset( A.p, fixRotateVector( A.q, B.p ) );
+	return C;
+}
+
+/// Relative transform of frame B in frame A -- the narrow-phase boundary. The wide
+/// difference lands in local range for any pair close enough to interact, which is the
+/// entire premise of the wide-position design.
+FIX_ALWAYS_INLINE fixTransform fixInvMulWorldTransformsWide( fixWorldTransformWide A, fixWorldTransformWide B )
+{
+	fixTransform C;
+	C.q = fixInvMulQuat( A.q, B.q );
+	C.p = fixInvRotateVector( A.q, fixPosWideSub( B.p, A.p ) );
+	return C;
+}
+
+/// Shift a wide world transform into the frame of a base position.
+FIX_ALWAYS_INLINE fixTransform fixToRelativeTransformWide( fixWorldTransformWide t, fixPosWide base )
+{
+	fixTransform r = { fixPosWideSub( t.p, base ), t.q };
+	return r;
+}
+
 /// An axis-aligned bounding box in wide (Q112.16) world space.
 ///
 /// The narrow counterpart is fixAABB in fixed_vec.h. Storage, min/max, union, contains

--- a/include/box3d/fixed_compat.h
+++ b/include/box3d/fixed_compat.h
@@ -107,6 +107,10 @@ B3_FIXED_INLINE fixInt128 b3Int128ShiftLeft( fixInt128 a, int shift ) { return f
 //     box3d needs one name whose meaning follows its own flag, so it keeps its own.
 #include "fixed/fixed_vec.h"
 #include "fixed/fixed_math.h"
+// b3Pos, b3WorldTransform and b3AABB take their WIDE form from here under
+// BOX3D_LUDICROUS_MODE. Included unconditionally: the library exports both widths on
+// every build and the header is cheap, so there is no #if guarding an #include.
+#include "fixed/fixed_wide.h"
 
 // ---- types ------------------------------------------------------------------------
 typedef fixCosSin                  b3CosSin;
@@ -208,4 +212,101 @@ B3_INLINE fixMatrix3 b3SubMM( fixMatrix3 a, fixMatrix3 b ) { return fixSubMM( a,
 B3_INLINE fixVec3 b3TransformPoint( fixTransform t, fixVec3 v ) { return fixTransformPoint( t, v ); }
 B3_INLINE fixMatrix3 b3Transpose( fixMatrix3 m ) { return fixTranspose( m ); }
 B3_INLINE fixed_t b3UnwindAngle( fixed_t radians ) { return fixUnwindAngle( radians ); }
+
+// ===================================================================================
+// WORLD POSITIONS AND BOUNDING VOLUMES
+// ===================================================================================
+//
+// These two families cross together because they are coupled: the wide b3AABB is built
+// from b3Pos. Moving one while the other stayed produced "assigning to fixPosWide from
+// incompatible type b3Pos" -- and only in the ludicrous configuration; the narrow build
+// compiled fine either way.
+//
+// ONE BEHAVIOUR CHANGE, and it is the only one in the whole extraction: the library's
+// wide extents differences in 128-bit before narrowing, where box3d narrowed first and
+// so reported ZERO extents for any box past Q48.16 range -- at exactly the distances
+// ludicrous mode exists to serve. For any box whose bounds both fit local range the two
+// agree bit-for-bit, so this is invisible to every build that was already correct.
+//
+// SECOND THING WORTH KNOWING, inherited not introduced: the wide b3LerpPosition computes
+// a + t*(b-a) rather than (1-t)*a + t*b, because the latter multiplies an absolute
+// 128-bit coordinate and overflows. That is one rounding instead of two and it is
+// deliberately NOT bit-identical to the narrow build -- the wide build carries its own
+// goldens for it. Do not "fix" the two widths to agree.
+#if defined( BOX3D_LUDICROUS_MODE )
+typedef fixPosWide                 b3Pos;
+typedef fixWorldTransformWide      b3WorldTransform;
+typedef fixAABBWide                b3AABB;
+
+B3_INLINE b3Pos   b3ToPos( b3Vec3 v )                                { return fixPosWideFromVec3( v ); }
+B3_INLINE b3Vec3  b3ToVec3( b3Pos p )                                { return fixPosWideToVec3( p ); }
+B3_INLINE b3Vec3  b3SubPos( b3Pos a, b3Pos b )                       { return fixPosWideSub( a, b ); }
+B3_INLINE b3Pos   b3OffsetPos( b3Pos p, b3Vec3 d )                   { return fixPosWideOffset( p, d ); }
+B3_INLINE b3Pos   b3LerpPosition( b3Pos a, b3Pos b, b3Fixed t )      { return fixLerpPositionWide( a, b, t ); }
+B3_INLINE b3Pos   b3TransformWorldPoint( b3WorldTransform t, b3Vec3 p )
+                                                                     { return fixTransformWorldPointWide( t, p ); }
+B3_INLINE b3Vec3  b3InvTransformWorldPoint( b3WorldTransform t, b3Pos p )
+                                                                     { return fixInvTransformWorldPointWide( t, p ); }
+B3_INLINE b3WorldTransform b3MakeWorldTransform( b3Transform t )     { return fixMakeWorldTransformWide( t ); }
+B3_INLINE b3WorldTransform b3MulWorldTransforms( b3WorldTransform A, b3Transform B )
+                                                                     { return fixMulWorldTransformsWide( A, B ); }
+B3_INLINE b3Transform b3InvMulWorldTransforms( b3WorldTransform A, b3WorldTransform B )
+                                                                     { return fixInvMulWorldTransformsWide( A, B ); }
+B3_INLINE b3Transform b3ToRelativeTransform( b3WorldTransform t, b3Pos base )
+                                                                     { return fixToRelativeTransformWide( t, base ); }
+
+B3_INLINE b3AABB  b3MakeAABB( const b3Vec3* points, int count, b3Fixed radius )
+{
+	// box3d builds boxes from LOCAL vertices; assembled narrow, widened once. This is the
+	// gap fixMakeAABBWideAt was added upstream to close -- fixMakeAABBWide takes wide points.
+	fixPosWide origin = { 0, 0, 0 };
+	return fixMakeAABBWideAt( points, count, radius, origin );
+}
+B3_INLINE bool    b3AABB_Contains( b3AABB a, b3AABB b )              { return fixAABBWide_Contains( a, b ); }
+B3_INLINE b3Fixed b3AABB_Area( b3AABB a )                            { return fixAABBWide_Area( a ); }
+B3_INLINE b3Vec3  b3AABB_Center( b3AABB a )                          { return fixAABBWide_Center( a ); }
+B3_INLINE b3Vec3  b3AABB_Extents( b3AABB a )                         { return fixAABBWide_Extents( a ); }
+B3_INLINE b3AABB  b3AABB_Union( b3AABB a, b3AABB b )                 { return fixAABBWide_Union( a, b ); }
+B3_INLINE b3AABB  b3AABB_Inflate( b3AABB a, b3Fixed e )              { return fixAABBWide_Inflate( a, e ); }
+B3_INLINE bool    b3AABB_Overlaps( b3AABB a, b3AABB b )              { return fixAABBWide_Overlaps( a, b ); }
+B3_INLINE b3AABB  b3AABB_Transform( b3Transform t, b3AABB a )        { return fixAABBWide_Transform( t, a ); }
+B3_INLINE b3Vec3  b3ClosestPointToAABB( b3Vec3 point, b3AABB a )     { return fixClosestPointToAABBWide( point, a ); }
+
+// box3d's local wide min/max, which were a copy of these all along.
+B3_INLINE b3Int128 b3W_min128( b3Int128 a, b3Int128 b )              { return fixWideMin( a, b ); }
+B3_INLINE b3Int128 b3W_max128( b3Int128 a, b3Int128 b )              { return fixWideMax( a, b ); }
+#else
+typedef fixVec3                    b3Pos;
+typedef fixTransform               b3WorldTransform;
+typedef fixAABB                    b3AABB;
+
+B3_INLINE b3Pos   b3ToPos( b3Vec3 v )                                { return v; }
+B3_INLINE b3Vec3  b3ToVec3( b3Pos p )                                { return p; }
+B3_INLINE b3Vec3  b3SubPos( b3Pos a, b3Pos b )                       { return fixVecSub( a, b ); }
+B3_INLINE b3Pos   b3OffsetPos( b3Pos p, b3Vec3 d )                   { return fixVecAdd( p, d ); }
+B3_INLINE b3Pos   b3LerpPosition( b3Pos a, b3Pos b, b3Fixed t )      { return fixLerpPosition( a, b, t ); }
+B3_INLINE b3Pos   b3TransformWorldPoint( b3WorldTransform t, b3Vec3 p )
+                                                                     { return fixTransformWorldPoint( t, p ); }
+B3_INLINE b3Vec3  b3InvTransformWorldPoint( b3WorldTransform t, b3Pos p )
+                                                                     { return fixInvTransformWorldPoint( t, p ); }
+B3_INLINE b3WorldTransform b3MakeWorldTransform( b3Transform t )     { return fixMakeWorldTransform( t ); }
+B3_INLINE b3WorldTransform b3MulWorldTransforms( b3WorldTransform A, b3Transform B )
+                                                                     { return fixMulWorldTransforms( A, B ); }
+B3_INLINE b3Transform b3InvMulWorldTransforms( b3WorldTransform A, b3WorldTransform B )
+                                                                     { return fixInvMulWorldTransforms( A, B ); }
+B3_INLINE b3Transform b3ToRelativeTransform( b3WorldTransform t, b3Pos base )
+                                                                     { return fixToRelativeTransform( t, base ); }
+
+B3_INLINE b3AABB  b3MakeAABB( const b3Vec3* points, int count, b3Fixed radius )
+                                                                     { return fixMakeAABB( points, count, radius ); }
+B3_INLINE bool    b3AABB_Contains( b3AABB a, b3AABB b )              { return fixAABB_Contains( a, b ); }
+B3_INLINE b3Fixed b3AABB_Area( b3AABB a )                            { return fixAABB_Area( a ); }
+B3_INLINE b3Vec3  b3AABB_Center( b3AABB a )                          { return fixAABB_Center( a ); }
+B3_INLINE b3Vec3  b3AABB_Extents( b3AABB a )                         { return fixAABB_Extents( a ); }
+B3_INLINE b3AABB  b3AABB_Union( b3AABB a, b3AABB b )                 { return fixAABB_Union( a, b ); }
+B3_INLINE b3AABB  b3AABB_Inflate( b3AABB a, b3Fixed e )              { return fixAABB_Inflate( a, e ); }
+B3_INLINE bool    b3AABB_Overlaps( b3AABB a, b3AABB b )              { return fixAABB_Overlaps( a, b ); }
+B3_INLINE b3AABB  b3AABB_Transform( b3Transform t, b3AABB a )        { return fixAABB_Transform( t, a ); }
+B3_INLINE b3Vec3  b3ClosestPointToAABB( b3Vec3 point, b3AABB a )     { return fixClosestPointToAABB( point, a ); }
+#endif
 

--- a/include/box3d/math_functions.h
+++ b/include/box3d/math_functions.h
@@ -46,60 +46,21 @@
 // double precision large-world mode is unnecessary and no longer supported.
 #error "BOX3D_DOUBLE_PRECISION is not supported with fixed-point math"
 #endif
-
-#if defined( BOX3D_LUDICROUS_MODE )
-
-/// A world position in ludicrous mode: Q112.16 fixed point in a 128-bit
-/// integer. Same 16 fraction bits as b3Fixed (so the boundary subtract to local
-/// space is an exact truncation, not a rescale), with all 64 extra bits going to
-/// integer *range* (±2.6e33 units, far past a light-year in metres). Uniform
-/// 15-micron resolution — the thesis — is preserved exactly at any distance. A
-/// distinct struct on purpose: every world/local coordinate crossing that is not
-/// routed through the boundary vocabulary becomes a compile error.
-typedef struct b3Pos
-{
-	b3Int128 x;
-	b3Int128 y;
-	b3Int128 z;
-} b3Pos;
-
-/// A world transform: 128-bit translation, narrow (b3Fixed) rotation. Rotation is
-/// frame-local and never needs range, so the quaternion stays Q48.16.
-typedef struct b3WorldTransform
-{
-	b3Pos p;
-	b3Quat q;
-} b3WorldTransform;
-
-#else
-
-/// A world position. Fixed point has uniform precision everywhere, so world
-/// positions use the same representation as local vectors.
-typedef b3Vec3 b3Pos;
-
-/// A world transform. Same representation as a local transform in fixed point.
-typedef b3Transform b3WorldTransform;
-
-#endif
-
-/// Axis aligned bounding box.
-#if defined( BOX3D_LUDICROUS_MODE )
-/// Ludicrous mode: AABB bounds are 128-bit world positions, so the broadphase tree is
-/// collision-active across the full wide-position range (past a light-year). Puts int128
-/// into the hot tree. Nobody needs this; it exists to be measured (and marveled at).
-typedef struct b3AABB
-{
-	b3Pos lowerBound;
-	b3Pos upperBound;
-} b3AABB;
-#else
-typedef struct b3AABB
-{
-	b3Vec3 lowerBound;
-	b3Vec3 upperBound;
-} b3AABB;
-#endif
-
+// The world-position family (b3Pos, b3WorldTransform and their arithmetic) and the
+// AABB family now come from mas-bandwidth/fixed via box3d/fixed_compat.h, with the
+// width chosen there next to BOX3D_LUDICROUS_MODE.
+//
+// They moved TOGETHER because they are coupled: the wide b3AABB is built from
+// b3Pos, so moving one while the other stayed gave "assigning to fixPosWide from
+// incompatible type b3Pos". The narrow build compiled fine either way, which is
+// why this only surfaced in the ludicrous configuration.
+//
+// STILL HERE, and each on purpose: box3d's Bound crossing vocabulary
+// (b3BoundToPos, b3PosToBound, b3BoundToVec3, b3Vec3ToBound, b3OffsetAABB), which
+// marks a boundary rather than doing arithmetic; b3IsBoundedAABB and b3IsSaneAABB,
+// which resolve B3_HUGE through the mutable b3GetLengthUnitsPerMeter() global and
+// so encode world-scale POLICY; and the segment/line distance queries and
+// b3Steiner, which are physics.
 // Valid in both modes: 0.0f promotes to double, the identity rotation stays b3Fixed
 static const b3Pos b3Pos_zero = { B3_FIX( 0.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) };
 static const b3WorldTransform b3WorldTransform_identity = { { B3_FIX( 0.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) }, { { B3_FIX( 0.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) }, B3_FIX( 1.0f ) } };
@@ -125,18 +86,6 @@ B3_API b3Quat b3MakeQuatFromMatrix( const b3Matrix3* m );
 /// Find a quaternion that rotates one vector to another.
 B3_API b3Quat b3ComputeQuatBetweenUnitVectors( b3Vec3 v1, b3Vec3 v2 );
 
-/// Convert a vector to a world position.
-B3_INLINE b3Pos b3ToPos( b3Vec3 v )
-{
-	return B3_LITERAL( b3Pos ){ v.x, v.y, v.z };
-}
-
-/// Lossy conversion of a world position to a b3Fixed vector.
-B3_INLINE b3Vec3 b3ToVec3( b3Pos p )
-{
-	return B3_LITERAL( b3Vec3 ){ (b3Fixed)p.x, (b3Fixed)p.y, (b3Fixed)p.z };
-}
-
 /// Bridge b3Vec3-based math to the AABB bound storage type. Bounds are 128-bit b3Pos in
 /// ludicrous mode (BOX3D_LUDICROUS_MODE) and b3Vec3 in the default build, so these are the
 /// identity there. Bound-touching code uses them to compile in both builds without #if
@@ -156,96 +105,10 @@ B3_INLINE b3Pos b3BoundToPos( b3Vec3 v ) { return b3ToPos( v ); }
 B3_INLINE b3Vec3 b3PosToBound( b3Pos p ) { return b3ToVec3( p ); }
 #endif
 
-/// a - b, demoted to b3Fixed. The primary precision boundary operation.
-B3_INLINE b3Vec3 b3SubPos( b3Pos a, b3Pos b )
-{
-	return B3_LITERAL( b3Vec3 ){ (b3Fixed)( a.x - b.x ), (b3Fixed)( a.y - b.y ), (b3Fixed)( a.z - b.z ) };
-}
-
-/// p + d
-B3_INLINE b3Pos b3OffsetPos( b3Pos p, b3Vec3 d )
-{
-	return B3_LITERAL( b3Pos ){ p.x + d.x, p.y + d.y, p.z + d.z };
-}
-
 /// World position interpolation for sweeps and sampling.
 #if defined( BOX3D_LUDICROUS_MODE )
-/// Wide build: the two-rounding form ((1-t)*a + t*b) would multiply b3FixMul by
-/// an absolute 128-bit coordinate, which overflows and truncates. Reformulate as
-/// a + t*(b-a): the difference (b-a) is in local range, so the multiply is a
-/// safe b3FixMul on b3Fixed, and the result adds back onto the 128-bit base. This
-/// is one rounding instead of two, so it is NOT bit-identical to the narrow build
-/// (the wide build carries its own goldens).
-B3_INLINE b3Pos b3LerpPosition( b3Pos a, b3Pos b, b3Fixed t )
-{
-	return B3_LITERAL( b3Pos ){
-		a.x + b3FixMul( t , (b3Fixed)( b.x - a.x ) ),
-		a.y + b3FixMul( t , (b3Fixed)( b.y - a.y ) ),
-		a.z + b3FixMul( t , (b3Fixed)( b.z - a.z ) ),
-	};
-}
 #else
-B3_INLINE b3Pos b3LerpPosition( b3Pos a, b3Pos b, b3Fixed t )
-{
-	return B3_LITERAL( b3Pos ){
-		b3FixMul( ( B3_FIX( 1.0f ) - t ) , a.x ) + b3FixMul( t , b.x ),
-		b3FixMul( ( B3_FIX( 1.0f ) - t ) , a.y ) + b3FixMul( t , b.y ),
-		b3FixMul( ( B3_FIX( 1.0f ) - t ) , a.z ) + b3FixMul( t , b.z ),
-	};
-}
 #endif
-
-/// Transform a local point to a world position. Rotation in b3Fixed, translation in double.
-B3_INLINE b3Pos b3TransformWorldPoint( b3WorldTransform t, b3Vec3 p )
-{
-	b3Vec3 r = b3RotateVector( t.q, p );
-	return B3_LITERAL( b3Pos ){ t.p.x + r.x, t.p.y + r.y, t.p.z + r.z };
-}
-
-/// Transform a world position to a local point. One double subtraction, then b3Fixed.
-B3_INLINE b3Vec3 b3InvTransformWorldPoint( b3WorldTransform t, b3Pos p )
-{
-	b3Vec3 d = { (b3Fixed)( p.x - t.p.x ), (b3Fixed)( p.y - t.p.y ), (b3Fixed)( p.z - t.p.z ) };
-	return b3InvRotateVector( t.q, d );
-}
-
-/// Relative transform of frame B in frame A. The narrow phase boundary.
-B3_INLINE b3Transform b3InvMulWorldTransforms( b3WorldTransform A, b3WorldTransform B )
-{
-	b3Transform C;
-	C.q = b3InvMulQuat( A.q, B.q );
-	b3Vec3 d = { (b3Fixed)( B.p.x - A.p.x ), (b3Fixed)( B.p.y - A.p.y ), (b3Fixed)( B.p.z - A.p.z ) };
-	C.p = b3InvRotateVector( A.q, d );
-	return C;
-}
-
-/// Compose a world transform with a local transform.
-B3_INLINE b3WorldTransform b3MulWorldTransforms( b3WorldTransform A, b3Transform B )
-{
-	b3WorldTransform C;
-	C.q = b3MulQuat( A.q, B.q );
-	b3Vec3 r = b3RotateVector( A.q, B.p );
-	C.p = B3_LITERAL( b3Pos ){ A.p.x + r.x, A.p.y + r.y, A.p.z + r.z };
-	return C;
-}
-
-/// Shift a world transform into the frame of a base position.
-B3_INLINE b3Transform b3ToRelativeTransform( b3WorldTransform t, b3Pos base )
-{
-	b3Transform r;
-	r.q = t.q;
-	r.p = B3_LITERAL( b3Vec3 ){ (b3Fixed)( t.p.x - base.x ), (b3Fixed)( t.p.y - base.y ), (b3Fixed)( t.p.z - base.z ) };
-	return r;
-}
-
-/// Promote a b3Fixed transform to a world transform. Lossless.
-B3_INLINE b3WorldTransform b3MakeWorldTransform( b3Transform t )
-{
-	b3WorldTransform w;
-	w.p = b3ToPos( t.p );
-	w.q = t.q;
-	return w;
-}
 
 /// Translate a local AABB by a world origin. Fixed-point addition is exact, so no
 /// outward rounding is needed: the translated box is the translated box.
@@ -273,205 +136,7 @@ B3_INLINE b3AABB b3OffsetAABB( b3AABB localBox, b3Pos origin )
 B3_API b3Matrix3 b3Steiner( b3Fixed mass, b3Vec3 origin );
 
 #if defined( BOX3D_LUDICROUS_MODE )
-// Ludicrous mode: AABB bounds are 128-bit. Storage, min/max, union, contains and overlap stay
-// 128-bit (the hot tree ops); extent/center narrow to b3Fixed for the b3Vec3-returning API
-// (exact whenever the box fits local range, which every in-range scene does).
-B3_FIXED_INLINE b3Int128 b3W_min128( b3Int128 a, b3Int128 b ) { return a < b ? a : b; }
-B3_FIXED_INLINE b3Int128 b3W_max128( b3Int128 a, b3Int128 b ) { return a > b ? a : b; }
-
-B3_INLINE b3AABB b3MakeAABB( const b3Vec3* points, int count, b3Fixed radius )
-{
-	B3_ASSERT( count > 0 );
-	b3AABB a = { { points[0].x, points[0].y, points[0].z }, { points[0].x, points[0].y, points[0].z } };
-	for ( int i = 1; i < count; ++i )
-	{
-		a.lowerBound.x = b3W_min128( a.lowerBound.x, points[i].x );
-		a.lowerBound.y = b3W_min128( a.lowerBound.y, points[i].y );
-		a.lowerBound.z = b3W_min128( a.lowerBound.z, points[i].z );
-		a.upperBound.x = b3W_max128( a.upperBound.x, points[i].x );
-		a.upperBound.y = b3W_max128( a.upperBound.y, points[i].y );
-		a.upperBound.z = b3W_max128( a.upperBound.z, points[i].z );
-	}
-	a.lowerBound.x -= radius; a.lowerBound.y -= radius; a.lowerBound.z -= radius;
-	a.upperBound.x += radius; a.upperBound.y += radius; a.upperBound.z += radius;
-	return a;
-}
-
-B3_INLINE bool b3AABB_Contains( b3AABB a, b3AABB b )
-{
-	if ( a.lowerBound.x > b.lowerBound.x || b.upperBound.x > a.upperBound.x ) return false;
-	if ( a.lowerBound.y > b.lowerBound.y || b.upperBound.y > a.upperBound.y ) return false;
-	if ( a.lowerBound.z > b.lowerBound.z || b.upperBound.z > a.upperBound.z ) return false;
-	return true;
-}
-
-B3_INLINE b3Fixed b3AABB_Area( b3AABB a )
-{
-	b3Fixed dx = (b3Fixed)( a.upperBound.x - a.lowerBound.x );
-	b3Fixed dy = (b3Fixed)( a.upperBound.y - a.lowerBound.y );
-	b3Fixed dz = (b3Fixed)( a.upperBound.z - a.lowerBound.z );
-	return b3FixMul( B3_FIX( 2.0f ) , ( b3FixMul( dx , dy ) + b3FixMul( dy , dz ) + b3FixMul( dz , dx ) ) );
-}
-
-B3_INLINE b3Vec3 b3AABB_Center( b3AABB a )
-{
-	// narrow the bounds to b3Fixed (exact in local range) then use the SAME half-up rounding
-	// as the narrow build's b3MulSV(0.5, ...) — integer /2 would truncate and shift the box.
-	return b3MulSV( B3_FIX( 0.5f ), b3Add( b3ToVec3( a.upperBound ), b3ToVec3( a.lowerBound ) ) );
-}
-
-B3_INLINE b3Vec3 b3AABB_Extents( b3AABB a )
-{
-	return b3MulSV( B3_FIX( 0.5f ), b3Sub( b3ToVec3( a.upperBound ), b3ToVec3( a.lowerBound ) ) );
-}
-
-B3_INLINE b3AABB b3AABB_Union( b3AABB a, b3AABB b )
-{
-	b3AABB out;
-	out.lowerBound.x = b3W_min128( a.lowerBound.x, b.lowerBound.x );
-	out.lowerBound.y = b3W_min128( a.lowerBound.y, b.lowerBound.y );
-	out.lowerBound.z = b3W_min128( a.lowerBound.z, b.lowerBound.z );
-	out.upperBound.x = b3W_max128( a.upperBound.x, b.upperBound.x );
-	out.upperBound.y = b3W_max128( a.upperBound.y, b.upperBound.y );
-	out.upperBound.z = b3W_max128( a.upperBound.z, b.upperBound.z );
-	return out;
-}
-
-B3_INLINE b3AABB b3AABB_Inflate( b3AABB a, b3Fixed extension )
-{
-	b3AABB out = a;
-	out.lowerBound.x -= extension; out.lowerBound.y -= extension; out.lowerBound.z -= extension;
-	out.upperBound.x += extension; out.upperBound.y += extension; out.upperBound.z += extension;
-	return out;
-}
-
-B3_INLINE bool b3AABB_Overlaps( b3AABB a, b3AABB b )
-{
-	if ( a.upperBound.x < b.lowerBound.x || a.lowerBound.x > b.upperBound.x ) return false;
-	if ( a.upperBound.y < b.lowerBound.y || a.lowerBound.y > b.upperBound.y ) return false;
-	if ( a.upperBound.z < b.lowerBound.z || a.lowerBound.z > b.upperBound.z ) return false;
-	return true;
-}
-
-B3_INLINE b3AABB b3AABB_Transform( b3Transform transform, b3AABB a )
-{
-	b3Vec3 center = b3TransformPoint( transform, b3AABB_Center( a ) );
-	b3Matrix3 m = b3MakeMatrixFromQuat( transform.q );
-	b3Vec3 extent = b3MulMV( b3AbsMatrix3( m ), b3AABB_Extents( a ) );
-	b3Vec3 lo = b3Sub( center, extent ), hi = b3Add( center, extent );
-	b3AABB out = { { lo.x, lo.y, lo.z }, { hi.x, hi.y, hi.z } };
-	return out;
-}
-
-B3_INLINE b3Vec3 b3ClosestPointToAABB( b3Vec3 point, b3AABB a )
-{
-	b3Vec3 lo = { (b3Fixed)a.lowerBound.x, (b3Fixed)a.lowerBound.y, (b3Fixed)a.lowerBound.z };
-	b3Vec3 hi = { (b3Fixed)a.upperBound.x, (b3Fixed)a.upperBound.y, (b3Fixed)a.upperBound.z };
-	return b3Clamp( point, lo, hi );
-}
 #else
-/// Get the AABB of a point cloud.
-B3_INLINE b3AABB b3MakeAABB( const b3Vec3* points, int count, b3Fixed radius )
-{
-	B3_ASSERT( count > 0 );
-	b3AABB a = { points[0], points[0] };
-	for ( int i = 1; i < count; ++i )
-	{
-		a.lowerBound = b3Min( a.lowerBound, points[i] );
-		a.upperBound = b3Max( a.upperBound, points[i] );
-	}
-
-	b3Vec3 r = { radius, radius, radius };
-	a.lowerBound = b3Sub( a.lowerBound, r );
-	a.upperBound = b3Add( a.upperBound, r );
-
-	return a;
-}
-
-/// Does a fully contain b?
-B3_INLINE bool b3AABB_Contains( b3AABB a, b3AABB b )
-{
-	if ( a.lowerBound.x > b.lowerBound.x || b.upperBound.x > a.upperBound.x )
-		return false;
-	if ( a.lowerBound.y > b.lowerBound.y || b.upperBound.y > a.upperBound.y )
-		return false;
-	if ( a.lowerBound.z > b.lowerBound.z || b.upperBound.z > a.upperBound.z )
-		return false;
-
-	return true;
-}
-
-/// Get the surface area of an axis-aligned bounding box.
-B3_INLINE b3Fixed b3AABB_Area( b3AABB a )
-{
-	b3Vec3 delta = b3Sub( a.upperBound, a.lowerBound );
-	return b3FixMul( B3_FIX( 2.0f ) , ( b3FixMul( delta.x , delta.y ) + b3FixMul( delta.y , delta.z ) + b3FixMul( delta.z , delta.x ) ) );
-}
-
-/// Get the center of an axis-aligned bounding box.
-B3_INLINE b3Vec3 b3AABB_Center( b3AABB a )
-{
-	return b3MulSV( B3_FIX( 0.5f ), b3Add( a.upperBound, a.lowerBound ) );
-}
-
-/// Get the extents (half-widths) of an axis-aligned bounding box.
-B3_INLINE b3Vec3 b3AABB_Extents( b3AABB a )
-{
-	return b3MulSV( B3_FIX( 0.5f ), b3Sub( a.upperBound, a.lowerBound ) );
-}
-
-/// Get the union of two axis-aligned bounding boxes.
-B3_INLINE b3AABB b3AABB_Union( b3AABB a, b3AABB b )
-{
-	b3AABB out;
-	out.lowerBound = b3Min( a.lowerBound, b.lowerBound );
-	out.upperBound = b3Max( a.upperBound, b.upperBound );
-	return out;
-}
-
-/// Add uniform padding to an axis-aligned bounding box.
-B3_INLINE b3AABB b3AABB_Inflate( b3AABB a, b3Fixed extension )
-{
-	b3Vec3 radius = { extension, extension, extension };
-
-	b3AABB out;
-	out.lowerBound = b3Sub( a.lowerBound, radius );
-	out.upperBound = b3Add( a.upperBound, radius );
-	return out;
-}
-
-/// Do two axis-aligned boxes overlap?
-B3_INLINE bool b3AABB_Overlaps( b3AABB a, b3AABB b )
-{
-	// No intersection if separated along one axis
-	if ( a.upperBound.x < b.lowerBound.x || a.lowerBound.x > b.upperBound.x )
-		return false;
-	if ( a.upperBound.y < b.lowerBound.y || a.lowerBound.y > b.upperBound.y )
-		return false;
-	if ( a.upperBound.z < b.lowerBound.z || a.lowerBound.z > b.upperBound.z )
-		return false;
-
-	// Overlapping on all axis means bounds are intersecting
-	return true;
-}
-
-/// Transform an axis-aligned bounding box. This can create a larger box
-/// than if you recomputed the AABB of the original shape with the transform
-/// applied.
-B3_INLINE b3AABB b3AABB_Transform( b3Transform transform, b3AABB a )
-{
-	b3Vec3 center = b3TransformPoint( transform, b3AABB_Center( a ) );
-	b3Matrix3 m = b3MakeMatrixFromQuat( transform.q );
-	b3Vec3 extent = b3MulMV( b3AbsMatrix3( m ), b3AABB_Extents( a ) );
-	b3AABB out = { b3Sub( center, extent ), b3Add( center, extent ) };
-	return out;
-}
-
-/// Get the closest point on an axis-aligned bounding box.
-B3_INLINE b3Vec3 b3ClosestPointToAABB( b3Vec3 point, b3AABB a )
-{
-	return b3Clamp( point, a.lowerBound, a.upperBound );
-}
 #endif
 
 /// The closest points between to segments or infinite lines.
@@ -603,4 +268,5 @@ B3_FORCE_INLINE b3Vec3 operator-( b3Vec3 a, b3Vec3 b )
 #endif
 
 /**@}*/ // math_cpp
+
 

--- a/tools/revendor-fixed.sh
+++ b/tools/revendor-fixed.sh
@@ -20,8 +20,8 @@ set -euo pipefail
 FIXED_REPO="https://github.com/mas-bandwidth/fixed.git"
 # v1.0.0. Pinned as a SHA rather than the tag name on purpose: a tag can be moved,
 # a commit cannot, and "vendored at v1.0.0" should mean one specific tree forever.
-FIXED_PIN="af73ce22eb5d8459c541c5178c6ef157aefb1b88"
-FIXED_VERSION="v1.1.0"
+FIXED_PIN="ba88f94cb9cc03951533daf7678d8980d4118163"
+FIXED_VERSION="v1.2.0"
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DEST="$ROOT/extern/fixed"


### PR DESCRIPTION
`math_functions.h` drops from **607 to 272 lines**. Every fixed-point type box3d has is now [mas-bandwidth/fixed](https://github.com/mas-bandwidth/fixed)'s, vendored at `extern/fixed` and pinned at **v1.2.0**.

### The two families moved together because they are coupled

I tried the AABB alone first and it failed. The wide `b3AABB` is *built from* `b3Pos`, and #15 had deliberately left `b3Pos` behind, so ludicrous gave `assigning to 'fixPosWide' from incompatible type 'b3Pos'`. **The narrow build compiled fine either way** — which is why this only surfaced in the configuration nobody builds by default.

Unblocking it took two upstream releases: `fixed` v1.1.0 (the wide AABB operations) and v1.2.0 (the wide world-position family).

### One behaviour change in the entire extraction, and its prediction was written first

The library's wide extents differences in 128-bit *before* narrowing; box3d narrowed first and so reported **zero extents** for any box past Q48.16 range — at exactly the distances ludicrous mode exists to serve, behind a flag that is off by default so nothing ever compiled it.

The prediction, recorded on the board **before** running it: the ludicrous goldens should **not** move, because the test scenes sit 100 km out, well inside local range, where the bug never fired.

**They did not move.** Had they, the "invisible where already correct" claim would have been wrong and the change would have needed re-arguing.

### Inherited, not introduced — do not "fix" this

The wide `b3LerpPosition` computes `a + t*(b-a)` rather than `(1-t)*a + t*b`, because the latter multiplies an absolute 128-bit coordinate and overflows. One rounding instead of two, deliberately **not** bit-identical between widths, and the wide build carries its own goldens for it.

### What stayed, each on purpose

- box3d's **Bound crossing vocabulary** (`b3BoundToPos`, `b3PosToBound`, `b3BoundToVec3`, `b3Vec3ToBound`, `b3OffsetAABB`) — marks a boundary rather than doing arithmetic.
- `b3IsBoundedAABB` / `b3IsSaneAABB` — they resolve `B3_HUGE` through the mutable `b3GetLengthUnitsPerMeter()` global. World-scale **policy**; a math library should hold no opinion about how big a world is.
- The segment/line distance queries and `b3Steiner` — physics that happens to be written in fixed point.

### Verification — all with CI's flags

| Configuration | Result |
|---|---|
| narrow, Debug, `VALIDATE=ON`, `WARNING_AS_ERROR=ON` | build + full suite green |
| ludicrous, same | build + full suite green, **goldens unmoved** |
| shared library + samples | build green, 12 expected symbols exported |
| vendor drift | clean |