### PR TITLE
Box3D -> Fixed3D port: Fixes 09, Follow cam engine half, and the f42be21 triangle manifold fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,20 @@ jobs:
             timeout: 10
             args: '-DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18 -DBOX3D_WIDE_POSITIONS=ON -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"'
             test: ./bin/test
+          # Optimized runs. The determinism golden hashes are otherwise only checked at -O0,
+          # and -O2 is where a codegen difference in the integer math would first show up.
+          # Upstream adds these against float contraction; here the value is the same job at
+          # a different optimization level, on the two toolchains that carry the goldens.
+          - name: windows-relwithdebinfo
+            os: windows-latest
+            msvc: true
+            config: RelWithDebInfo
+            args: -T ClangCL
+            test: ./bin/RelWithDebInfo/test
+          - name: macos-relwithdebinfo
+            os: macos-latest
+            config: RelWithDebInfo
+            test: ./bin/test
     steps:
     - uses: actions/checkout@v6
 
@@ -80,10 +94,10 @@ jobs:
         arch: x64
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBOX3D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX3D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON ${{ matrix.args }}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{ matrix.config || env.BUILD_TYPE }} -DBOX3D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX3D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON ${{ matrix.args }}
 
     - name: Build
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      run: cmake --build ${{github.workspace}}/build --config ${{ matrix.config || env.BUILD_TYPE }}
 
     - name: Test
       working-directory: ${{github.workspace}}/build
@@ -93,9 +107,9 @@ jobs:
       run: ${{ matrix.test }}
 
   # mingw needs some extra setup so keeping it separate from the matrix.
-  # Also the one optimized test run. Debug -O0 copies whole structs and hid the
-  # b3SurfaceMaterial padding dedup bug. RelWithDebInfo tests -O2 codegen while
-  # B3_ENABLE_ASSERT keeps asserts alive, heavy validation stays Debug only.
+  # Debug -O0 copies whole structs and hid the b3SurfaceMaterial padding dedup bug.
+  # RelWithDebInfo tests -O2 codegen while B3_ENABLE_ASSERT keeps asserts alive,
+  # heavy validation stays Debug only.
   build-windows-mingw:
     name: windows-mingw
     runs-on: windows-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,87 @@
 # Box3D Fixed-Point Conversion — Session Handoff
 
 Box3D converted from float to Q48.16 fixed point (internal and external API).
-Baseline float code is commit c52908c. EVERYTHING below is committed and pushed;
-there is no pending working-tree state.
 
-## Current status (as of 2026-08-04 — v1.4.0, MAINTENANCE MODE)
+## THE PORT CURSOR — read this before any Box3D -> Fixed3D pass
+
+**Everything in erincatto/box3d up to and including `3fc20f5` is carried across.**
+`git log 3fc20f5..upstream/main` is the remaining work. (This line replaced
+*"Baseline float code is commit c52908c"* on 2026-08-22 — same claim, said as a cursor.) Two named exceptions, both on
+the issue board rather than buried here, because a cursor with silent holes is worse
+than no cursor:
+
+- **fixed3d#20** — the sample-viewer half of `3fc20f5` (follow cam, world text,
+  stb_truetype, the world_text shader). Held for a bench with a display; no simulation
+  content, so it does not gate the cursor.
+- **fixed3d#21** — `f42be21` is PARTIALLY ported: its triangle-manifold fixes landed
+  2026-08-22, its 64-bit content-hash rework and player API rename did NOT. The cursor
+  therefore does NOT move past `f42be21`, and `30c67b5` (rapidhash) sits behind it.
+
+The PORT RECORDs below run newest first and are the detail for each step.
+
+## Current status (as of 2026-08-22 — v1.4.0, MAINTENANCE MODE)
+
+- **PORT RECORD f42be21 "64-bit hashes (#126)" (2026-08-11) — PARTIAL, triangle
+  manifold only.** PORTED: b3ClipSegmentToTriangleFace tests the crossing by SIGN
+  rather than by the product of the two separations, which in Q48.16 is a
+  quantization fix and not a style change (b3FixMul of two separations under ~0.004
+  goes to zero, dropping a clip point); b3QueryTriangleAndCapsuleEdges hoists the
+  plane dot out of the loop and its parallel-edge skip now advances v1/edgeIndex (a
+  real bug — the next iteration walked from the wrong vertex); the capsule-edge
+  contact point puts the radius on point2, the capsule-core side, value-identical and
+  free; two B3_VALIDATEs upstream dropped; the b3CollideTask quaternion-dot comment
+  and the drawMass restructure. GOLDEN: RAGDOLL_HASH only, 0xB222C195 -> 0xC9322058
+  narrow and 0x886BE415 -> 0xAD895018 ludicrous, every sleep step and every other
+  scene unchanged, identical for worker counts 1-5 in both builds; isolated by
+  bisecting the four hunks one at a time. **NOT PORTED, deliberately:** the deep-path
+  contact point reassociation — the same value in exact arithmetic, and taking it
+  moves the ragdoll sleep step 287 -> 453, which is the b3Lerp rounding lottery in the
+  "deliberately NOT fused" list below. The comment at the site says so; do not tidy it
+  back in. SKIPPED: b3GetVersion (upstream's own version), the B3_FORCE_INLINE
+  annotations (no analogue — our equivalents are one-line forwarders into the vendored
+  `fixed` library), and the new edgeQuery.indexA early return (already satisfied by
+  our `haveEdge` guard). REMAINDER: **fixed3d#21**.
+
+- **PORT RECORD 3fc20f5 "Follow cam (#107)" (2026-07-29) — engine half.** PORTED:
+  sensor visitors must be convex (b3IsConvex in shape.h), **which is a crash fix
+  here** — b3OverlapSensor builds the visitor proxy with b3MakeShapeProxy, whose
+  switch handles only sphere/capsule/hull and otherwise hits B3_ASSERT(false) with a
+  zeroed proxy, so a compound, mesh or height-field visitor with sensor events enabled
+  trapped in any validate build and silently reported nothing in release. Measured:
+  the new TestSensorVisitorMustBeConvex exits 133 (SIGTRAP) on Debug+VALIDATE with the
+  old rule and 0 with the new one; in Release it does not discriminate, which is
+  stated in the test. B3_MAX_SHAPE_CAST_POINTS becomes B3_MAX_HULL_VERTICES (128 here,
+  256 upstream, was a hard 64), so proxies of 65..128 points stop being truncated in
+  compound.c, sensor.c and the replay reader — the recording FORMAT is unchanged.
+  CMake fp-contract tests the compiler rather than the platform; CI gains
+  matrix.config plus macos- and windows-relwithdebinfo (upstream's reason is float
+  contraction, ours is that the goldens are otherwise only checked at -O0); debug draw
+  body names go white and the mass label loses its leading spaces. HELD: the
+  sample-viewer feature, **fixed3d#20**.
+
+- **PORT RECORD 781673b "Fixes 09 (#104)" (2026-07-24).** PORTED: the capsule
+  face/edge admission at BOTH call sites drops the relative edge tolerance for
+  `edgeSeparation > faceSeparation + linearSlop` — strictly better in fixed point,
+  an int64 add where the old form was a b3FixMul — with the face separation taking the
+  clipped min only at pointCount == 2 under upstream's new B3_VALIDATE, and
+  b3DeepestPointSeparation gone with its only caller; NO GOLDEN MOVED, matching
+  upstream not touching its own test_determinism.c. src/hull_map.h renamed to
+  src/hull.h; B3_PRINTF_FORMAT in base.h with core.h and three sample declarations
+  using it; the geometry registry's entries become a b3Array; valid-transform asserts
+  on the two box-hull builders; clang-cl fp-contract and the four clang-cl presets;
+  sample cleanups (the RagdollPile enum becomes m_isDebug ? 8 : 20, four unused
+  three-material arrays drop out of sample_character, two dead locals). Four tests
+  translated to Q48.16 and green — upstream's 1e-5f tolerances are BELOW our 1.5e-5
+  quantum and floor to 8 * B3_FIXED_EPSILON, with 16 for the plane offset's extra
+  rounding. ALREADY SATISFIED (this tree was ahead): recording ops 0x5D/0x5E/0x5F and
+  their whole stack, so B3_REC_VERSION_MINOR stays at 6 where upstream went 3 -> 4;
+  b3Log's printf attribute; the sample printf argument casts, ours to
+  (unsigned long long) where upstream uses (int). NOT PORTED: the SoA half of
+  CheckTransformedBox (b3BoxHull has no vx/nx lanes here), and our stronger
+  B3_VALIDATE( faceSeparation <= B3_SPECULATIVE_DISTANCE ) is kept where upstream
+  deleted its `<= 0.0f` version.
+
+## Older status (as of 2026-08-04 — v1.4.0)
 
 - **PORT RECORD c52908c "Fixes 08 (#98)" (2026-07-24)** — hull builder leak +
   samples data-folder resilience. Engine: ResolveFaces now retires each

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,8 @@ The PORT RECORDs below run newest first and are the detail for each step.
   zeroed proxy, so a compound, mesh or height-field visitor with sensor events enabled
   trapped in any validate build and silently reported nothing in release. Measured:
   the new TestSensorVisitorMustBeConvex exits 133 (SIGTRAP) on Debug+VALIDATE with the
-  old rule and 0 with the new one; in Release it does not discriminate, which is
-  stated in the test. B3_MAX_SHAPE_CAST_POINTS becomes B3_MAX_HULL_VERTICES (128 here,
+  old rule and 0 with the new one; in Release, and in any NDEBUG config including the
+  two RelWithDebInfo CI jobs, it does not discriminate — a note in the test says so. B3_MAX_SHAPE_CAST_POINTS becomes B3_MAX_HULL_VERTICES (128 here,
   256 upstream, was a hard 64), so proxies of 65..128 points stop being truncated in
   compound.c, sensor.c and the replay reader — the recording FORMAT is unchanged.
   CMake fp-contract tests the compiler rather than the platform; CI gains

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,9 @@ endif()
 # https://box2d.org/posts/2024/08/determinism/
 if (MINGW OR APPLE OR UNIX)
 	add_compile_options(-ffp-contract=off)
+elseif (MSVC AND CMAKE_C_COMPILER_ID STREQUAL "Clang")
+	# clang-cl defaults to contraction on and silently drops the GNU spelling
+	add_compile_options(/clang:-ffp-contract=off)
 endif()
 
 option(BOX3D_DISABLE_SIMD "Disable SIMD math (slower)" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,11 +86,16 @@ endif()
 
 # Deterministic math
 # https://box2d.org/posts/2024/08/determinism/
-if (MINGW OR APPLE OR UNIX)
-	add_compile_options(-ffp-contract=off)
-elseif (MSVC AND CMAKE_C_COMPILER_ID STREQUAL "Clang")
-	# clang-cl defaults to contraction on and silently drops the GNU spelling
-	add_compile_options(/clang:-ffp-contract=off)
+# Contraction into FMA is the one value changing transform enabled by default, and whether
+# it fires depends on the target. Test the compiler, not the platform, so every gcc and
+# clang gets the flag including a clang that is neither MinGW nor clang-cl.
+if (CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+	if (CMAKE_C_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
+		# clang-cl defaults to contraction on and silently drops the GNU spelling
+		add_compile_options(/clang:-ffp-contract=off)
+	else()
+		add_compile_options(-ffp-contract=off)
+	endif()
 endif()
 
 option(BOX3D_DISABLE_SIMD "Disable SIMD math (slower)" OFF)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -54,6 +54,42 @@
         "CMAKE_CXX_COMPILER": "g++",
         "FETCHCONTENT_BASE_DIR": "${sourceDir}/.fetchcontent-cache/mingw"
       }
+    },
+    {
+      "name": "windows-clang-cl",
+      "displayName": "Windows clang-cl (Visual Studio solution, ClangCL toolset)",
+      "toolset": "ClangCL",
+      "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows" },
+      "binaryDir": "${sourceDir}/build/clang-cl-vs",
+      "cacheVariables": {
+        "FETCHCONTENT_BASE_DIR": "${sourceDir}/.fetchcontent-cache/clang-cl-vs"
+      }
+    },
+    {
+      "name": "clang-cl-debug",
+      "displayName": "Windows clang-cl Debug (Ninja, needs LLVM on PATH)",
+      "generator": "Ninja",
+      "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows" },
+      "binaryDir": "${sourceDir}/build/clang-cl",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_C_COMPILER": "clang-cl",
+        "CMAKE_CXX_COMPILER": "clang-cl",
+        "FETCHCONTENT_BASE_DIR": "${sourceDir}/.fetchcontent-cache/clang-cl"
+      }
+    },
+    {
+      "name": "clang-cl-release",
+      "displayName": "Windows clang-cl Release (Ninja, needs LLVM on PATH)",
+      "generator": "Ninja",
+      "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows" },
+      "binaryDir": "${sourceDir}/build/clang-cl",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_C_COMPILER": "clang-cl",
+        "CMAKE_CXX_COMPILER": "clang-cl",
+        "FETCHCONTENT_BASE_DIR": "${sourceDir}/.fetchcontent-cache/clang-cl"
+      }
     }
   ],
   "buildPresets": [
@@ -64,6 +100,10 @@
     { "name": "macos-debug",     "configurePreset": "macos",       "configuration": "Debug" },
     { "name": "macos-release",   "configurePreset": "macos",       "configuration": "Release" },
     { "name": "mingw-debug",     "configurePreset": "mingw-debug" },
-    { "name": "mingw-release",   "configurePreset": "mingw-release" }
+    { "name": "mingw-release",   "configurePreset": "mingw-release" },
+    { "name": "windows-clang-cl-debug",   "configurePreset": "windows-clang-cl", "configuration": "Debug" },
+    { "name": "windows-clang-cl-release", "configurePreset": "windows-clang-cl", "configuration": "Release" },
+    { "name": "clang-cl-debug",   "configurePreset": "clang-cl-debug" },
+    { "name": "clang-cl-release", "configurePreset": "clang-cl-release" }
   ]
 }

--- a/include/box3d/base.h
+++ b/include/box3d/base.h
@@ -68,6 +68,13 @@
 #endif
 // clang-format on
 
+// This is used to validate arguments for functions similar to printf.
+#if defined( __GNUC__ ) || defined( __clang__ )
+#define B3_PRINTF_FORMAT( INDEX1, INDEX2 ) __attribute__( ( format( printf, INDEX1, INDEX2 ) ) )
+#else
+#define B3_PRINTF_FORMAT( INDEX1, INDEX2 )
+#endif
+
 #if defined( BOX3D_VALIDATE ) && !defined( NDEBUG )
 #define B3_ENABLE_VALIDATION 1
 #else

--- a/include/box3d/constants.h
+++ b/include/box3d/constants.h
@@ -104,9 +104,6 @@ B3_API b3Fixed b3GetStallThreshold( void );
 /// The maximum number of contact points between two touching shapes.
 #define B3_MAX_MANIFOLD_POINTS 4
 
