### PR TITLE
v1.4.0: bump version sites

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Box3D converted from float to Q48.16 fixed point (internal and external API).
 Baseline float code is commit c52908c. EVERYTHING below is committed and pushed;
 there is no pending working-tree state.
 
-## Current status (as of 2026-07-16 — v1.3.0, MAINTENANCE MODE)
+## Current status (as of 2026-08-04 — v1.4.0, MAINTENANCE MODE)
 
 - **PORT RECORD c52908c "Fixes 08 (#98)" (2026-07-24)** — hull builder leak +
   samples data-folder resilience. Engine: ResolveFaces now retires each

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 include(CMakeDependentOption)
 
 project(box3d
-	VERSION 1.3.0
+	VERSION 1.4.0
 	DESCRIPTION "Fixed3D: Box3D in Q48.16 fixed point"
 	HOMEPAGE_URL "https://github.com/mas-bandwidth/fixed3d"
 	LANGUAGES C CXX

--- a/src/core.c
+++ b/src/core.c
@@ -115,7 +115,7 @@ void b3Log( const char* format, ... )
 
 b3Version b3GetVersion( void )
 {
-	return (b3Version){ 1, 2, 0 };
+	return (b3Version){ 1, 4, 0 };
 }
 
 static b3AllocFcn* b3_allocFcn = NULL;


### PR DESCRIPTION
CMakeLists project VERSION 1.3.0 -> 1.4.0; `b3GetVersion()` 1.2.0 -> 1.4.0 (it had reported 1.2.0 since before v1.3.0 shipped); CLAUDE.md status line brought current. Release v1.4.0 cuts on merge + green CI.