### PR TITLE
test: TaggedQueryRoundTrip leaves its recording file behind

### DIFF
--- a/test/test_recording.c
+++ b/test/test_recording.c
@@ -957,6 +957,12 @@ static int TaggedQuery( void )
 	b3RecPlayer_Destroy( player );
 	b3DestroyRecording( loaded );
 	b3DestroyRecording( rec );
+	// Clean up the file this test wrote, as the other two file-writing tests in here
+	// already do. Without it the suite leaves tagged_query_test.b3rec in whatever
+	// directory it was run from -- and *.b3rec is gitignored HERE, so it is invisible in
+	// this repo and only shows up as a stray when someone runs the tests from elsewhere.
+	// Which is exactly how it was found.
+	remove( path );
 	return 0;
 }
 


### PR DESCRIPTION
The two other file-writing tests in `test_recording.c` call `remove( path )` when they are done. This one does not, so the suite drops `tagged_query_test.b3rec` into whatever directory it was run from and leaves it there.

`*.b3rec` is gitignored in **this** repo, so the leak is invisible here no matter how often the tests run. It only becomes visible when someone runs the suite from a directory that does not ignore it — which is how it was found: a stray turned up at the root of an unrelated repo this morning and had to be traced back.

Verified by running the suite from a clean directory: passes, and leaves zero `.b3rec` files behind.