-/// The maximum number points to use for shape cast proxies (swept point cloud).
-#define B3_MAX_SHAPE_CAST_POINTS 64
-
 /// The number of iterations for gyroscopic torques.
 #ifndef B3_GYROSCOPIC_ITERATIONS
 #define B3_GYROSCOPIC_ITERATIONS 1
@@ -124,6 +121,9 @@ B3_API b3Fixed b3GetStallThreshold( void );
 /// Relative tolerance used to determine if two edges are parallel.
 /// Fixed point: wrap with B3_FIX at use sites (the raw float is the portable constant).
 #define B3_PARALLEL_EDGE_TOL 0.005f
+
+/// The maximum number points to use for shape cast proxies (swept point cloud).
+#define B3_MAX_SHAPE_CAST_POINTS B3_MAX_HULL_VERTICES
 
 /// These generous limits allow for easy hashing. See b3ShapePairKey.
 #define B3_SHAPE_POWER 22

--- a/include/box3d/types.h
+++ b/include/box3d/types.h
@@ -493,6 +493,7 @@ typedef struct b3ShapeDef
 	bool isSensor;
 
 	/// Enable sensor events for this shape. This applies to sensors and non-sensors. False by default, even for sensors.
+	/// Only convex shapes may act as sensor visitors.
 	bool enableSensorEvents;
 
 	/// Enable contact events for this shape. Only applies to kinematic and dynamic bodies. Ignored for sensors. False by default.

--- a/samples/earcut.h
+++ b/samples/earcut.h
@@ -262,11 +262,8 @@ void Earcut<N>::earcutLinked(Node* ear, int pass) {
     Node* prev;
     Node* next;
 
-    int iterations = 0;
-
     // iterate through ears, slicing them one by one
     while (ear->prev != ear->next) {
-        iterations++;
         prev = ear->prev;
         next = ear->next;
 

--- a/samples/gfx/draw.h
+++ b/samples/gfx/draw.h
@@ -122,12 +122,8 @@ void DrawWireSphere( b3WorldTransform transform, const b3Sphere* sphere, int seg
 void DrawWireCapsule( b3WorldTransform transform, const b3Capsule* capsule, int segments, Vec4 color );
 
 // printf-style positioned text label. The renderer projects with its latched camera.
-#if defined( __GNUC__ ) || defined( __clang__ )
-void DrawString3D( b3Pos point, Vec4 color, const char* format, ... ) __attribute__( ( format( printf, 3, 4 ) ) );
-#else
 B3_PRINTF_FORMAT( 3, 4 )
 void DrawString3D( b3Pos point, Vec4 color, const char* format, ... );
-#endif
 
 #ifdef __cplusplus
 } // extern "C"

--- a/samples/gfx/draw.h
+++ b/samples/gfx/draw.h
@@ -125,6 +125,7 @@ void DrawWireCapsule( b3WorldTransform transform, const b3Capsule* capsule, int 
 #if defined( __GNUC__ ) || defined( __clang__ )
 void DrawString3D( b3Pos point, Vec4 color, const char* format, ... ) __attribute__( ( format( printf, 3, 4 ) ) );
 #else
+B3_PRINTF_FORMAT( 3, 4 )
 void DrawString3D( b3Pos point, Vec4 color, const char* format, ... );
 #endif
 

--- a/samples/gfx/text.c
+++ b/samples/gfx/text.c
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Erin Catto
 // SPDX-License-Identifier: MIT
 
+#if defined( _MSC_VER ) && !defined( _CRT_SECURE_NO_WARNINGS )
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
 #include "gfx/text.h"
 
 #include <assert.h>

--- a/samples/gfx/text.h
+++ b/samples/gfx/text.h
@@ -52,13 +52,9 @@ void DrawString( b3Vec3 worldPos, Vec4 color, const char* text );
 // Submit a UTF-8 string at a screen-pixel position (origin top-left, Y down,
 // framebuffer pixels). Same copy/truncation/overflow rules as DrawString.
 void DrawScreenString( int x, int y, Vec4 color, const char* text );
-#if defined( __GNUC__ ) || defined( __clang__ )
-void DrawScreenStringFormat( int x, int y, Vec4 color, const char* fmt, ... ) __attribute__( ( format( printf, 4, 5 ) ) );
-#else
 
 B3_PRINTF_FORMAT( 4, 5 )
 void DrawScreenStringFormat( int x, int y, Vec4 color, const char* fmt, ... );
-#endif
 
 // Iteration surface for the GUI shell. Pointers/strings are valid until
 // the next ResetTextArena (called by ResetFrameArena, which the GUI shell

--- a/samples/gfx/text.h
+++ b/samples/gfx/text.h
@@ -55,6 +55,8 @@ void DrawScreenString( int x, int y, Vec4 color, const char* text );
 #if defined( __GNUC__ ) || defined( __clang__ )
 void DrawScreenStringFormat( int x, int y, Vec4 color, const char* fmt, ... ) __attribute__( ( format( printf, 4, 5 ) ) );
 #else
+
+B3_PRINTF_FORMAT( 4, 5 )
 void DrawScreenStringFormat( int x, int y, Vec4 color, const char* fmt, ... );
 #endif
 

--- a/samples/sample.h
+++ b/samples/sample.h
@@ -216,6 +216,7 @@ public:
 	// Index 2/3 accounts for the implicit `this`. Catches b3Fixed passed to %f/%g (varargs UB).
 	void DrawTextLine( const char* text, ... ) __attribute__( ( format( printf, 2, 3 ) ) );
 #else
+	B3_PRINTF_FORMAT( 2, 3 )
 	void DrawTextLine( const char* text, ... );
 #endif
 	void ResetProfile();

--- a/samples/sample.h
+++ b/samples/sample.h
@@ -212,13 +212,9 @@ public:
 	virtual void MouseMove( b3Vec2 p );
 
 	void ToggleThirdPerson();
-#if defined( __GNUC__ ) || defined( __clang__ )
 	// Index 2/3 accounts for the implicit `this`. Catches b3Fixed passed to %f/%g (varargs UB).
-	void DrawTextLine( const char* text, ... ) __attribute__( ( format( printf, 2, 3 ) ) );
-#else
 	B3_PRINTF_FORMAT( 2, 3 )
 	void DrawTextLine( const char* text, ... );
-#endif
 	void ResetProfile();
 
 	// Static ground box at the origin, drawn with the procedural grid material

--- a/samples/sample_character.cpp
+++ b/samples/sample_character.cpp
@@ -336,12 +336,6 @@ public:
 			b3BodyId body = b3CreateBody( m_worldId, &bodyDef );
 
 			b3ShapeDef shapeDef = b3DefaultShapeDef();
-			b3SurfaceMaterial materials[3];
-			materials[0] = { B3_FIX( 0.6f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) };
-			materials[1] = { B3_FIX( 0.6f ), B3_FIX( 1.0f ), B3_FIX( 1.0f ) };
-			materials[2] = { B3_FIX( 0.1f ), B3_FIX( 0.0f ), B3_FIX( 2.0f ) };
-			shapeDef.materials = materials;
-			shapeDef.materialCount = 3;
 
 			if ( m_levelMesh != nullptr )
 			{
@@ -403,13 +397,6 @@ public:
 
 			m_heightField = b3CreateWave( 50.0f, 50.0f, b3Vec3_one, B3_FIX( 0.02f ), B3_FIX( 0.04f ), true );
 			b3ShapeDef shapeDef = b3DefaultShapeDef();
-			b3SurfaceMaterial materials[3];
-			materials[0] = { B3_FIX( 0.6f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) };
-			materials[1] = { B3_FIX( 0.6f ), B3_FIX( 1.0f ), B3_FIX( 1.0f ) };
-			materials[2] = { B3_FIX( 0.1f ), B3_FIX( 0.0f ), B3_FIX( 2.0f ) };
-			shapeDef.materials = materials;
-			shapeDef.materialCount = 3;
-
 			b3CreateHeightFieldShape( body, &shapeDef, m_heightField );
 		}
 
@@ -1348,12 +1335,6 @@ public:
 			b3BodyId body = b3CreateBody( m_worldId, &bodyDef );
 
 			b3ShapeDef shapeDef = b3DefaultShapeDef();
-			b3SurfaceMaterial materials[3];
-			materials[0] = { B3_FIX( 0.6f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) };
-			materials[1] = { B3_FIX( 0.6f ), B3_FIX( 1.0f ), B3_FIX( 1.0f ) };
-			materials[2] = { B3_FIX( 0.1f ), B3_FIX( 0.0f ), B3_FIX( 2.0f ) };
-			shapeDef.materials = materials;
-			shapeDef.materialCount = 3;
 
 			if ( m_levelMesh != nullptr )
 			{
@@ -1423,13 +1404,6 @@ public:
 
 			m_heightField = b3CreateWave( 50.0f, 50.0f, b3Vec3_one, B3_FIX( 0.02f ), B3_FIX( 0.04f ), true );
 			b3ShapeDef shapeDef = b3DefaultShapeDef();
-			b3SurfaceMaterial materials[3];
-			materials[0] = { B3_FIX( 0.6f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) };
-			materials[1] = { B3_FIX( 0.6f ), B3_FIX( 1.0f ), B3_FIX( 1.0f ) };
-			materials[2] = { B3_FIX( 0.1f ), B3_FIX( 0.0f ), B3_FIX( 2.0f ) };
-			shapeDef.materials = materials;
-			shapeDef.materialCount = 3;
-
 			b3CreateHeightFieldShape( body, &shapeDef, m_heightField );
 		}
 

--- a/samples/sample_ragdoll.cpp
+++ b/samples/sample_ragdoll.cpp
@@ -211,15 +211,6 @@ static int sampleRagdollMesh = RegisterSample( "Ragdoll", "Mesh", RagdollOnMesh:
 class RagdollPile : public Sample
 {
 public:
-	enum
-	{
-#ifdef NDEBUG
-		e_count = 20
-#else
-		e_count = 8
-#endif
-	};
-
 	explicit RagdollPile( SampleContext* context )
 		: Sample( context )
 	{
@@ -237,10 +228,10 @@ public:
 		b3CreateMeshShape( groundId, &shapeDef, m_groundMesh, b3Vec3_one );
 
 		g_randomSeed = 42;
-		b3Fixed a = e_count * B3_FIX( 0.1f );
+		b3Fixed a = m_count * B3_FIX( 0.1f );
 		b3Vec3 lower = { -a, -a, -a };
 		b3Vec3 upper = { a, a, a };
-		for ( int i = 0; i < e_count; ++i )
+		for ( int i = 0; i < m_count; ++i )
 		{
 			b3Vec3 offset = RandomVec3( lower, upper );
 			b3Pos position = SamplePos( { offset.x, B3_FIX( 2.0f ), offset.z } );
@@ -264,8 +255,9 @@ public:
 		return new RagdollPile( context );
 	}
 
+	static constexpr int m_count = m_isDebug ? 8 : 20;
 	b3MeshData* m_groundMesh;
-	Human m_humans[e_count] = {};
+	Human m_humans[m_count] = {};
 };
 
 static int sampleRagdollPile = RegisterSample( "Ragdoll", "Pile", RagdollPile::Create );

--- a/samples/sample_tree.cpp
+++ b/samples/sample_tree.cpp
@@ -284,9 +284,6 @@ public:
 			return;
 		}
 
-		constexpr int bufferSize = 512;
-		char buffer[bufferSize];
-
 		b3Fixed maxArea = 0;
 		int maxAreaIndex = -1;
 

--- a/shared/determinism.c
+++ b/shared/determinism.c
@@ -88,6 +88,9 @@ bool UpdateFallingRagdolls( b3WorldId worldId, FallingRagdollData* data )
 		{
 			int awakeCount = b3World_GetAwakeBodyCount( worldId );
 			assert( awakeCount == 0 );
+			// assert compiles away under NDEBUG, and clang-cl's does not even name its argument,
+			// so the variable reads as unused in an optimized build with warnings as errors.
+			(void)awakeCount;
 
 			data->hash = B3_HASH_INIT;
 			for ( int i = 0; i < RAGDOLL_GRID_COUNT; ++i )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ set(BOX3D_SOURCE_FILES
 	dynamic_tree.c
 	height_field.c
 	hull.c
+	hull.h
 	id_pool.c
 	id_pool.h
 	island.c

--- a/src/compound.c
+++ b/src/compound.c
@@ -3,7 +3,7 @@
 
 #include "compound.h"
 
-#include "hull_map.h"
+#include "hull.h"
 #include "math_internal.h"
 #include "shape.h"
 

--- a/src/convex_manifold.c
+++ b/src/convex_manifold.c
@@ -1233,19 +1233,6 @@ static bool b3BuildHullFaceAndCapsuleContact( b3LocalManifold* manifold, const b
 	return false;
 }
 
-static inline b3Fixed b3DeepestPointSeparation( const b3LocalManifold* manifold )
-{
-	// Deepest point
-	b3Fixed minSeparation = B3_FIXED_MAX;
-	int pointCount = manifold->pointCount;
-	for ( int i = 0; i < pointCount; ++i )
-	{
-		minSeparation = b3FixMin( minSeparation, manifold->points[i].separation );
-	}
-
-	return minSeparation;
-}
-
 static bool b3BuildHullAndCapsuleEdgeContact( b3LocalManifold* manifold, int capacity, const b3HullData* hullA,
 											  const b3Capsule* capsuleB, b3Transform transformBtoA, b3SeparatingAxis query )
 {
@@ -1410,25 +1397,23 @@ void b3CollideHullAndCapsule( b3LocalManifold* manifold, int capacity, const b3H
 	// Create face contact
 	b3Fixed faceSeparation = faceQuery.separation - capsuleB->radius;
 	b3BuildHullFaceAndCapsuleContact( manifold, hullA, capsuleB, transformBtoA, faceQuery );
-	if ( manifold->pointCount > 1 )
+	B3_VALIDATE( manifold->pointCount == 0 || manifold->pointCount == 2 );
+	if ( manifold->pointCount == 2 )
 	{
-		// If ( Out.PointCount <= 1 ) -> Compare with unclipped separation
-		// If ( Out.PointCount > 1 ) -> Be aggressive and compare with clipped separation
-		// Face contact can be empty if it does not realize the axis of minimum penetration
-		faceSeparation = b3DeepestPointSeparation( manifold );
+		// This becomes the clipped separation.
+		faceSeparation = b3FixMin( manifold->points[0].separation, manifold->points[1].separation );
 	}
-	B3_VALIDATE( faceSeparation <= B3_FIX( 0.0f ) );
 
 	// Face contact can be empty if it does not realize the axis of minimum penetration.
 	// Create edge contact if face contact fails or edge contact is significantly better!
-	const b3Fixed kRelEdgeTolerance = B3_FIX( 0.90f );
-	const b3Fixed kAbsTolerance = b3FixMul( B3_FIX( 0.5f ) , B3_LINEAR_SLOP );
+	// Upstream 781673b replaced the relative tolerance with a plain slop offset. In fixed point the
+	// new form is strictly better: it is an int64 add instead of a b3FixMul, so nothing quantizes.
+	const b3Fixed linearSlop = B3_LINEAR_SLOP;
 	// The edge query can find no admissible pair (its separation stays at the
 	// -B3_FIXED_MAX sentinel, which would wrap under further arithmetic).
 	bool haveEdge = edgeQuery.indexB != B3_NULL_INDEX;
 	b3Fixed edgeSeparation = haveEdge ? edgeQuery.separation - capsuleB->radius : B3_FIXED_MIN;
-	if ( manifold->pointCount == 0 ? haveEdge
-								   : ( haveEdge && edgeSeparation > b3FixMul( kRelEdgeTolerance , faceSeparation ) + kAbsTolerance ) )
+	if ( manifold->pointCount == 0 ? haveEdge : ( haveEdge && edgeSeparation > faceSeparation + linearSlop ) )
 	{
 		// Edge contact
 		b3BuildHullAndCapsuleEdgeContact( manifold, capacity, hullA, capsuleB, transformBtoA, edgeQuery );

--- a/src/core.h
+++ b/src/core.h
@@ -144,11 +144,8 @@ void* b3AllocZeroed( size_t size );
 void b3Free( void* mem, size_t size );
 void* b3GrowAlloc( void* oldMem, int oldSize, int newSize );
 
-#if defined( __GNUC__ ) || defined( __clang__ )
-void b3Log( const char* format, ... ) __attribute__( ( format( printf, 1, 2 ) ) );
-#else
+B3_PRINTF_FORMAT( 1, 2 )
 void b3Log( const char* format, ... );
-#endif
 
 // Geometry content hashes reserve zero to mean unhashed
 static inline uint32_t b3NonZeroHash( uint32_t hash )

--- a/src/hull.c
+++ b/src/hull.c
@@ -4,7 +4,7 @@
 // Dirk Gregorius contributed portions of this code
 
 #include "algorithm.h"
-#include "hull_map.h"
+#include "hull.h"
 #include "math_internal.h"
 #include "shape.h"
 
@@ -2792,6 +2792,7 @@ bool b3CompareHullData( const b3HullData* hull1, const b3HullData* hull2 )
 _Static_assert( sizeof( b3HullData ) == 224 + ( sizeof( b3AABB ) - 2 * sizeof( b3Vec3 ) ), "unexpected hull data size" );
 _Static_assert( sizeof( b3BoxHull ) == 720 + ( sizeof( b3AABB ) - 2 * sizeof( b3Vec3 ) ), "unexpected box hull size" );
 
+// Implement b3HullMap.
 #define NAME b3HullMap
 #define KEY_TY const b3HullData*
 #define VAL_TY int
@@ -3228,6 +3229,8 @@ static const b3BoxHull s_boxHull = {
 
 b3BoxHull b3MakeTransformedBoxHull( b3Fixed hx, b3Fixed hy, b3Fixed hz, b3Transform transform )
 {
+	B3_ASSERT( b3IsValidTransform( transform ) );
+
 	b3BoxHull boxHull = s_boxHull;
 
 	b3Fixed minH = b3FixMul( B3_FIX( 0.2f ) , B3_LINEAR_SLOP );
@@ -3335,6 +3338,8 @@ void b3ScaleBox( b3Vec3* halfWidths, b3Transform* transform, b3Vec3 postScale, b
 // todo use new hull scaling technique
 b3BoxHull b3MakeScaledBoxHull( b3Vec3 halfWidths, b3Transform transform, b3Vec3 postScale )
 {
+	B3_ASSERT( b3IsValidTransform( transform ) );
+
 	b3Vec3 h = halfWidths;
 	b3Transform xf = transform;
 	b3ScaleBox( &h, &xf, postScale, b3FixMul( B3_FIX( 4.0f ) , B3_LINEAR_SLOP ) );

--- a/src/hull.h
+++ b/src/hull.h
@@ -12,8 +12,8 @@
 uint64_t b3HashHullData( const b3HullData* hull );
 bool b3CompareHullData( const b3HullData* hull1, const b3HullData* hull2 );
 
-// Map keyed by hull content. The world hull database stores a reference count,
-// compound baking stores a byte offset. Implementation lives in hull.c.
+// Map keyed by hull content. The world hull database uses the value as a reference count,
+// while compound baking stores uses the value as a byte offset. Implementation is in hull.c.
 #define NAME b3HullMap
 #define KEY_TY const b3HullData*
 #define VAL_TY int

--- a/src/physics_world.c
+++ b/src/physics_world.c
@@ -1437,20 +1437,20 @@ void b3World_Draw( b3WorldId worldId, b3DebugDraw* draw, uint64_t maskBits )
 				const char* name = b3FindName( &world->names, body->nameId );
 				if ( name != NULL )
 				{
-					draw->DrawStringFcn( p, name, b3_colorOrange, draw->context );
+					draw->DrawStringFcn( p, name, b3_colorWhite, draw->context );
 				}
 			}
 
 			if ( draw->drawMass && body->type == b3_dynamicBody )
 			{
-				b3Vec3 offset = { B3_FIX( 0.1f ), B3_FIX( 0.1f ), B3_FIX( 0.1f ) };
+				b3Vec3 offset = { B3_FIX( 0.05f ), B3_FIX( 0.05f ), B3_FIX( 0.05f ) };
 
 				b3WorldTransform transform = { bodySim->center, bodySim->transform.q };
 				draw->DrawTransformFcn( transform, draw->context );
 				b3Pos p = b3TransformWorldPoint( transform, offset );
 
 				char buffer[32];
-				snprintf( buffer, 32, "  %.2f", b3FixToDouble( body->mass ) );
+				snprintf( buffer, 32, "%.2f", b3FixToDouble( body->mass ) );
 				draw->DrawStringFcn( p, buffer, b3_colorWhite, draw->context );
 			}
 

--- a/src/physics_world.c
+++ b/src/physics_world.c
@@ -11,7 +11,7 @@
 #include "contact.h"
 #include "core.h"
 #include "ctz.h"
-#include "hull_map.h"
+#include "hull.h"
 #include "island.h"
 #include "joint.h"
 #include "parallel_for.h"
@@ -40,18 +40,21 @@ const b3HullData* b3AddHullToDatabase( b3World* world, const b3HullData* src )
 {
 	b3HullMap* database = world->hullDatabase;
 
-	// Compare by content so an unowned query hull finds the shared copy.
+	// Compare by content to de-duplicate. Not trusting the hash.
 	b3HullMap_itr itr = b3HullMap_get( database, src );
 	if ( b3HullMap_is_end( itr ) == false )
 	{
+		// Bump reference count.
 		itr.data->val += 1;
 		return itr.data->key;
 	}
 
-	b3HullData* owned = b3CloneHull( src );
-	B3_ASSERT( owned != NULL );
-	b3HullMap_insert( database, owned, 1 );
-	return owned;
+	b3HullData* clone = b3CloneHull( src );
+	B3_ASSERT( clone != NULL );
+
+	// Start with reference count of 1.
+	b3HullMap_insert( database, clone, 1 );
+	return clone;
 }
 
 const b3HullData* b3AddOwnedHullToDatabase( b3World* world, b3HullData* owned )

--- a/src/physics_world.c
+++ b/src/physics_world.c
@@ -666,6 +666,10 @@ static void b3CollideTask( int startIndex, int endIndex, int workerIndex, void* 
 		if ( ( isFast == false || isMeshContact == false ) && recycleDistance > B3_FIX( 0.0f ) &&
 			 ( contact->flags & b3_relativeTransformValid ) && ( contact->flags & b3_contactRecycleFlag ) )
 		{
+			// The scalar part of b3InvMulQuat is just the quaternion dot product.
+			// cos(relative_angle/2) = scalar(conj(q1) * q2) = dot(q1, q2)
+			// A small relative angle means this value is close to 1. Need to use abs or square
+			// due to double cover.
 			b3Fixed angleA = b3DotQuat( transformA.q, contact->cachedRotationA );
 			b3Fixed angleB = b3DotQuat( transformB.q, contact->cachedRotationB );
 			b3Fixed angularDistance = b3FixMin( b3FixMul( angleA , angleA ), b3FixMul( angleB , angleB ) );
@@ -1441,17 +1445,19 @@ void b3World_Draw( b3WorldId worldId, b3DebugDraw* draw, uint64_t maskBits )
 				}
 			}
 
-			if ( draw->drawMass && body->type == b3_dynamicBody )
+			if ( draw->drawMass )
 			{
-				b3Vec3 offset = { B3_FIX( 0.05f ), B3_FIX( 0.05f ), B3_FIX( 0.05f ) };
-
 				b3WorldTransform transform = { bodySim->center, bodySim->transform.q };
 				draw->DrawTransformFcn( transform, draw->context );
-				b3Pos p = b3TransformWorldPoint( transform, offset );
 
-				char buffer[32];
-				snprintf( buffer, 32, "%.2f", b3FixToDouble( body->mass ) );
-				draw->DrawStringFcn( p, buffer, b3_colorWhite, draw->context );
+				if ( body->type == b3_dynamicBody )
+				{
+					b3Vec3 offset = { B3_FIX( 0.05f ), B3_FIX( 0.05f ), B3_FIX( 0.05f ) };
+					b3Pos p = b3TransformWorldPoint( transform, offset );
+					char buffer[32];
+					snprintf( buffer, 32, "%.2f", b3FixToDouble( body->mass ) );
+					draw->DrawStringFcn( p, buffer, b3_colorWhite, draw->context );
+				}
 			}
 
 			if ( draw->drawSleep )

--- a/src/physics_world.h
+++ b/src/physics_world.h
@@ -178,7 +178,7 @@ typedef struct b3World
 	b3Array( b3Shape ) shapes;
 
 	// Reference counted store of shared hull data keyed by content. Shapes hold a
-	// pointer to the owned copy here. Opaque to avoid leaking the verstable map
+	// pointer to the hull stored in the db. Type erased to avoid leaking the verstable map
 	// type into this header.
 	void* hullDatabase;
 

--- a/src/recording.c
+++ b/src/recording.c
@@ -818,23 +818,15 @@ uint64_t b3Hash64Blob( const uint8_t* bytes, int n )
 static uint32_t b3RegistryPush( b3GeometryRegistry* reg, b3GeometryHashMap* map, b3GeometryHashMap_itr itr, bool hashPresent,
 								b3GeometryKind kind, uint64_t contentHash, uint8_t* bytes, int byteCount )
 {
-	if ( reg->count >= reg->capacity )
-	{
-		int newCap = reg->capacity < 8 ? 8 : reg->capacity * 2;
-		reg->entries = (b3GeometryEntry*)b3GrowAlloc( reg->entries, reg->capacity * (int)sizeof( b3GeometryEntry ),
-													  newCap * (int)sizeof( b3GeometryEntry ) );
-		reg->capacity = newCap;
-	}
-
-	uint32_t id = (uint32_t)reg->count;
-	b3GeometryEntry* entry = reg->entries + reg->count;
+	uint32_t id = (uint32_t)reg->entries.count;
+	b3GeometryEntry* entry = b3Array_Emplace( reg->entries );
 	entry->contentHash = contentHash;
 	entry->id = id;
 	entry->kind = kind;
 	entry->byteCount = byteCount;
-	entry->bytes = bytes; // take ownership
+	// Take ownership.
+	entry->bytes = bytes;
 	entry->hashNext = hashPresent ? (int)itr.data->val : B3_NULL_INDEX;
-	reg->count++;
 
 	if ( hashPresent )
 	{
@@ -851,11 +843,11 @@ static b3GeometryHashMap* b3RegistryMap( b3GeometryRegistry* reg )
 {
 	if ( reg->dedupMap == NULL )
 	{
-		b3GeometryHashMap* fresh = (b3GeometryHashMap*)b3Alloc( sizeof( b3GeometryHashMap ) );
+		b3GeometryHashMap* fresh = b3Alloc( sizeof( b3GeometryHashMap ) );
 		b3GeometryHashMap_init( fresh );
 		reg->dedupMap = fresh;
 	}
-	return (b3GeometryHashMap*)reg->dedupMap;
+	return reg->dedupMap;
 }
 
 uint32_t b3InternGeometry( b3GeometryRegistry* reg, b3GeometryKind kind, uint64_t contentHash, uint8_t* bytes, int byteCount )
@@ -867,12 +859,12 @@ uint32_t b3InternGeometry( b3GeometryRegistry* reg, b3GeometryKind kind, uint64_
 	if ( hashPresent )
 	{
 		// Walk every entry sharing this hash so a collision still finds the identical blob.
-		for ( int idx = (int)itr.data->val; idx != B3_NULL_INDEX; idx = reg->entries[idx].hashNext )
+		for ( int index = (int)itr.data->val; index != B3_NULL_INDEX; index = reg->entries.data[index].hashNext )
 		{
-			b3GeometryEntry* e = reg->entries + idx;
+			b3GeometryEntry* e = reg->entries.data + index;
 			if ( e->byteCount == byteCount && memcmp( e->bytes, bytes, (size_t)byteCount ) == 0 )
 			{
-				// Duplicate: the caller transferred ownership; return existing id
+				// Duplicate. Free bytes because the caller transferred ownership. Return existing id.
 				b3Free( bytes, (size_t)byteCount );
 				return e->id;
 			}
@@ -892,22 +884,18 @@ uint32_t b3AppendGeometry( b3GeometryRegistry* reg, b3GeometryKind kind, uint64_
 
 void b3FreeRegistry( b3GeometryRegistry* reg )
 {
-	for ( int i = 0; i < reg->count; ++i )
+	for ( int i = 0; i < reg->entries.count; ++i )
 	{
-		b3Free( reg->entries[i].bytes, (size_t)reg->entries[i].byteCount );
+		b3Free( reg->entries.data[i].bytes, (size_t)reg->entries.data[i].byteCount );
 	}
-	if ( reg->entries != NULL )
-	{
-		b3Free( reg->entries, (size_t)( reg->capacity * (int)sizeof( b3GeometryEntry ) ) );
-	}
+
+	b3Array_Destroy( reg->entries );
+
 	if ( reg->dedupMap != NULL )
 	{
 		b3GeometryHashMap_cleanup( (b3GeometryHashMap*)reg->dedupMap );
 		b3Free( reg->dedupMap, sizeof( b3GeometryHashMap ) );
 	}
-	reg->entries = NULL;
-	reg->count = 0;
-	reg->capacity = 0;
 	reg->dedupMap = NULL;
 }
 
@@ -974,10 +962,10 @@ void b3RecInternTag( b3Recording* rec, uint64_t key, uint64_t id, const char* na
 // the tag table stops after the geometry entries and ignores the trailing tag bytes.
 void b3RecWriteRegistry( b3Recording* rec )
 {
-	b3RecW_U32( &rec->buffer, (uint32_t)rec->registry.count );
-	for ( int i = 0; i < rec->registry.count; ++i )
+	b3RecW_U32( &rec->buffer, (uint32_t)rec->registry.entries.count );
+	for ( int i = 0; i < rec->registry.entries.count; ++i )
 	{
-		b3GeometryEntry* e = rec->registry.entries + i;
+		b3GeometryEntry* e = rec->registry.entries.data + i;
 		b3RecW_U8( &rec->buffer, (uint8_t)e->kind );
 		b3RecW_U32( &rec->buffer, (uint32_t)e->byteCount );
 		b3RecBufAppend( &rec->buffer, e->bytes, e->byteCount );
@@ -996,7 +984,7 @@ void b3RecWriteRegistry( b3Recording* rec )
 
 b3Recording* b3CreateRecording( int byteCapacity )
 {
-	b3Recording* rec = (b3Recording*)b3Alloc( sizeof( b3Recording ) );
+	b3Recording* rec = b3Alloc( sizeof( b3Recording ) );
 	*rec = (b3Recording){ 0 };
 
 	int initCap = byteCapacity > 0 ? byteCapacity : 65536;
@@ -1218,7 +1206,7 @@ b3Recording* b3LoadRecordingFromFile( const char* path )
 uint32_t b3RecInternHull( b3Recording* rec, const b3HullData* hull )
 {
 	int byteCount = hull->byteCount;
-	uint8_t* bytes = (uint8_t*)b3Alloc( (size_t)byteCount );
+	uint8_t* bytes = b3Alloc( (size_t)byteCount );
 	memcpy( bytes, hull, (size_t)byteCount );
 	uint64_t h = b3Hash64Blob( bytes, byteCount );
 	return b3InternGeometry( &rec->registry, b3_geometryHull, h, bytes, byteCount );
@@ -1227,7 +1215,7 @@ uint32_t b3RecInternHull( b3Recording* rec, const b3HullData* hull )
 uint32_t b3RecInternMesh( b3Recording* rec, const b3MeshData* mesh )
 {
 	int byteCount = mesh->byteCount;
-	uint8_t* bytes = (uint8_t*)b3Alloc( (size_t)byteCount );
+	uint8_t* bytes = b3Alloc( (size_t)byteCount );
 	memcpy( bytes, mesh, (size_t)byteCount );
 	uint64_t h = b3Hash64Blob( bytes, byteCount );
 	return b3InternGeometry( &rec->registry, b3_geometryMesh, h, bytes, byteCount );
@@ -1236,7 +1224,7 @@ uint32_t b3RecInternMesh( b3Recording* rec, const b3MeshData* mesh )
 uint32_t b3RecInternHeightField( b3Recording* rec, const b3HeightFieldData* hf )
 {
 	int byteCount = hf->byteCount;
-	uint8_t* bytes = (uint8_t*)b3Alloc( (size_t)byteCount );
+	uint8_t* bytes = b3Alloc( (size_t)byteCount );
 	memcpy( bytes, hf, (size_t)byteCount );
 	uint64_t h = b3Hash64Blob( bytes, byteCount );
 	return b3InternGeometry( &rec->registry, b3_geometryHeightField, h, bytes, byteCount );
@@ -1245,7 +1233,7 @@ uint32_t b3RecInternHeightField( b3Recording* rec, const b3HeightFieldData* hf )
 uint32_t b3RecInternCompound( b3Recording* rec, const b3CompoundData* compound )
 {
 	int byteCount = compound->byteCount;
-	uint8_t* bytes = (uint8_t*)b3Alloc( (size_t)byteCount );
+	uint8_t* bytes = b3Alloc( (size_t)byteCount );
 	memcpy( bytes, compound, (size_t)byteCount );
 	// Null the tree node pointer in the copy so the canonical bytes are pointer-free.
 	// b3ConvertBytesToCompound fixes it back on load via nodeOffset.

--- a/src/recording.h
+++ b/src/recording.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "container.h"
 #include "core.h"
 
 #include "box3d/id.h"
@@ -122,13 +123,13 @@ typedef struct b3GeometryEntry
 	int hashNext;
 } b3GeometryEntry;
 
+b3DeclareArray( b3GeometryEntry );
+
 // Growable array of geometry entries. Ids are array indices, so the array is serialized in order.
 // dedupMap maps content hash to entry id for O(1) dedup; it is opaque here and owned by recording.c.
 typedef struct b3GeometryRegistry
 {
-	b3GeometryEntry* entries;
-	int count;
-	int capacity;
+	b3Array( b3GeometryEntry ) entries;
 	void* dedupMap;
 } b3GeometryRegistry;
 

--- a/src/recording_replay.c
+++ b/src/recording_replay.c
@@ -1035,7 +1035,7 @@ static void b3RecDispatch_CreateMeshShape( const b3RecArgs_CreateMeshShape* a, b
 		return;
 	}
 	b3RegistrySlot* slot = rdr->slots + id;
-	const b3MeshData* mesh = (const b3MeshData*)b3RecGetLiveMesh( slot );
+	const b3MeshData* mesh = b3RecGetLiveMesh( slot );
 	b3BodyId bodyId = b3RecMakeBodyId( rdr, a->body );
 	b3ShapeId gotId = b3CreateMeshShape( bodyId, &a->def, mesh, a->scale );
 	b3RecCheckShapeId( rdr, gotId, recId );
@@ -1185,7 +1185,7 @@ static void b3RecDispatch_ShapeSetMesh( const b3RecArgs_ShapeSetMesh* a, b3RecRe
 		return;
 	}
 	b3RegistrySlot* slot = rdr->slots + id;
-	const b3MeshData* mesh = (const b3MeshData*)b3RecGetLiveMesh( slot );
+	const b3MeshData* mesh = b3RecGetLiveMesh( slot );
 	b3Shape_SetMesh( b3RecMakeShapeId( rdr, a->shape ), mesh, a->scale );
 }
 
@@ -2635,12 +2635,12 @@ static void b3RecCaptureKeyframe( b3RecPlayer* player )
 	b3World* world = b3GetWorldFromId( player->rdr.replayWorldId );
 	b3RecBuffer buf = { 0 };
 
-	int regCountBefore = player->keyframeRec->registry.count;
+	int regCountBefore = player->keyframeRec->registry.entries.count;
 	B3_UNUSED( regCountBefore );
 
 	b3SerializeWorld( world, &buf, player->keyframeRec );
 	// Registry must not grow: all geometry was pre-seeded and the registry dedups exactly.
-	B3_ASSERT( player->keyframeRec->registry.count == regCountBefore );
+	B3_ASSERT( player->keyframeRec->registry.entries.count == regCountBefore );
 
 	size_t bodyBytes = (size_t)player->bodyIdCount * sizeof( b3BodyId );
 	size_t newBytes = (size_t)buf.capacity + bodyBytes;

--- a/src/sensor.c
+++ b/src/sensor.c
@@ -107,9 +107,8 @@ static bool b3SensorQueryCallback( int proxyId, uint64_t userData, void* context
 	b3World* world = queryContext->world;
 	b3Shape* otherShape = b3Array_Get( world->shapes, shapeId );
 
-	// Mesh vs mesh is not supported
-	if ( ( otherShape->type == b3_meshShape || otherShape->type == b3_heightShape ) &&
-		 ( sensorShape->type == b3_meshShape || sensorShape->type == b3_heightShape ) )
+	// Visitors must be convex.
+	if ( b3IsConvex( otherShape->type ) == false )
 	{
 		return true;
 	}

--- a/src/shape.h
+++ b/src/shape.h
@@ -170,3 +170,8 @@ static inline bool b3ShouldQueryCollide( const b3Filter* shapeFilter, const b3Qu
 	return ( shapeFilter->categoryBits & queryFilter->maskBits ) != 0 &&
 		   ( shapeFilter->maskBits & queryFilter->categoryBits ) != 0;
 }
+
+static inline bool b3IsConvex( b3ShapeType type )
+{
+	return type == b3_sphereShape || type == b3_capsuleShape || type == b3_hullShape;
+}

--- a/src/triangle_manifold.c
+++ b/src/triangle_manifold.c
@@ -355,10 +355,14 @@ static void b3BuildTriangleAndCapsuleEdgeContact( b3LocalManifold* manifold, con
 		return;
 	}
 
-	// point1 is on the triangle edge and point2 on the capsule CORE, so the radius pulls point2
-	// back to the capsule surface. Value-identical to the old spelling; taken because it says what
-	// it means, and measured to move no golden.
-	b3Vec3 point = b3Lerp( result.point1, b3MulSub( result.point2, capsule->radius, normal ), B3_FIX( 0.5f ) );
+	// NOT PORTED, deliberately, and the twin of the refusal in b3CollideTriangleAndCapsule below.
+	// Upstream f42be21 moves the radius onto point2 — semantically the tidier reading, since point1
+	// is on the triangle edge and point2 on the capsule core. It is NOT value-identical here:
+	// b3Lerp is fixMul(1-t,a) + fixMul(t,b) with round-half-up, so moving an odd radius term from
+	// one side to the other flips the rounding on 288 of 1156 small-operand combinations, by one
+	// quantum. It moves no golden TODAY, which is not a reason to take a rounding reshuffle that
+	// buys nothing. Do not clean up.
+	b3Vec3 point = b3Lerp( b3MulSub( result.point1, capsule->radius, normal ), result.point2, B3_FIX( 0.5f ) );
 	b3Fixed separation = b3Dot( normal, b3Sub( p1, v1 ) );
 
 	manifold->normal = normal;
@@ -461,10 +465,12 @@ void b3CollideTriangleAndCapsule( b3LocalManifold* manifold, int capacity, const
 		// Create contact from closest points.
 		// NOT PORTED, deliberately: upstream f42be21 rewrites this as
 		//   b3Lerp( pointA, b3MulSub( pointB, radius, delta ), 0.5 )
-		// which is the same value in exact arithmetic — both are (pointA + pointB)/2 - radius*delta/2
-		// — and differs only in rounding. Measured on this tree: taking it moves the ragdoll sleep
-		// step 287 -> 453. That is the b3Lerp rounding lottery this repo already paid for (see the
-		// "deliberately NOT fused" list in CLAUDE.md), spent for no behavioural gain. Do not clean up.
+		// Equal in EXACT arithmetic — both reduce to (pointA + pointB)/2 - radius*delta/2 — but not
+		// in Q48.16, where round-half-up makes the two spellings differ by a quantum whenever the
+		// radius term is odd and the operands differ in parity. Measured on this tree: taking it
+		// moves the ragdoll sleep step 287 -> 453. That is the b3Lerp rounding lottery this repo
+		// already paid for (see the "deliberately NOT fused" list in CLAUDE.md), spent for no
+		// behavioural gain. Do not clean up.
 		b3Vec3 point = b3MulSV( B3_FIX( 0.5f ), b3Add( b3Sub( distanceOutput.pointA, b3MulSV( radius, delta ) ), distanceOutput.pointB ) );
 
 		// Normal points from triangle to capsule.

--- a/src/triangle_manifold.c
+++ b/src/triangle_manifold.c
@@ -140,8 +140,11 @@ static bool b3ClipSegmentToTriangleFace( b3ClipVertex segment[2], const b3Vec3* 
 			segment[vertexCount++] = p2;
 		}
 
-		// If the points are on different sides of the plane
-		if ( b3FixMul( distance1 , distance2 ) < B3_FIX( 0.0f ) )
+		// If the points are on different sides of the plane. Upstream f42be21 replaced the product
+		// with a sign comparison. In Q48.16 that is a correctness fix rather than a tidy-up: b3FixMul
+		// of two separations under ~0.004 quantizes to zero, so a shallow crossing was silently
+		// dropped and the clip returned one point instead of two.
+		if ( ( distance1 > B3_FIX( 0.0f ) ) != ( distance2 > B3_FIX( 0.0f ) ) )
 		{
 			// Find intersection point of edge and plane
 			b3Fixed t = b3FixDiv( distance1 , ( distance1 - distance2 ) );
@@ -199,6 +202,9 @@ static b3SeparatingAxis b3QueryTriangleAndCapsuleEdges( const b3Vec3* vertices, 
 	b3Fixed squaredTolerance = b3FixMul( B3_FIX( 0.005f ) , B3_FIX( 0.005f ) );
 
 	int edgeIndex = 2;
+
+	// Loop invariant: does not depend on the triangle edge.
+	b3Fixed a = b3Dot( capsuleEdge, plane.normal );
 	b3Vec3 v1 = vertices[2];
 	for ( int index = 0; index < 3; ++index )
 	{
@@ -209,12 +215,15 @@ static b3SeparatingAxis b3QueryTriangleAndCapsuleEdges( const b3Vec3* vertices, 
 		// Pretend the triangle edge embeds a zero area face with a side normal. This
 		// provides a way to find an edge-edge normal that points outward from
 		// the triangle.
-		b3Fixed a = b3Dot( capsuleEdge, plane.normal );
 		b3Fixed b = b3Dot( capsuleEdge, sideNormal );
 
 		// Is the capsule edge parallel to the triangle edge? If so, face contact can handle it.
 		if ( b3FixMul( a , a ) + b3FixMul( b , b ) < b3FixMul( squaredTolerance , b3LengthSquared( capsuleEdge ) ) )
 		{
+			// The skip must still advance the edge walk, or the next iteration reads the wrong v1
+			// and reports the wrong edge index.
+			v1 = v2;
+			edgeIndex = index;
 			continue;
 		}
 
@@ -346,9 +355,11 @@ static void b3BuildTriangleAndCapsuleEdgeContact( b3LocalManifold* manifold, con
 		return;
 	}
 
-	b3Vec3 point = b3Lerp( b3MulSub( result.point1, capsule->radius, normal ), result.point2, B3_FIX( 0.5f ) );
+	// point1 is on the triangle edge and point2 on the capsule CORE, so the radius pulls point2
+	// back to the capsule surface. Value-identical to the old spelling; taken because it says what
+	// it means, and measured to move no golden.
+	b3Vec3 point = b3Lerp( result.point1, b3MulSub( result.point2, capsule->radius, normal ), B3_FIX( 0.5f ) );
 	b3Fixed separation = b3Dot( normal, b3Sub( p1, v1 ) );
-	B3_VALIDATE( b3FixAbs( separation - query.separation ) < B3_LINEAR_SLOP );
 
 	manifold->normal = normal;
 	manifold->pointCount = 1;
@@ -448,6 +459,12 @@ void b3CollideTriangleAndCapsule( b3LocalManifold* manifold, int capacity, const
 		}
 
 		// Create contact from closest points.
+		// NOT PORTED, deliberately: upstream f42be21 rewrites this as
+		//   b3Lerp( pointA, b3MulSub( pointB, radius, delta ), 0.5 )
+		// which is the same value in exact arithmetic — both are (pointA + pointB)/2 - radius*delta/2
+		// — and differs only in rounding. Measured on this tree: taking it moves the ragdoll sleep
+		// step 287 -> 453. That is the b3Lerp rounding lottery this repo already paid for (see the
+		// "deliberately NOT fused" list in CLAUDE.md), spent for no behavioural gain. Do not clean up.
 		b3Vec3 point = b3MulSV( B3_FIX( 0.5f ), b3Add( b3Sub( distanceOutput.pointA, b3MulSV( radius, delta ) ), distanceOutput.pointB ) );
 
 		// Normal points from triangle to capsule.
@@ -950,7 +967,6 @@ static void b3CollideTriangleAndHullEdges( b3LocalManifold* manifold, int capaci
 
 	// This can slide off the end from caching
 	b3Fixed separation = b3Dot( query.normal, b3Sub( pB, pA ) );
-	B3_VALIDATE( b3FixAbs( separation - query.separation ) < B3_LINEAR_SLOP );
 
 	b3Vec3 point = b3MulSV( B3_FIX( 0.5f ), b3Add( result.point1, result.point2 ) );
 

--- a/src/triangle_manifold.c
+++ b/src/triangle_manifold.c
@@ -390,9 +390,9 @@ void b3CollideTriangleAndCapsule( b3LocalManifold* manifold, int capacity, const
 	distanceInput.useRadii = false;
 
 	b3DistanceOutput distanceOutput = b3ShapeDistance( &distanceInput, cache, NULL, 0 );
-
+	b3Fixed speculativeDistance = B3_SPECULATIVE_DISTANCE;
 	b3Fixed radius = capsuleB->radius;
-	if ( distanceOutput.distance > radius + B3_SPECULATIVE_DISTANCE )
+	if ( distanceOutput.distance > radius + speculativeDistance )
 	{
 		// Shapes are separated, persist the cache
 		return;
@@ -468,22 +468,24 @@ void b3CollideTriangleAndCapsule( b3LocalManifold* manifold, int capacity, const
 	b3SeparatingAxis faceQuery = b3QueryTriangleFaceAndCapsule( plane, capsuleB );
 	if ( faceQuery.separation > radius )
 	{
-		// Shapes are separated
+		// Shapes are separated. Should be impossible for a reasonable capsule radius.
 		return;
 	}
 
 	b3SeparatingAxis edgeQuery = b3QueryTriangleAndCapsuleEdges( triangleA, plane, capsuleB );
 	if ( edgeQuery.separation > radius )
 	{
-		// Shapes are separated
+		// Shapes are separated. Should be impossible for a reasonable capsule radius.
 		return;
 	}
 
 	// Create face contact
 	b3Fixed faceSeparation = faceQuery.separation - radius;
 	b3BuildTriangleAndCapsuleFaceContact( manifold, triangleA, plane, capsuleB );
+	B3_VALIDATE( manifold->pointCount == 0 || manifold->pointCount == 2 );
 	if ( manifold->pointCount == 2 )
 	{
+		// This becomes the clipped separation.
 		faceSeparation = b3FixMin( manifold->points[0].separation, manifold->points[1].separation );
 	}
 	// The clipped face points are not guaranteed to realize the SAT axis of minimum
@@ -495,15 +497,15 @@ void b3CollideTriangleAndCapsule( b3LocalManifold* manifold, int capacity, const
 
 	// Face contact can be empty if it does not realize the axis of minimum penetration.
 	// Create edge contact if face contact fails or edge contact is significantly better!
-	const b3Fixed kRelEdgeTolerance = B3_FIX( 0.50f );
-	const b3Fixed kAbsTolerance = b3FixMul( B3_FIX( 1.0f ) , B3_LINEAR_SLOP );
+	// Upstream 781673b replaced the relative tolerance with a plain slop offset. In fixed point the
+	// new form is strictly better: it is an int64 add instead of a b3FixMul, so nothing quantizes.
+	const b3Fixed linearSlop = B3_LINEAR_SLOP;
 
 	// The edge query can find no admissible pair (its separation stays at the
 	// -B3_FIXED_MAX sentinel, which would wrap under further arithmetic).
 	bool haveEdge = edgeQuery.indexB != B3_NULL_INDEX;
 	b3Fixed edgeSeparation = haveEdge ? edgeQuery.separation - radius : B3_FIXED_MIN;
-	if ( manifold->pointCount == 0 ? haveEdge
-								   : ( haveEdge && edgeSeparation > b3FixMul( kRelEdgeTolerance , faceSeparation ) + kAbsTolerance ) )
+	if ( manifold->pointCount == 0 ? haveEdge : ( haveEdge && edgeSeparation > faceSeparation + linearSlop ) )
 	{
 		// Edge contact
 		b3BuildTriangleAndCapsuleEdgeContact( manifold, triangleA, plane, capsuleB, edgeQuery );

--- a/test/test_body_query.c
+++ b/test/test_body_query.c
@@ -355,6 +355,116 @@ static int OverlapFilter( void )
 	return 0;
 }
 
+static bool CountOverlapCallback( b3ShapeId shapeId, void* context )
+{
+	(void)shapeId;
+	*(int*)context += 1;
+	return true;
+}
+
+// A box hull proxy built around a world target with a zero origin must hit the same shapes as the
+// same box built at the local origin and queried with the target as origin. This is the origin
+// relative equivalence the world query promises, and the pattern users reach for when they bake a
+// query box with b3MakeTransformedBoxHull.
+static int OverlapHullProxyEquivalence( void )
+{
+	b3WorldDef worldDef = b3DefaultWorldDef();
+	b3WorldId worldId = b3CreateWorld( &worldDef );
+
+	b3BodyDef bodyDef = b3DefaultBodyDef();
+	bodyDef.type = b3_staticBody;
+	bodyDef.position = (b3Pos){ B3_FIX( 10.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) };
+	b3BodyId bodyId = b3CreateBody( worldId, &bodyDef );
+	b3BoxHull box = b3MakeBoxHull( B3_FIX( 1.0f ), B3_FIX( 1.0f ), B3_FIX( 1.0f ) );
+	b3ShapeDef shapeDef = b3DefaultShapeDef();
+	b3CreateHullShape( bodyId, &shapeDef, &box.base );
+
+	b3World_Step( worldId, B3_FIX( 1.0f ) / 60, 1 );
+
+	b3QueryFilter filter = b3DefaultQueryFilter();
+
+	// Overlapping target: a 10 wide query box centered on the body.
+	{
+		b3Vec3 offset = { B3_FIX( 10.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) };
+
+		b3BoxHull baked = b3MakeTransformedBoxHull( B3_FIX( 5.0f ), B3_FIX( 5.0f ), B3_FIX( 5.0f ),
+													(b3Transform){ offset, b3Quat_identity } );
+		b3ShapeProxy bakedProxy = { baked.boxPoints, baked.base.vertexCount, B3_FIX( 0.0f ) };
+		int bakedHits = 0;
+		b3World_OverlapShape( worldId, b3Pos_zero, &bakedProxy, filter, CountOverlapCallback, &bakedHits );
+
+		b3Pos origin = b3OffsetPos( b3Pos_zero, offset );
+		b3BoxHull local = b3MakeBoxHull( B3_FIX( 5.0f ), B3_FIX( 5.0f ), B3_FIX( 5.0f ) );
+		b3ShapeProxy localProxy = { local.boxPoints, local.base.vertexCount, B3_FIX( 0.0f ) };
+		int localHits = 0;
+		b3World_OverlapShape( worldId, origin, &localProxy, filter, CountOverlapCallback, &localHits );
+
+		ENSURE( bakedHits == 1 );
+		ENSURE( localHits == bakedHits );
+	}
+
+	// Clearing target: same box far from the body, both formulations agree on the miss.
+	{
+		b3Vec3 offset = { B3_FIX( 100.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) };
+
+		b3BoxHull baked = b3MakeTransformedBoxHull( B3_FIX( 5.0f ), B3_FIX( 5.0f ), B3_FIX( 5.0f ),
+													(b3Transform){ offset, b3Quat_identity } );
+		b3ShapeProxy bakedProxy = { baked.boxPoints, baked.base.vertexCount, B3_FIX( 0.0f ) };
+		int bakedHits = 0;
+		b3World_OverlapShape( worldId, b3Pos_zero, &bakedProxy, filter, CountOverlapCallback, &bakedHits );
+
+		b3Pos origin = b3OffsetPos( b3Pos_zero, offset );
+		b3BoxHull local = b3MakeBoxHull( B3_FIX( 5.0f ), B3_FIX( 5.0f ), B3_FIX( 5.0f ) );
+		b3ShapeProxy localProxy = { local.boxPoints, local.base.vertexCount, B3_FIX( 0.0f ) };
+		int localHits = 0;
+		b3World_OverlapShape( worldId, origin, &localProxy, filter, CountOverlapCallback, &localHits );
+
+		ENSURE( bakedHits == 0 );
+		ENSURE( localHits == bakedHits );
+	}
+
+	b3DestroyWorld( worldId );
+	return 0;
+}
+
+// A quarter turn baked into the query hull must reach the overlap test. A long thin bar hits a body
+// off the origin when aligned along X and clears it once rotated to lie along Z.
+static int OverlapHullProxyRotation( void )
+{
+	b3WorldDef worldDef = b3DefaultWorldDef();
+	b3WorldId worldId = b3CreateWorld( &worldDef );
+
+	b3BodyDef bodyDef = b3DefaultBodyDef();
+	bodyDef.type = b3_staticBody;
+	bodyDef.position = (b3Pos){ B3_FIX( 3.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) };
+	b3BodyId bodyId = b3CreateBody( worldId, &bodyDef );
+	b3BoxHull box = b3MakeBoxHull( B3_FIX( 0.5f ), B3_FIX( 0.5f ), B3_FIX( 0.5f ) );
+	b3ShapeDef shapeDef = b3DefaultShapeDef();
+	b3CreateHullShape( bodyId, &shapeDef, &box.base );
+
+	b3World_Step( worldId, B3_FIX( 1.0f ) / 60, 1 );
+
+	b3QueryFilter filter = b3DefaultQueryFilter();
+
+	// Bar long in local X, centered at the origin, reaches the body at x = 3.
+	b3BoxHull aligned = b3MakeTransformedBoxHull( B3_FIX( 4.0f ), B3_FIX( 0.3f ), B3_FIX( 0.3f ), b3Transform_identity );
+	b3ShapeProxy alignedProxy = { aligned.boxPoints, aligned.base.vertexCount, B3_FIX( 0.0f ) };
+	int alignedHits = 0;
+	b3World_OverlapShape( worldId, b3Pos_zero, &alignedProxy, filter, CountOverlapCallback, &alignedHits );
+	ENSURE( alignedHits == 1 );
+
+	// Rotated a quarter turn about Y the long axis points along Z, so the bar no longer reaches x = 3.
+	b3Quat q = b3MakeQuatFromAxisAngle( (b3Vec3){ B3_FIX( 0.0f ), B3_FIX( 1.0f ), B3_FIX( 0.0f ) }, B3_PI / 2 );
+	b3BoxHull turned = b3MakeTransformedBoxHull( B3_FIX( 4.0f ), B3_FIX( 0.3f ), B3_FIX( 0.3f ), (b3Transform){ b3Vec3_zero, q } );
+	b3ShapeProxy turnedProxy = { turned.boxPoints, turned.base.vertexCount, B3_FIX( 0.0f ) };
+	int turnedHits = 0;
+	b3World_OverlapShape( worldId, b3Pos_zero, &turnedProxy, filter, CountOverlapCallback, &turnedHits );
+	ENSURE( turnedHits == 0 );
+
+	b3DestroyWorld( worldId );
+	return 0;
+}
+
 // CollideMover -----------------------------------------------------------------------------
 
 static int MoverTouchesBox( void )
@@ -474,6 +584,8 @@ int BodyQueryTest( void )
 	RUN_SUBTEST( OverlapFalse );
 	RUN_SUBTEST( OverlapRespectsBodyTransform );
 	RUN_SUBTEST( OverlapFilter );
+	RUN_SUBTEST( OverlapHullProxyEquivalence );
+	RUN_SUBTEST( OverlapHullProxyRotation );
 
 	RUN_SUBTEST( MoverTouchesBox );
 	RUN_SUBTEST( MoverSeparated );

--- a/test/test_determinism.c
+++ b/test/test_determinism.c
@@ -27,10 +27,16 @@
 // bit-exact rigid translation of the trajectory. The hash differs only because it covers
 // the absolute transform bytes, and the wide build stores 128-bit positions (80-byte
 // b3WorldTransform vs 56-byte), so it carries its own golden. Full 128 bits are hashed.
+// Both hashes moved 2026-08-22 with the f42be21 triangle-face clip fix: the crossing test is a
+// sign comparison now, so a capsule core straddling a triangle edge with both separations under
+// ~0.004 gets its second clip point instead of losing it to a b3FixMul that quantized to zero.
+// Ragdolls rest on the mesh floor, so this is the only scene that moves. Previously 0x886BE415
+// (ludicrous) and 0xB222C195 (narrow). Every sleep step and every other scene carried over
+// unchanged, verified identical for worker counts 1-5 in both builds.
 #if defined( BOX3D_LUDICROUS_MODE )
-#define RAGDOLL_HASH 0x886BE415
+#define RAGDOLL_HASH 0xAD895018
 #else
-#define RAGDOLL_HASH 0xB222C195
+#define RAGDOLL_HASH 0xC9322058
 #endif
 
 // Goldens for the c37cfe4-ported scenarios (wave pile, query spawn, mesh drop).

--- a/test/test_hull.c
+++ b/test/test_hull.c
@@ -413,6 +413,100 @@ static int CreateHullMergeChurnStressTest( void )
 	return 0;
 }
 
+// b3ComputeCosSin is a coarse approximation, so build rotations from libm to keep the
+// analytic corner and plane positions exact.
+static b3Quat ExactQuat( b3Vec3 axis, b3Fixed radians )
+{
+	double half = 0.5 * b3FixToDouble( radians );
+	b3Fixed s = b3FixFromDouble( sin( half ) );
+	b3Fixed c = b3FixFromDouble( cos( half ) );
+	return (b3Quat){ { b3FixMul( s, axis.x ), b3FixMul( s, axis.y ), b3FixMul( s, axis.z ) }, c };
+}
+
+// Corner sign pattern baked by b3MakeTransformedBoxHull, in order.
+static const b3Vec3 s_boxCornerSigns[8] = {
+	{ B3_FIX( 1.0f ), B3_FIX( 1.0f ), B3_FIX( 1.0f ) },	  { -B3_FIX( 1.0f ), B3_FIX( 1.0f ), B3_FIX( 1.0f ) },
+	{ -B3_FIX( 1.0f ), -B3_FIX( 1.0f ), B3_FIX( 1.0f ) },  { B3_FIX( 1.0f ), -B3_FIX( 1.0f ), B3_FIX( 1.0f ) },
+	{ B3_FIX( 1.0f ), B3_FIX( 1.0f ), -B3_FIX( 1.0f ) },  { -B3_FIX( 1.0f ), B3_FIX( 1.0f ), -B3_FIX( 1.0f ) },
+	{ -B3_FIX( 1.0f ), -B3_FIX( 1.0f ), -B3_FIX( 1.0f ) }, { B3_FIX( 1.0f ), -B3_FIX( 1.0f ), -B3_FIX( 1.0f ) },
+};
+
+// The baked box hull is only exercised elsewhere through mass properties, which are analytic
+// and never read boxPoints or boxPlanes. Pin the geometry itself against the transform so an
+// axis swap in the point or plane bake cannot pass silently.
+static int CheckTransformedBox( b3Vec3 h, b3Transform xf )
+{
+	b3BoxHull box = b3MakeTransformedBoxHull( h.x, h.y, h.z, xf );
+
+	// Below-resolution float tolerances floor to eight quanta here (the tree's convention).
+	// The plane offset carries one extra rounding from its dot product, so it gets its own floor.
+	const b3Fixed tol = 8 * B3_FIXED_EPSILON;
+	const b3Fixed offsetTol = 16 * B3_FIXED_EPSILON;
+
+	// Each corner is the transform of the signed half extent.
+	for ( int i = 0; i < 8; ++i )
+	{
+		b3Vec3 local = { b3FixMul( s_boxCornerSigns[i].x, h.x ), b3FixMul( s_boxCornerSigns[i].y, h.y ),
+						 b3FixMul( s_boxCornerSigns[i].z, h.z ) };
+		b3Vec3 expected = b3TransformPoint( xf, local );
+		ENSURE_SMALL( box.boxPoints[i].x - expected.x, tol );
+		ENSURE_SMALL( box.boxPoints[i].y - expected.y, tol );
+		ENSURE_SMALL( box.boxPoints[i].z - expected.z, tol );
+	}
+
+	// Face normals rotate with the box, offsets carry the rotated normal through the translation.
+	b3Vec3 localNormals[6] = {
+		b3Neg( b3Vec3_axisX ), b3Vec3_axisX, b3Neg( b3Vec3_axisY ), b3Vec3_axisY, b3Neg( b3Vec3_axisZ ), b3Vec3_axisZ,
+	};
+	b3Fixed localOffsets[6] = { h.x, h.x, h.y, h.y, h.z, h.z };
+	for ( int i = 0; i < 6; ++i )
+	{
+		b3Vec3 n = b3RotateVector( xf.q, localNormals[i] );
+		b3Fixed offset = localOffsets[i] + b3Dot( n, xf.p );
+		ENSURE_SMALL( box.boxPlanes[i].normal.x - n.x, tol );
+		ENSURE_SMALL( box.boxPlanes[i].normal.y - n.y, tol );
+		ENSURE_SMALL( box.boxPlanes[i].normal.z - n.z, tol );
+		ENSURE_SMALL( box.boxPlanes[i].offset - offset, offsetTol );
+	}
+
+	// NOT PORTED: upstream also mirrors the eight vertices and six normals into vx/vy/vz and
+	// nx/ny/nz SoA lanes for its float SIMD narrow phase. b3BoxHull here has no such lanes
+	// (float SIMD is removed; our opt-in fixed SIMD is narrow-phase only), so those checks
+	// have no analogue.
+
+	// The stored AABB bounds every baked corner.
+	b3AABB pointBox = b3MakeAABB( box.boxPoints, 8, B3_FIX( 0.0f ) );
+	ENSURE( b3AABB_Contains( box.base.aabb, pointBox ) );
+
+	return 0;
+}
+
+static int TransformedBoxHullTest( void )
+{
+	b3Vec3 h = { B3_FIX( 0.25f ), B3_FIX( 0.5f ), B3_FIX( 0.3f ) };
+
+	// Identity.
+	if ( CheckTransformedBox( h, b3Transform_identity ) )
+		return 1;
+
+	// Translation only.
+	b3Transform translated = { { B3_FIX( 0.4f ), -B3_FIX( 0.7f ), B3_FIX( 0.1f ) }, b3Quat_identity };
+	if ( CheckTransformedBox( h, translated ) )
+		return 1;
+
+	// Rotation only. A quarter turn about Y swaps the world X and Z extents.
+	b3Transform rotated = { b3Vec3_zero, ExactQuat( b3Vec3_axisY, B3_PI / 4 ) };
+	if ( CheckTransformedBox( h, rotated ) )
+		return 1;
+
+	// Translation and rotation together.
+	b3Transform transformed = { { B3_FIX( 3.0f ), -B3_FIX( 2.0f ), B3_FIX( 1.5f ) }, ExactQuat( b3Vec3_axisZ, B3_PI / 4 ) };
+	if ( CheckTransformedBox( h, transformed ) )
+		return 1;
+
+	return 0;
+}
+
 static int CreateHullDegenerateTest( void )
 {
 	// Real (non-null) buffer; pointCount < 4 cases are guarded inside Construct().
@@ -530,6 +624,7 @@ int HullTest( void )
 	RUN_SUBTEST( CreateHullSphereStressTest );
 	RUN_SUBTEST( CreateHullMergeChurnStressTest );
 	RUN_SUBTEST( CreateHullDegenerateTest );
+	RUN_SUBTEST( TransformedBoxHullTest );
 	RUN_SUBTEST( CreateHullNearDegenerateTest );
 
 	return 0;

--- a/test/test_manifold.c
+++ b/test/test_manifold.c
@@ -1121,6 +1121,144 @@ static int CapsuleHullSeamTest( void )
 	return 0;
 }
 
+// A capsule core straddling a triangle face inside the interior. The core pierces the plane so the
+// deep path runs, and with the tilt kept small the face stays the axis of minimum penetration, so the
+// clip must return two points on the triangle face. This is the branch that had no coverage.
+static int CapsuleTriangleFaceDeepTest( void )
+{
+	// Triangle in the y = 0 plane, normal +y, centroid at the origin
+	b3Vec3 v1 = { -B3_FIX( 3.0f ), B3_FIX( 0.0f ), -B3_FIX( 2.0f ) };
+	b3Vec3 v2 = { B3_FIX( 0.0f ), B3_FIX( 0.0f ), B3_FIX( 4.0f ) };
+	b3Vec3 v3 = { B3_FIX( 3.0f ), B3_FIX( 0.0f ), -B3_FIX( 2.0f ) };
+	b3Vec3 triangle[] = { v1, v2, v3 };
+
+	b3Fixed yaws[] = { B3_FIX( 0.0f ), B3_FIX( 0.6f ), B3_FIX( 1.2f ), B3_FIX( 1.8f ), B3_FIX( 2.4f ) };
+	b3Fixed tilts[] = { B3_FIX( 0.06f ), B3_FIX( 0.1f ), B3_FIX( 0.15f ) };
+	b3Fixed radii[] = { B3_FIX( 0.05f ), B3_FIX( 0.1f ), B3_FIX( 0.2f ) };
+
+	// Bias the center just above the plane so the back side cull passes while the lower endpoint dips through
+	b3Fixed bias = B3_FIX( 0.01f );
+	b3Fixed halfLength = B3_FIX( 1.0f );
+
+	// The analytic endpoint heights are built from libm, so the only error in the expected separation
+	// is the engine's own quantization. Eight quanta is the tree's floor for a below-resolution tolerance.
+	const b3Fixed tol = 8 * B3_FIXED_EPSILON;
+
+	int faceContacts = 0;
+
+	for ( int i = 0; i < ARRAY_COUNT( yaws ); ++i )
+	{
+		for ( int j = 0; j < ARRAY_COUNT( tilts ); ++j )
+		{
+			for ( int r = 0; r < ARRAY_COUNT( radii ); ++r )
+			{
+				// Axis is the in-plane heading tipped up so the segment straddles the plane.
+				// libm rather than b3Sin/b3Cos: this is reference math, not simulation.
+				double tilt = b3FixToDouble( tilts[j] );
+				double yaw = b3FixToDouble( yaws[i] );
+				b3Vec3 axis = { b3FixFromDouble( cos( tilt ) * cos( yaw ) ), b3FixFromDouble( sin( tilt ) ),
+								b3FixFromDouble( cos( tilt ) * sin( yaw ) ) };
+				b3Vec3 center = { B3_FIX( 0.0f ), bias, B3_FIX( 0.0f ) };
+				b3Vec3 c1 = b3MulAdd( center, -halfLength, axis );
+				b3Vec3 c2 = b3MulAdd( center, halfLength, axis );
+				b3Capsule capsule = { c1, c2, radii[r] };
+
+				b3LocalManifoldPoint points[8];
+				b3LocalManifold manifold = { 0 };
+				manifold.points = points;
+				b3SimplexCache cache = { 0 };
+				b3CollideTriangleAndCapsule( &manifold, 8, triangle, &capsule, &cache );
+
+				// Two points on the triangle face with the plane normal
+				ENSURE( manifold.pointCount == 2 );
+				ENSURE( manifold.feature == b3_featureTriangleFace );
+				ENSURE_SMALL( manifold.normal.x, tol );
+				ENSURE_SMALL( manifold.normal.y - B3_FIX( 1.0f ), tol );
+				ENSURE_SMALL( manifold.normal.z, tol );
+
+				// Separations are the endpoint heights pulled in by the radius. The lower endpoint is below
+				// the plane, so the deepest separation is negative.
+				b3Fixed lower = b3FixMin( c1.y, c2.y ) - radii[r];
+				b3Fixed upper = b3FixMax( c1.y, c2.y ) - radii[r];
+				b3Fixed minSep = b3FixMin( manifold.points[0].separation, manifold.points[1].separation );
+				b3Fixed maxSep = b3FixMax( manifold.points[0].separation, manifold.points[1].separation );
+				ENSURE_SMALL( minSep - lower, tol );
+				ENSURE_SMALL( maxSep - upper, tol );
+				ENSURE( minSep < B3_FIX( 0.0f ) );
+
+				++faceContacts;
+			}
+		}
+	}
+
+	// Every configuration must reach the face path
+	ENSURE( faceContacts == ARRAY_COUNT( yaws ) * ARRAY_COUNT( tilts ) * ARRAY_COUNT( radii ) );
+
+	return 0;
+}
+
+// A capsule laid flat with its core below a box top face. The core sits inside the box so the deep
+// path runs, and across a sweep of depths, headings and radii the face clip must return two points.
+static int HullCapsuleFaceDeepTest( void )
+{
+	b3BoxHull hull = b3MakeBoxHull( B3_FIX( 0.5f ), B3_FIX( 0.5f ), B3_FIX( 0.5f ) );
+
+	b3Fixed depths[] = { B3_FIX( 0.1f ), B3_FIX( 0.2f ), B3_FIX( 0.3f ), B3_FIX( 0.4f ), B3_FIX( 0.45f ) };
+	b3Fixed yaws[] = { B3_FIX( 0.0f ), B3_FIX( 0.4f ), B3_FIX( 0.8f ), B3_FIX( 1.2f ) };
+	b3Fixed radii[] = { B3_FIX( 0.1f ), B3_FIX( 0.15f ), B3_FIX( 0.2f ) };
+	b3Fixed offsets[] = { -B3_FIX( 0.1f ), B3_FIX( 0.0f ), B3_FIX( 0.1f ) };
+	b3Fixed halfLength = B3_FIX( 0.3f );
+
+	const b3Fixed tol = 8 * B3_FIXED_EPSILON;
+
+	int faceContacts = 0;
+
+	for ( int i = 0; i < ARRAY_COUNT( depths ); ++i )
+	{
+		for ( int j = 0; j < ARRAY_COUNT( yaws ); ++j )
+		{
+			for ( int r = 0; r < ARRAY_COUNT( radii ); ++r )
+			{
+				for ( int o = 0; o < ARRAY_COUNT( offsets ); ++o )
+				{
+					b3Fixed y = depths[i];
+					double yaw = b3FixToDouble( yaws[j] );
+					b3Vec3 dir = { b3FixFromDouble( cos( yaw ) ), B3_FIX( 0.0f ), b3FixFromDouble( sin( yaw ) ) };
+					b3Vec3 center = { offsets[o], y, B3_FIX( 0.0f ) };
+					b3Vec3 c1 = b3MulAdd( center, -halfLength, dir );
+					b3Vec3 c2 = b3MulAdd( center, halfLength, dir );
+					b3Capsule capsule = { c1, c2, radii[r] };
+
+					b3LocalManifoldPoint points[8];
+					b3LocalManifold manifold = { 0 };
+					manifold.points = points;
+					b3SimplexCache cache = { 0 };
+					b3CollideHullAndCapsule( &manifold, 8, &hull.base, &capsule, b3Transform_identity, &cache );
+
+					// Two points on the top face. The hull path does not tag a feature, so the face is
+					// identified by the normal and the point count.
+					ENSURE( manifold.pointCount == 2 );
+					ENSURE_SMALL( manifold.normal.x, tol );
+					ENSURE_SMALL( manifold.normal.y - B3_FIX( 1.0f ), tol );
+					ENSURE_SMALL( manifold.normal.z, tol );
+
+					// Flat capsule, so both points sit at the same analytic gap
+					b3Fixed expected = ( y - B3_FIX( 0.5f ) ) - radii[r];
+					ENSURE_SMALL( manifold.points[0].separation - expected, tol );
+					ENSURE_SMALL( manifold.points[1].separation - expected, tol );
+					ENSURE( expected < B3_FIX( 0.0f ) );
+
+					++faceContacts;
+				}
+			}
+		}
+	}
+
+	ENSURE( faceContacts == ARRAY_COUNT( depths ) * ARRAY_COUNT( yaws ) * ARRAY_COUNT( radii ) * ARRAY_COUNT( offsets ) );
+
+	return 0;
+}
+
 int ManifoldTest( void )
 {
 	RUN_SUBTEST( CrossedEdgeTest );
@@ -1140,6 +1278,8 @@ int ManifoldTest( void )
 	RUN_SUBTEST( CapsuleTriangleEdgeDeepTest );
 	RUN_SUBTEST( SphereHullSeamTest );
 	RUN_SUBTEST( CapsuleHullSeamTest );
+	RUN_SUBTEST( CapsuleTriangleFaceDeepTest );
+	RUN_SUBTEST( HullCapsuleFaceDeepTest );
 
 	return 0;
 }

--- a/test/test_manifold.c
+++ b/test/test_manifold.c
@@ -1259,6 +1259,105 @@ static int HullCapsuleFaceDeepTest( void )
 	return 0;
 }
 
+// A broad edge-contact oracle sweep: 120 headings over the full circle against a scalene triangle,
+// running CheckEdgeContact on every edge contact that comes back, which rebuilds the normal,
+// separation and point from the REPORTED edge index. This widens the three-yaw coverage of
+// CapsuleTriangleEdgeDeepTest above.
+//
+// WHAT IT DOES NOT DO, stated so nobody reads it as the acceptance it is not: it does not
+// discriminate the f42be21 edge-walk advance (the `v1 = v2; edgeIndex = index;` in the parallel
+// skip). Measured 2026-08-22: that skip requires the capsule core to be simultaneously in the
+// triangle plane and parallel to one of its edges, and with any out-of-plane tilt the plane dot
+// alone puts the test far above tolerance. Instrumented, the skip fires ZERO times across the
+// entire suite; a deliberately constructed in-plane axis-parallel capsule fires it five times and
+// STILL produces byte-identical manifolds either way, because a single skip perturbs exactly one
+// following iteration and that iteration loses the max-separation comparison. The fix is correct
+// and defensive; it is not currently reachable from an observable difference in this tree.
+static int CapsuleTriangleEdgeWalkTest( void )
+{
+	// Scalene on purpose: three distinct edge directions, so each parallel yaw is hit separately.
+	b3Vec3 v1 = { -B3_FIX( 2.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) };
+	b3Vec3 v2 = { B3_FIX( 2.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) };
+	b3Vec3 v3 = { -B3_FIX( 0.5f ), B3_FIX( 0.0f ), -B3_FIX( 2.5f ) };
+	b3Vec3 triangle[] = { v1, v2, v3 };
+	b3Vec3 triangleEdges[] = { b3Sub( v2, v1 ), b3Sub( v3, v2 ), b3Sub( v1, v3 ) };
+	b3Vec3 triangleCenter = b3MulSV( b3FixDiv( B3_FIX( 1.0f ), B3_FIX( 3.0f ) ), b3Add( v1, b3Add( v2, v3 ) ) );
+
+	const b3Fixed radius = B3_FIX( 0.08f );
+	const b3Fixed halfLength = B3_FIX( 0.6f );
+
+	int edgeContacts = 0;
+	int parallelYaws = 0;
+
+	// 120 headings over the full circle, so every edge direction is crossed and the yaws either
+	// side of each parallel case are exercised too.
+	for ( int y = 0; y < 120; ++y )
+	{
+		double yaw = ( 2.0 * 3.14159265358979323846 * y ) / 120.0;
+
+		// Track whether this heading is parallel to some triangle edge, so the test can prove it
+		// actually visited the branch it exists to cover.
+		b3Vec3 flat = { b3FixFromDouble( cos( yaw ) ), B3_FIX( 0.0f ), b3FixFromDouble( sin( yaw ) ) };
+		for ( int e = 0; e < 3; ++e )
+		{
+			b3Vec3 dir = b3Normalize( triangleEdges[e] );
+			b3Fixed d = b3FixAbs( b3Dot( flat, dir ) );
+			if ( d > B3_FIX( 0.9995f ) )
+			{
+				parallelYaws += 1;
+				break;
+			}
+		}
+
+		for ( int t = 0; t < 3; ++t )
+		{
+			b3Fixed tilt = B3_FIX( 0.2f ) + t * B3_FIX( 0.1f );
+			double tiltD = b3FixToDouble( tilt );
+			b3Vec3 axis = { b3FixFromDouble( cos( tiltD ) * cos( yaw ) ), b3FixFromDouble( sin( tiltD ) ),
+							b3FixFromDouble( cos( tiltD ) * sin( yaw ) ) };
+
+			// Sit the core just inside the v1 v2 edge so the deep path runs.
+			b3Vec3 mid = { B3_FIX( 0.0f ), B3_FIX( 0.0f ), -B3_FIX( 0.03f ) };
+			b3Vec3 c1 = b3MulAdd( mid, -halfLength, axis );
+			b3Vec3 c2 = b3MulAdd( mid, halfLength, axis );
+			b3Capsule capsule = { c1, c2, radius };
+
+			b3LocalManifoldPoint points[8];
+			b3LocalManifold manifold = { 0 };
+			manifold.points = points;
+			b3SimplexCache cache = { 0 };
+			b3CollideTriangleAndCapsule( &manifold, 8, triangle, &capsule, &cache );
+
+			if ( manifold.pointCount != 1 || manifold.feature < b3_featureEdge1 || manifold.feature > b3_featureEdge3 )
+			{
+				continue;
+			}
+
+			int edgeIndex = manifold.feature - b3_featureEdge1;
+			b3Vec3 capsuleEdge = b3Sub( c2, c1 );
+			b3Vec3 capsuleCenter = b3Lerp( c1, c2, B3_FIX( 0.5f ) );
+			b3Vec3 orientRef = b3Sub( capsuleCenter, triangleCenter );
+
+			// The oracle rebuilds everything from the REPORTED index, which is the thing the
+			// missing advance corrupted.
+			if ( CheckEdgeContact( &manifold, triangle[edgeIndex], triangleEdges[edgeIndex], c1, capsuleEdge, orientRef,
+								   radius, B3_FIX( 1e-4f ), B3_FIX( 1e-4f ), B3_FIX( 2e-4f ) ) != 0 )
+			{
+				return 1;
+			}
+
+			++edgeContacts;
+		}
+	}
+
+	// Guards against the sweep going vacuous. parallelYaws counts headings ALIGNED with an edge,
+	// which is not the same as the skip branch firing — see the note above.
+	ENSURE( parallelYaws > 0 );
+	ENSURE( edgeContacts > 0 );
+
+	return 0;
+}
+
 int ManifoldTest( void )
 {
 	RUN_SUBTEST( CrossedEdgeTest );
@@ -1276,6 +1375,7 @@ int ManifoldTest( void )
 	RUN_SUBTEST( HullCapsuleEdgeDeepTest );
 	RUN_SUBTEST( TriangleHullEdgeSweepTest );
 	RUN_SUBTEST( CapsuleTriangleEdgeDeepTest );
+	RUN_SUBTEST( CapsuleTriangleEdgeWalkTest );
 	RUN_SUBTEST( SphereHullSeamTest );
 	RUN_SUBTEST( CapsuleHullSeamTest );
 	RUN_SUBTEST( CapsuleTriangleFaceDeepTest );

--- a/test/test_recording.c
+++ b/test/test_recording.c
@@ -1183,8 +1183,10 @@ static int AllOps( void )
 	b3Shape_SetSphere( sphereShapeId, &newSphere );
 	b3Capsule newCapsule = { { B3_FIX( 0.0f ), -B3_FIX( 0.3f ), B3_FIX( 0.0f ) }, { B3_FIX( 0.0f ), B3_FIX( 0.3f ), B3_FIX( 0.0f ) }, B3_FIX( 0.3f ) };
 	b3Shape_SetCapsule( capsuleShapeId, &newCapsule );
-	// Geometry swaps intern into the registry at the record site. The repeated SetHull takes the
-	// shared hull short circuit, which changes nothing and so must leave the stream alone.
+	// Geometry swaps intern into the registry at the record site. The second SetHull takes the
+	// shared-hull short circuit; it is here so the op stream carries a redundant swap and replay
+	// still has to agree. NOTE: AllOps asserts frame counts and non-divergence, not stream shape,
+	// so this line does NOT by itself prove the short circuit keeps the write out of the stream.
 	b3BoxHull swapHull = b3MakeBoxHull( B3_FIX( 0.4f ), B3_FIX( 0.6f ), B3_FIX( 0.4f ) );
 	b3Shape_SetHull( boxShapeId, &swapHull.base );
 	b3Shape_SetHull( boxShapeId, &swapHull.base );

--- a/test/test_recording.c
+++ b/test/test_recording.c
@@ -1183,7 +1183,10 @@ static int AllOps( void )
 	b3Shape_SetSphere( sphereShapeId, &newSphere );
 	b3Capsule newCapsule = { { B3_FIX( 0.0f ), -B3_FIX( 0.3f ), B3_FIX( 0.0f ) }, { B3_FIX( 0.0f ), B3_FIX( 0.3f ), B3_FIX( 0.0f ) }, B3_FIX( 0.3f ) };
 	b3Shape_SetCapsule( capsuleShapeId, &newCapsule );
+	// Geometry swaps intern into the registry at the record site. The repeated SetHull takes the
+	// shared hull short circuit, which changes nothing and so must leave the stream alone.
 	b3BoxHull swapHull = b3MakeBoxHull( B3_FIX( 0.4f ), B3_FIX( 0.6f ), B3_FIX( 0.4f ) );
+	b3Shape_SetHull( boxShapeId, &swapHull.base );
 	b3Shape_SetHull( boxShapeId, &swapHull.base );
 	b3MeshData* swapMeshData = b3CreateGridMesh( 3, 3, B3_FIX( 1.5f ), 0, false );
 	ENSURE( swapMeshData != NULL );
@@ -1704,7 +1707,7 @@ static int GeometryHashCollision( void )
 	uint32_t idA = b3InternGeometry( &reg, b3_geometryHull, sharedHash, blobA, n );
 	uint32_t idB = b3InternGeometry( &reg, b3_geometryHull, sharedHash, blobB, n );
 	ENSURE( idA != idB );
-	ENSURE( reg.count == 2 );
+	ENSURE( reg.entries.count == 2 );
 
 	// Re-interning either blob must find it through the hash chain and never grow the registry,
 	// including the one shadowed behind the bucket head. The old single-entry lookup missed the
@@ -1712,12 +1715,12 @@ static int GeometryHashCollision( void )
 	uint8_t* blobA2 = (uint8_t*)b3Alloc( (size_t)n );
 	memset( blobA2, 0xAA, (size_t)n );
 	ENSURE( b3InternGeometry( &reg, b3_geometryHull, sharedHash, blobA2, n ) == idA );
-	ENSURE( reg.count == 2 );
+	ENSURE( reg.entries.count == 2 );
 
 	uint8_t* blobB2 = (uint8_t*)b3Alloc( (size_t)n );
 	memset( blobB2, 0xBB, (size_t)n );
 	ENSURE( b3InternGeometry( &reg, b3_geometryHull, sharedHash, blobB2, n ) == idB );
-	ENSURE( reg.count == 2 );
+	ENSURE( reg.entries.count == 2 );
 
 	b3FreeRegistry( &reg );
 
@@ -1737,10 +1740,10 @@ static int GeometryHashCollision( void )
 	uint8_t* live = (uint8_t*)b3Alloc( (size_t)n );
 	memset( live, 0xAA, (size_t)n );
 	uint32_t resolved = b3InternGeometry( &seeded, b3_geometryHull, sharedHash, live, n );
-	ENSURE( seeded.count == 3 );			  // no growth
+	ENSURE( seeded.entries.count == 3 );			  // no growth
 	ENSURE( resolved == 0 || resolved == 2 ); // a valid slot index for that content
-	ENSURE( seeded.entries[resolved].byteCount == n );
-	ENSURE( memcmp( seeded.entries[resolved].bytes, slot0, (size_t)n ) == 0 );
+	ENSURE( seeded.entries.data[resolved].byteCount == n );
+	ENSURE( memcmp( seeded.entries.data[resolved].bytes, slot0, (size_t)n ) == 0 );
 
 	b3FreeRegistry( &seeded );
 	return 0;
@@ -2180,6 +2183,148 @@ static int HullMeshSwapReplay( void )
 	return 0;
 }
 
+// A box sliding across a mesh floor, with the option to swap both geometries and retune a
+// per-triangle material part way through. Returns the final state hash so the caller can prove the
+// mutations move the simulation. Recording is optional so the same scene serves as the control.
+static uint64_t RunGeometryMutatorScene( b3Recording* rec, bool mutate, const b3MeshData* meshA, const b3MeshData* meshB,
+										 const b3HullData* swapHull, b3Fixed swapFriction )
+{
+	b3WorldDef worldDef = b3DefaultWorldDef();
+	worldDef.workerCount = 1;
+	b3WorldId worldId = b3CreateWorld( &worldDef );
+
+	if ( rec != NULL )
+	{
+		b3World_StartRecording( worldId, rec );
+	}
+
+	// The mesh body is created first so its ordinal is stable for the read back after replay.
+	b3SurfaceMaterial meshMaterials[2] = { b3DefaultSurfaceMaterial(), b3DefaultSurfaceMaterial() };
+	meshMaterials[1].friction = B3_FIX( 0.05f );
+
+	b3BodyDef meshBodyDef = b3DefaultBodyDef();
+	meshBodyDef.type = b3_staticBody;
+	b3BodyId meshBodyId = b3CreateBody( worldId, &meshBodyDef );
+
+	b3ShapeDef meshShapeDef = b3DefaultShapeDef();
+	meshShapeDef.materials = meshMaterials;
+	meshShapeDef.materialCount = 2;
+	b3ShapeId meshShapeId =
+		b3CreateMeshShape( meshBodyId, &meshShapeDef, meshA, (b3Vec3){ B3_FIX( 1.0f ), B3_FIX( 1.0f ), B3_FIX( 1.0f ) } );
+
+	b3BodyDef boxBodyDef = b3DefaultBodyDef();
+	boxBodyDef.type = b3_dynamicBody;
+	boxBodyDef.position = (b3Pos){ -B3_FIX( 2.0f ), B3_FIX( 2.0f ), B3_FIX( 0.0f ) };
+	boxBodyDef.linearVelocity = (b3Vec3){ B3_FIX( 4.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) };
+	b3BodyId boxBodyId = b3CreateBody( worldId, &boxBodyDef );
+
+	b3BoxHull box = b3MakeBoxHull( B3_FIX( 0.5f ), B3_FIX( 0.5f ), B3_FIX( 0.5f ) );
+	b3ShapeDef boxShapeDef = b3DefaultShapeDef();
+	boxShapeDef.density = B3_FIX( 1.0f );
+	b3ShapeId boxShapeId = b3CreateHullShape( boxBodyId, &boxShapeDef, &box.base );
+
+	b3Fixed timeStep = B3_FIX( 1.0f ) / 60;
+	for ( int i = 0; i < 10; ++i )
+	{
+		b3World_Step( worldId, timeStep, 4 );
+	}
+
+	if ( mutate )
+	{
+		b3Shape_SetHull( boxShapeId, swapHull );
+		b3Shape_SetMesh( meshShapeId, meshB, (b3Vec3){ B3_FIX( 1.0f ), B3_FIX( 1.0f ), B3_FIX( 1.0f ) } );
+
+		b3SurfaceMaterial grippy = b3DefaultSurfaceMaterial();
+		grippy.friction = swapFriction;
+		b3Shape_SetMeshMaterial( meshShapeId, grippy, 1 );
+	}
+
+	for ( int i = 0; i < 30; ++i )
+	{
+		b3World_Step( worldId, timeStep, 4 );
+	}
+
+	uint64_t hash = b3HashWorldState( b3GetWorldFromId( worldId ) );
+
+	if ( rec != NULL )
+	{
+		b3World_StopRecording( worldId );
+	}
+	b3DestroyWorld( worldId );
+
+	return hash;
+}
+
+// Swapping a shape's hull or mesh, or retuning one of its per-triangle materials, is a world
+// mutation like any other and has to ride the stream. The geometry pair interns into the registry
+// at the record site so replay rebuilds the same shape instead of running on the geometry it was
+// created with. The control run proves the mutations move the simulation, so the state hash gate
+// has teeth, and the read back covers each op on its own where dynamics alone would not.
+static int GeometryMutatorReplay( void )
+{
+	// Two flat floors with different triangulations, both carrying two material slots so the
+	// material index stays live across the swap.
+	b3MeshData* meshA = b3CreateGridMesh( 8, 8, B3_FIX( 2.0f ), 2, false );
+	ENSURE( meshA != NULL );
+	b3MeshData* meshB = b3CreateGridMesh( 12, 12, B3_FIX( 1.5f ), 2, false );
+	ENSURE( meshB != NULL );
+	ENSURE( meshA->triangleCount != meshB->triangleCount );
+
+	b3BoxHull swapHull = b3MakeBoxHull( B3_FIX( 0.25f ), B3_FIX( 1.5f ), B3_FIX( 0.25f ) );
+	const b3Fixed swapFriction = B3_FIX( 0.95f );
+
+	uint64_t controlHash = RunGeometryMutatorScene( NULL, false, meshA, meshB, &swapHull.base, swapFriction );
+
+	b3Recording* rec = b3CreateRecording( 0 );
+	ENSURE( rec != NULL );
+	uint64_t mutatedHash = RunGeometryMutatorScene( rec, true, meshA, meshB, &swapHull.base, swapFriction );
+
+	// Without this the replay gate below could pass on a recording that never carried the ops.
+	ENSURE( mutatedHash != controlHash );
+
+	const uint8_t* data = b3Recording_GetData( rec );
+	int size = b3Recording_GetSize( rec );
+	ENSURE( size > 0 );
+
+	ENSURE( b3ValidateReplay( data, size, 1 ) );
+	ENSURE( b3ValidateReplay( data, size, 4 ) );
+
+	b3RecPlayer* player = b3RecPlayer_Create( data, size, 1 );
+	ENSURE( player != NULL );
+	while ( b3RecPlayer_StepFrame( player ) )
+	{
+	}
+	ENSURE( b3RecPlayer_HasDiverged( player ) == false );
+
+	// Body ordinals follow creation order in the replayed world.
+	b3BodyId replayMeshBody = b3RecPlayer_GetBodyId( player, 0 );
+	b3BodyId replayBoxBody = b3RecPlayer_GetBodyId( player, 1 );
+	ENSURE( b3Body_IsValid( replayMeshBody ) && b3Body_IsValid( replayBoxBody ) );
+
+	b3ShapeId replayMeshShape;
+	ENSURE( b3Body_GetShapes( replayMeshBody, &replayMeshShape, 1 ) == 1 );
+	b3ShapeId replayBoxShape;
+	ENSURE( b3Body_GetShapes( replayBoxBody, &replayBoxShape, 1 ) == 1 );
+
+	const b3HullData* replayHull = b3Shape_GetHull( replayBoxShape );
+	ENSURE( replayHull != NULL );
+	ENSURE( replayHull->hash == swapHull.base.hash );
+
+	b3Mesh replayMesh = b3Shape_GetMesh( replayMeshShape );
+	ENSURE( replayMesh.data != NULL );
+	ENSURE( replayMesh.data->hash == meshB->hash );
+	ENSURE( replayMesh.data->triangleCount == meshB->triangleCount );
+
+	b3SurfaceMaterial replayMaterial = b3Shape_GetMeshSurfaceMaterial( replayMeshShape, 1 );
+	ENSURE( replayMaterial.friction == swapFriction );
+
+	b3RecPlayer_Destroy( player );
+	b3DestroyRecording( rec );
+	b3DestroyMesh( meshA );
+	b3DestroyMesh( meshB );
+	return 0;
+}
+
 int RecordingTest( void )
 {
 	RUN_SUBTEST( GeometryHashCollision );
@@ -2200,6 +2345,7 @@ int RecordingTest( void )
 	RUN_SUBTEST( QueryReplay );
 	RUN_SUBTEST( TaggedQuery );
 	RUN_SUBTEST( TransformedHullRoundTrip );
+	RUN_SUBTEST( GeometryMutatorReplay );
 	RUN_SUBTEST( AllOps );
 	RUN_SUBTEST( ReservedHeaderBytes );
 	return 0;

--- a/test/test_world.c
+++ b/test/test_world.c
@@ -399,6 +399,14 @@ static int TestSensor( void )
 // The case that actually moved is a COMPOUND visitor: the old rule let it through, the new
 // rule does not. A hull visitor in the same place is the control, so a sensor query that
 // silently found nothing could not make the compound half pass by accident.
+//
+// THIS TEST ONLY BITES IN A VALIDATE BUILD, and that is the whole point of the change. Under
+// the old rule a non-convex visitor reached b3MakeShapeProxy, whose switch handles only
+// sphere, capsule and hull: in Debug+VALIDATE it hits B3_ASSERT( false ) and traps (measured:
+// exit 133, SIGTRAP), while in Release it returns a zeroed proxy and quietly reports nothing,
+// which is indistinguishable from the new behaviour. So restoring the old rule fails this test
+// in Debug+VALIDATE and PASSES it in Release and in any NDEBUG config, including the two
+// RelWithDebInfo CI jobs.
 static int TestSensorVisitorMustBeConvex( void )
 {
 	for ( int useCompound = 0; useCompound < 2; ++useCompound )

--- a/test/test_world.c
+++ b/test/test_world.c
@@ -395,6 +395,84 @@ static int TestSensor( void )
 	return 0;
 }
 
+// Upstream 3fc20f5 narrowed sensor visitors from "not mesh vs mesh" to "must be convex".
+// The case that actually moved is a COMPOUND visitor: the old rule let it through, the new
+// rule does not. A hull visitor in the same place is the control, so a sensor query that
+// silently found nothing could not make the compound half pass by accident.
+static int TestSensorVisitorMustBeConvex( void )
+{
+	for ( int useCompound = 0; useCompound < 2; ++useCompound )
+	{
+		b3WorldDef worldDef = b3DefaultWorldDef();
+		b3WorldId worldId = b3CreateWorld( &worldDef );
+
+		// A static box at the origin, as a one-hull compound or as the bare hull.
+		b3BodyDef bodyDef = b3DefaultBodyDef();
+		bodyDef.type = b3_staticBody;
+		b3BodyId visitorBodyId = b3CreateBody( worldId, &bodyDef );
+
+		b3ShapeDef visitorDef = b3DefaultShapeDef();
+		visitorDef.enableSensorEvents = true;
+
+		b3BoxHull box = b3MakeBoxHull( B3_FIX( 1.0f ), B3_FIX( 1.0f ), B3_FIX( 1.0f ) );
+		b3CompoundData* compound = NULL;
+		if ( useCompound )
+		{
+			b3CompoundHullDef hullDef = { .hull = &box.base,
+										  .transform = b3Transform_identity,
+										  .material = b3DefaultSurfaceMaterial() };
+			b3CompoundDef def = { .hulls = &hullDef, .hullCount = 1 };
+			compound = b3CreateCompound( &def );
+			ENSURE( compound != NULL );
+			b3CreateBakedCompoundShape( visitorBodyId, &visitorDef, compound );
+		}
+		else
+		{
+			b3CreateHullShape( visitorBodyId, &visitorDef, &box.base );
+		}
+
+		// A weightless dynamic sensor sphere sitting inside the box, so the overlap is there
+		// from the first step and nothing has to move for it to be found.
+		bodyDef = b3DefaultBodyDef();
+		bodyDef.type = b3_dynamicBody;
+		bodyDef.gravityScale = B3_FIX( 0.0f );
+		b3BodyId sensorId = b3CreateBody( worldId, &bodyDef );
+
+		b3ShapeDef sensorDef = b3DefaultShapeDef();
+		sensorDef.isSensor = true;
+		sensorDef.enableSensorEvents = true;
+		b3Sphere sphere = { { B3_FIX( 0.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) }, B3_FIX( 0.5f ) };
+		b3CreateSphereShape( sensorId, &sensorDef, &sphere );
+
+		int beginCount = 0;
+		b3Fixed timeStep = b3FixDiv( B3_FIX( 1.0f ), B3_FIX( 60.0f ) );
+		for ( int i = 0; i < 4; ++i )
+		{
+			b3World_Step( worldId, timeStep, 4 );
+			beginCount += b3World_GetSensorEvents( worldId ).beginCount;
+		}
+
+		if ( useCompound )
+		{
+			// Non-convex visitor: no events. This is the behaviour change.
+			ENSURE( beginCount == 0 );
+		}
+		else
+		{
+			// Convex visitor at the same place: the sensor really does see it.
+			ENSURE( beginCount == 1 );
+		}
+
+		if ( compound != NULL )
+		{
+			b3DestroyCompound( compound );
+		}
+		b3DestroyWorld( worldId );
+	}
+
+	return 0;
+}
+
 static int TestContactEvents( void )
 {
 	b3WorldDef worldDef = b3DefaultWorldDef();
@@ -1278,6 +1356,7 @@ int WorldTest( void )
 	RUN_SUBTEST( TestWorldCoverage );
 	RUN_SUBTEST( TestExplosion );
 	RUN_SUBTEST( TestSensor );
+	RUN_SUBTEST( TestSensorVisitorMustBeConvex );
 	RUN_SUBTEST( TestContinuousMoveEvent );
 	RUN_SUBTEST( TestContactEvents );
 	RUN_SUBTEST( TestHitEvents );


### PR DESCRIPTION
The daily Box3D to Fixed3D pass for 2026-08-22. Upstream had four commits sitting past the cursor,
the oldest from 2026-07-24, so this is a backlog rather than a normal day.

## The cursor

It moves `c52908c` to `3fc20f5`. It also becomes an actual cursor: it lived as one sentence,
*"Baseline float code is commit c52908c"*, inside a paragraph about working-tree state, which is a
true claim filed where a daily port pass would not look for it. `CLAUDE.md` now opens with a named
section and the command that reads it, `git log 3fc20f5..upstream/main`.

Two exceptions, both on the board rather than implicit, because a cursor with silent holes is worse
than no cursor: #20 and #21. The cursor deliberately stops at `f42be21` because that commit is only
partly ported here, and moving past a partial port is how held work disappears.

## What each commit did

**`781673b` "Fixes 09"** — the capsule face/edge admission at both call sites drops its relative
tolerance for `edgeSeparation > faceSeparation + linearSlop`. That is strictly better in fixed point
than it is upstream: it is an int64 add where the old form was a `b3FixMul`, so nothing quantizes.
No golden moved, which matches upstream not touching its own `test_determinism.c`. Plus the
`hull_map.h` to `hull.h` rename, `B3_PRINTF_FORMAT`, the geometry registry becoming a `b3Array`, the
clang-cl presets, and four upstream tests translated to Q48.16. Upstream's `1e-5f` tolerances sit
BELOW our `1.5e-5` quantum, so they floor to `8 * B3_FIXED_EPSILON` per the tree's convention.

Recording ops `0x5D`/`0x5E`/`0x5F` were already here — this tree was ahead of upstream — so
`B3_REC_VERSION_MINOR` stays at 6 where upstream went 3 to 4.

**`3fc20f5` "Follow cam", engine half** — sensor visitors must be convex, **and that is a crash fix
here**. `b3OverlapSensor` builds the visitor proxy with `b3MakeShapeProxy`, whose switch handles
only sphere, capsule and hull and otherwise hits `B3_ASSERT( false )` with a zeroed proxy. So a
compound, mesh or height-field visitor with sensor events enabled trapped in any validate build and
silently reported nothing in release. The new test exits 133, SIGTRAP, with the old rule restored.
Also `B3_MAX_SHAPE_CAST_POINTS` going from a hard 64 to `B3_MAX_HULL_VERTICES`, the CI matrix, and
some debug-draw tidying.

**`f42be21`, triangle manifold half only** — the one worth reading. `b3ClipSegmentToTriangleFace`
now tests the crossing by SIGN instead of by the product of the two separations. Upstream is fixing
a style; here it is a quantization bug with no test: `b3FixMul` of two separations under ~0.004 goes
to zero, so a shallow crossing was silently dropped and the clip returned one point where it owed
two. **`RAGDOLL_HASH` moves and nothing else does** — both builds, every sleep step unchanged, wave
pile and query spawn and mesh drop all untouched, identical for worker counts 1 to 5. That
attribution came from bisecting the four hunks one at a time rather than from staring at them.

## Two upstream changes deliberately refused

Both reassociate a contact-point expression that is equal in exact arithmetic. `b3Lerp` here is
`fixMul(1-t,a) + fixMul(t,b)` with round-half-up, so moving the radius term across changes the
rounding: 288 of 1156 small-operand combinations differ by one quantum. Taking the deep-path one
moves the ragdoll sleep step 287 to 453. That is the `b3Lerp` rounding lottery this repo already
paid for and wrote into the "deliberately NOT fused" list, spent for no behavioral gain. Comments
sit at both sites so a later pass does not tidy them back in.

## The cold read, and what it caught

Floor 8 says high-blast output gets an independent cold reader before it ships, so the branch went
to one with none of the reasoning behind it and instructions to argue for rejection. It returned
reject-soft with five findings. **All five were real and all five are fixed in `00b336b`**, and two
were claims of mine that were flatly false:

- I wrote that one reassociation was "value-identical". It is not, and my own check agreed with me
  only because I had modeled `b3Lerp` as `a + t*(b-a)`, which is not what `extern/fixed` does. That
  hunk is now refused along with its twin.
- The edge-walk advance ships with no reachable test. Instrumented, that branch fires **zero** times
  across the whole suite; a constructed in-plane axis-parallel capsule fires it five times and still
  gives byte-identical manifolds either way. The fix stays because it is correct; its test is
  relabeled as the broad oracle sweep it actually is, with the measurement written above it.
- `B3_PRINTF_FORMAT` went into the dead `#else` arm of a pre-existing guard in three sample headers.
- Two test comments claimed more scope than the tests have.

It also confirmed, by re-derivation rather than from my commit text, that no float reaches the
simulation path, that the golden movement is fully attributable to the clip hunk, and that every new
tolerance is at the 8-quantum floor and none is vacuous.

## One thing for you, inherited rather than introduced

Raising `B3_MAX_SHAPE_CAST_POINTS` means a writer can now emit up to 128 proxy points where it
clamped at 64. The format is count-prefixed so it is not a format change, but an OLDER reader clamps
to 64, consumes 64 vectors, then misreads the radius and every op after it — and only `versionMajor`
is checked, so nothing rejects the file. Upstream has the same hole. Worth deciding whether the
recording version should bump.

## Verification

Full suite green in Release, Release+LUDICROUS, Debug+VALIDATE+ASan/UBSan, and the samples build,
after every commit rather than at the end. macOS arm64 only: no Windows, Linux or MinGW run here, so
the new CI jobs and clang-cl presets are unexercised until CI picks them up.
