### PR TITLE
Make inverse quantities honest at scale: the invMass floor, the wide inverse, and the gyroscopic hoist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,15 @@ jobs:
             # inverse change itself contributing 0.4s of that. Optimized builds are
             # unaffected or faster. Tracked as mas-bandwidth/fixed#18; when that lands,
             # this comes back down rather than staying quietly generous.
-            timeout: 20
+            #
+            # 20 was still not enough -- the test step alone ran 18m47s without
+            # finishing, against roughly 2 minutes on main, which is a much worse ratio
+            # than the 1.94x measured in a plain Debug build. MSan with
+            # -fsanitize-memory-track-origins amplifies this library's shape (many small
+            # calls passing vectors and matrices by value) far more than an uninstrumented
+            # build does. 40 is set to let the job finish and report a real number rather
+            # than to be comfortable.
+            timeout: 40
             args: '-DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18 -DCMAKE_C_FLAGS="-fsanitize=memory -fsanitize-memory-track-origins=1 -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-fsanitize=memory -fsanitize-memory-track-origins=1 -fno-omit-frame-pointer" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=memory"'
             test: ./bin/test
             msan-options: abort_on_error=1:halt_on_error=1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,15 @@ jobs:
             test: ./bin/test
           - name: ubuntu-clang-msan
             os: ubuntu-latest
-            timeout: 10
+            # 10 until the fixed v1.3.0 pin move, which made the Debug test binary
+            # about twice as slow and pushed this job from 8m22s to over the limit --
+            # a red check with no sanitizer finding in it. The cost is in the vendored
+            # library's unoptimized codegen, not in this repository and not in the
+            # inverse work: measured at 19.54s -> 37.84s across the pin, with the
+            # inverse change itself contributing 0.4s of that. Optimized builds are
+            # unaffected or faster. Tracked as mas-bandwidth/fixed#18; when that lands,
+            # this comes back down rather than staying quietly generous.
+            timeout: 20
             args: '-DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18 -DCMAKE_C_FLAGS="-fsanitize=memory -fsanitize-memory-track-origins=1 -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-fsanitize=memory -fsanitize-memory-track-origins=1 -fno-omit-frame-pointer" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=memory"'
             test: ./bin/test
             msan-options: abort_on_error=1:halt_on_error=1

--- a/extern/fixed/NOTES.md
+++ b/extern/fixed/NOTES.md
@@ -4,7 +4,7 @@ This directory is a **generated copy** of [mas-bandwidth/fixed](https://github.c
 the deterministic fixed-point math library that Fixed3D's own fixed-point core was
 extracted into.
 
-    Pinned at: v1.2.0  (ba88f94cb9cc03951533daf7678d8980d4118163)
+    Pinned at: v1.3.0  (db2e4809f62a031e994b336cbada2d012f9c99df)
 
 ## Do not edit anything in this directory
 

--- a/extern/fixed/include/fixed/base.h
+++ b/extern/fixed/include/fixed/base.h
@@ -7,37 +7,64 @@
 // vocabulary rather than sharing a namespace with them.
 #pragma once
 
+// EACH MACRO IS GUARDED SEPARATELY, and that is the whole point of the shape below.
+//
+// These were previously wrapped in one `#ifndef FIX_API` around the entire block, which
+// looked equivalent and is not: a consumer that supplies only FIX_API -- the common case,
+// because FIX_API is the one that carries an export decoration -- silently loses
+// FIX_INLINE, FIX_FORCE_INLINE, FIX_LITERAL and FIX_ZERO_INIT along with it. The failure
+// is a wall of "unknown type name 'FIX_INLINE'" pointing at this header, from a consumer
+// who touched exactly one macro and reasonably expected to override exactly one.
+//
+// box3d hit this while vendoring the library and had to hand the whole set down to work
+// around it. Guarding per macro means a consumer overrides what it means to override.
 #include <stdbool.h>
-// Guarded so a consumer that needs its own definitions -- an export decoration on
-// FIX_API, a different inline policy -- can supply them before including this header
-// and have them win. Standalone users of `fixed` get the definitions below.
-#ifndef FIX_API
+
 #ifdef __cplusplus
-	#define FIX_API extern "C"
-	#define FIX_INLINE inline
-	#if defined( _MSC_VER )
-		#define FIX_FORCE_INLINE __forceinline
-	#elif defined( __GNUC__ ) || defined( __clang__ )
-		#define FIX_FORCE_INLINE inline __attribute__((always_inline))
-	#else
-		#define FIX_FORCE_INLINE inline
+	#ifndef FIX_API
+		#define FIX_API extern "C"
 	#endif
-	#define FIX_LITERAL(T) T
-	#define FIX_ZERO_INIT {}
+	#ifndef FIX_INLINE
+		#define FIX_INLINE inline
+	#endif
+	#ifndef FIX_FORCE_INLINE
+		#if defined( _MSC_VER )
+			#define FIX_FORCE_INLINE __forceinline
+		#elif defined( __GNUC__ ) || defined( __clang__ )
+			#define FIX_FORCE_INLINE inline __attribute__((always_inline))
+		#else
+			#define FIX_FORCE_INLINE inline
+		#endif
+	#endif
+	#ifndef FIX_LITERAL
+		#define FIX_LITERAL(T) T
+	#endif
+	#ifndef FIX_ZERO_INIT
+		#define FIX_ZERO_INIT {}
+	#endif
 #else
-	#define FIX_API
-	#define FIX_INLINE static inline
-	#if defined( _MSC_VER )
-		#define FIX_FORCE_INLINE static __forceinline
-	#elif defined( __GNUC__ ) || defined( __clang__ )
-		#define FIX_FORCE_INLINE static inline __attribute__((always_inline))
-	#else
-		#define FIX_FORCE_INLINE static inline
+	#ifndef FIX_API
+		#define FIX_API
 	#endif
-	#define FIX_LITERAL(T) (T)
-	#define FIX_ZERO_INIT {0}
+	#ifndef FIX_INLINE
+		#define FIX_INLINE static inline
+	#endif
+	#ifndef FIX_FORCE_INLINE
+		#if defined( _MSC_VER )
+			#define FIX_FORCE_INLINE static __forceinline
+		#elif defined( __GNUC__ ) || defined( __clang__ )
+			#define FIX_FORCE_INLINE static inline __attribute__((always_inline))
+		#else
+			#define FIX_FORCE_INLINE static inline
+		#endif
+	#endif
+	#ifndef FIX_LITERAL
+		#define FIX_LITERAL(T) (T)
+	#endif
+	#ifndef FIX_ZERO_INIT
+		#define FIX_ZERO_INIT {0}
+	#endif
 #endif
-#endif // FIX_API
 
 // Guarded assert hooks: a consumer that defines these first wins, so it can route
 // this library's assertions into its own diagnostics. Standalone users of `fixed`

--- a/extern/fixed/include/fixed/fixed.h
+++ b/extern/fixed/include/fixed/fixed.h
@@ -6,19 +6,11 @@
 
 #include <stdint.h>
 
-// This header is self-contained so that base.h can include it before the rest
-// of the API macros are defined.
-#ifndef FIX_INLINE
-#if defined( _MSC_VER )
-#define FIX_ALWAYS_INLINE static __forceinline
-#elif defined( __GNUC__ ) || defined( __clang__ )
-#define FIX_ALWAYS_INLINE static inline __attribute__( ( always_inline ) )
-#else
-#define FIX_ALWAYS_INLINE static inline
-#endif
-#else
-#define FIX_ALWAYS_INLINE FIX_FORCE_INLINE
-#endif
+// The 128-bit seam: fixInt128/fixUInt128 and their operation vocabulary, native
+// __int128 where the compiler has it and an emulated pair where it does not (plain
+// MSVC). Also carries this library's FIX_ALWAYS_INLINE definition, because the seam is
+// the first thing every other header needs. This header stays self-contained.
+#include "fixed/fixed_int128.h"
 
 /**
  * @defgroup fixed Fixed-point scalar
@@ -65,21 +57,6 @@ typedef int64_t fixed_t;
 #define FIX( x )                                                                                                              \
 	( (fixed_t)( (double)( x ) * (double)FIX_ONE + ( (double)( x ) >= 0.0 ? 0.5 : -0.5 ) ) )
 
-// 128 bit helper layer. The fixed-point core requires the __int128 compiler
-// extension (clang, gcc, or clang-cl on Windows; pure MSVC does not have it).
-// __extension__ keeps -Wpedantic quiet: __int128 is not ISO C.
-#if defined( __SIZEOF_INT128__ )
-
-#define FIX_HAS_INT128 1
-__extension__ typedef __int128 fixInt128;
-__extension__ typedef unsigned __int128 fixUInt128;
-
-#else
-
-#error "Fixed3D fixed point math requires __int128: use clang, gcc, or clang-cl on Windows"
-
-#endif
-
 /// Left shift that is well defined for negative values (two's complement wrap).
 /// C makes shifting a negative value undefined; routing through unsigned keeps
 /// the same bits and keeps UBSan quiet.
@@ -91,7 +68,19 @@ FIX_ALWAYS_INLINE fixed_t fixShiftLeft( fixed_t a, int shift )
 /// 128-bit variant of fixShiftLeft
 FIX_ALWAYS_INLINE fixInt128 fixInt128ShiftLeft( fixInt128 a, int shift )
 {
-	return (fixInt128)( (fixUInt128)a << shift );
+	return fixInt128FromUnsigned( fixUInt128Shl( fixInt128ToUnsigned( a ), shift ) );
+}
+
+/// @return the minimum of two 128-bit values.
+FIX_ALWAYS_INLINE fixInt128 fixInt128Min( fixInt128 a, fixInt128 b )
+{
+	return fixInt128Lt( a, b ) ? a : b;
+}
+
+/// @return the maximum of two 128-bit values.
+FIX_ALWAYS_INLINE fixInt128 fixInt128Max( fixInt128 a, fixInt128 b )
+{
+	return fixInt128Gt( a, b ) ? a : b;
 }
 
 /// Exact signed 128-bit division. Bit-identical to the compiler's __divti3 for
@@ -103,8 +92,14 @@ FIX_ALWAYS_INLINE fixInt128 fixInt128ShiftLeft( fixInt128 a, int shift )
 /// differential fuzz on both ISAs). Apple silicon's library call is already
 /// within 8% of a hand-written Knuth divide, so non-x86 targets keep the
 /// plain division.
+/// On the emulated arm (plain MSVC, or any build with FIX_FORCE_EMULATED_INT128) the
+/// shift-subtract divide in fixed_int128.h is the whole implementation: the fast paths
+/// below are native-type transformations with nothing to accelerate.
 FIX_ALWAYS_INLINE fixInt128 fixInt128Div( fixInt128 a, fixInt128 b )
 {
+#if FIX_INT128_EMULATED
+	return fixEmuInt128Div( a, b );
+#else
 #if defined( __x86_64__ )
 	fixUInt128 ua = a < 0 ? -(fixUInt128)a : (fixUInt128)a;
 	fixUInt128 ub = b < 0 ? -(fixUInt128)b : (fixUInt128)b;
@@ -170,6 +165,7 @@ FIX_ALWAYS_INLINE fixInt128 fixInt128Div( fixInt128 a, fixInt128 b )
 #else
 	return a / b;
 #endif
+#endif
 }
 
 /// Multiply two fixed-point numbers with round-to-nearest.
@@ -179,20 +175,20 @@ FIX_ALWAYS_INLINE fixInt128 fixInt128Div( fixInt128 a, fixInt128 b )
 /// own BOX3D_FIXED_SATURATE down through its compatibility header.)
 FIX_ALWAYS_INLINE fixed_t fixMul( fixed_t a, fixed_t b )
 {
-	fixInt128 product = (fixInt128)a * b;
+	fixInt128 product = fixInt128MulI64( a, b );
 	// Round half up, then shift out the fraction bits (arithmetic shift)
-	fixInt128 r = ( product + FIX_HALF ) >> FIX_FRACTION_BITS;
+	fixInt128 r = fixInt128Shr( fixInt128Add( product, fixInt128FromI64( FIX_HALF ) ), FIX_FRACTION_BITS );
 #if defined( FIX_SATURATE )
-	if ( r > (fixInt128)INT64_MAX )
+	if ( fixInt128Gt( r, fixInt128FromI64( INT64_MAX ) ) )
 	{
 		return FIX_MAX;
 	}
-	if ( r < -(fixInt128)INT64_MAX )
+	if ( fixInt128Lt( r, fixInt128FromI64( -INT64_MAX ) ) )
 	{
 		return FIX_MIN;
 	}
 #endif
-	return (fixed_t)r;
+	return (fixed_t)fixInt128ToI64( r );
 }
 
 /// Divide two fixed-point numbers with truncation toward zero and saturation.
@@ -211,17 +207,30 @@ FIX_ALWAYS_INLINE fixed_t fixDiv( fixed_t a, fixed_t b )
 		return fixShiftLeft( a, FIX_FRACTION_BITS ) / b;
 	}
 
-	fixInt128 q = fixInt128Div( fixInt128ShiftLeft( a, FIX_FRACTION_BITS ), b );
-	if ( q > (fixInt128)INT64_MAX )
+	fixInt128 q = fixInt128Div( fixInt128ShiftLeft( fixInt128FromI64( a ), FIX_FRACTION_BITS ), fixInt128FromI64( b ) );
+	if ( fixInt128Gt( q, fixInt128FromI64( INT64_MAX ) ) )
 	{
 		return FIX_MAX;
 	}
-	if ( q < -(fixInt128)INT64_MAX )
+	if ( fixInt128Lt( q, fixInt128FromI64( -INT64_MAX ) ) )
 	{
 		return FIX_MIN;
 	}
-	return (fixed_t)q;
+	return (fixed_t)fixInt128ToI64( q );
 }
+
+// The seed for the exact integer square root below. gcc and clang compile
+// __builtin_sqrt to the hardware instruction; plain MSVC has no such builtin and uses
+// <math.h>'s sqrt. Either spelling is only a STARTING POINT -- the repair loops that
+// follow drive the result to the exact integer floor from any nearby seed -- so the
+// choice cannot move a bit of output, and the frozen determinism hashes hold that.
+// Internal to this header; not part of the overridable macro set in base.h.
+#if defined( _MSC_VER ) && !defined( __clang__ )
+	#include <math.h>
+	#define FIX_SQRT_SEED( x ) sqrt( x )
+#else
+	#define FIX_SQRT_SEED( x ) __builtin_sqrt( x )
+#endif
 
 /// Exact integer square root of an unsigned 128 bit value (helper for fixSqrt).
 FIX_ALWAYS_INLINE uint64_t fixISqrt128High( uint64_t hi, uint64_t lo )
@@ -236,16 +245,16 @@ FIX_ALWAYS_INLINE uint64_t fixISqrt128High( uint64_t hi, uint64_t lo )
 			return 0;
 		}
 
-		uint64_t r = (uint64_t)__builtin_sqrt( (double)lo );
+		uint64_t r = (uint64_t)FIX_SQRT_SEED( (double)lo );
 		if ( r > 0xFFFFFFFFu )
 		{
 			r = 0xFFFFFFFFu;
 		}
-		while ( r > 0 && (fixUInt128)r * r > lo )
+		while ( r > 0 && fixUInt128Gt( fixUInt128MulU64( r, r ), fixUInt128FromU64( lo ) ) )
 		{
 			r -= 1;
 		}
-		while ( (fixUInt128)( r + 1 ) * ( r + 1 ) <= lo )
+		while ( fixUInt128Le( fixUInt128MulU64( r + 1, r + 1 ), fixUInt128FromU64( lo ) ) )
 		{
 			r += 1;
 		}
@@ -253,30 +262,31 @@ FIX_ALWAYS_INLINE uint64_t fixISqrt128High( uint64_t hi, uint64_t lo )
 	}
 
 	// Rare 128 bit case: restoring shift-subtract square root
-	fixUInt128 n = ( (fixUInt128)hi << 64 ) | lo;
+	fixUInt128 n = fixUInt128Make( hi, lo );
 	fixUInt128 x = n;
-	fixUInt128 c = 0;
-	fixUInt128 d = (fixUInt128)1 << 126;
-	while ( d > n )
+	fixUInt128 c = FIX_UINT128_ZERO;
+	fixUInt128 d = fixUInt128Shl( fixUInt128FromU64( 1 ), 126 );
+	while ( fixUInt128Gt( d, n ) )
 	{
-		d >>= 2;
+		d = fixUInt128Shr( d, 2 );
 	}
 
-	while ( d != 0 )
+	while ( !fixUInt128Eq( d, FIX_UINT128_ZERO ) )
 	{
-		if ( x >= c + d )
+		fixUInt128 cd = fixUInt128Add( c, d );
+		if ( fixUInt128Ge( x, cd ) )
 		{
-			x -= c + d;
-			c = ( c >> 1 ) + d;
+			x = fixUInt128Sub( x, cd );
+			c = fixUInt128Add( fixUInt128Shr( c, 1 ), d );
 		}
 		else
 		{
-			c >>= 1;
+			c = fixUInt128Shr( c, 1 );
 		}
-		d >>= 2;
+		d = fixUInt128Shr( d, 2 );
 	}
 
-	return (uint64_t)c;
+	return fixUInt128Lo( c );
 }
 
 /// Fixed-point square root. Exact (round toward zero). Negative inputs return 0.
@@ -385,6 +395,96 @@ FIX_ALWAYS_INLINE fixed_t fixFromDouble( double x )
 {
 	double d = x * (double)FIX_ONE;
 	return (fixed_t)( d >= 0.0 ? d + 0.5 : d - 0.5 );
+}
+
+//! @cond
+
+// ---------------------------------------------------------------------------------------------
+// Q2.30 packed components (fixed30_t)
+//
+// A SECOND raw fixed-point domain: 32-bit storage, 2 integer bits (sign included), 30 fraction
+// bits. Built for always-normalized quantities (quaternion components never leave [-1, 1], so
+// nearly all bits go to fraction). The raw value is wrapped in a struct ON PURPOSE: fixed_t is
+// a bare int64 typedef and Q48.16/Q2.30 raws differ by 2^14, so a bare 32-bit typedef would
+// let a mixup compile silently -- the same trap as assigning a double into a fixed_t. With the
+// struct, arithmetic and cross-domain assignment refuse to compile; go through the converters.
+//
+// ROUNDING RULE (pinned): dropping bits rounds to nearest via ( raw + ( 1 << ( drop - 1 ) ) ) >> drop,
+// the same form as the floor( v * scale + 0.5 ) wire family.
+// ---------------------------------------------------------------------------------------------
+
+//! @endcond
+
+/// Number of fractional bits in a Q2.30 packed component.
+#define FIX30_FRACTION_BITS 30
+
+/// One, in Q2.30.
+#define FIX30_ONE ( (int32_t)1 << FIX30_FRACTION_BITS )
+
+/// The shift between the Q48.16 and Q2.30 raw domains.
+#define FIX30_SHIFT ( FIX30_FRACTION_BITS - FIX_FRACTION_BITS )
+
+/// A Q2.30 packed fixed-point component: 32-bit storage, 2 integer bits (sign included),
+/// 30 fraction bits. Domain [-2, 2); built for always-normalized quantities. Deliberately a
+/// struct so a Q48.16/Q2.30 raw mixup cannot compile silently.
+typedef struct fixed30_t
+{
+	int32_t raw;
+} fixed30_t;
+
+/// Pack Q48.16 to Q2.30. Gains 14 fraction bits (exact for in-range values); values outside
+/// [-2, 2) saturate to the domain bounds.
+FIX_ALWAYS_INLINE fixed30_t fix30FromFix( fixed_t a )
+{
+	// Saturation is tested BEFORE the shift. Shifting first and testing after -- which is
+	// what this looked like in box3d -- is signed overflow for |a| >= 2^49, and the shifted
+	// value is discarded in exactly those cases, so the order is free. Same answer for
+	// every input, no undefined behavior. The in-range shift routes through fixShiftLeft
+	// because a is signed and may be negative.
+	if ( a >= ( (fixed_t)2 << FIX_FRACTION_BITS ) )
+	{
+		fixed30_t saturated = { INT32_MAX };
+		return saturated;
+	}
+
+	if ( a < -( (fixed_t)2 << FIX_FRACTION_BITS ) )
+	{
+		fixed30_t saturated = { INT32_MIN };
+		return saturated;
+	}
+
+	fixed30_t result = { (int32_t)fixShiftLeft( a, FIX30_SHIFT ) };
+	return result;
+}
+
+/// Unpack Q2.30 to Q48.16. Drops 14 fraction bits, rounding to nearest per the pinned rule.
+FIX_ALWAYS_INLINE fixed_t fixFromFix30( fixed30_t a )
+{
+	return ( (fixed_t)a.raw + ( (fixed_t)1 << ( FIX30_SHIFT - 1 ) ) ) >> FIX30_SHIFT;
+}
+
+/// Convert Q2.30 to a double. Exact: every Q2.30 value is representable in a double.
+FIX_ALWAYS_INLINE double fix30ToDouble( fixed30_t a )
+{
+	return (double)a.raw / (double)FIX30_ONE;
+}
+
+/// Convert a double to Q2.30, rounding to nearest, saturating to the domain. A boundary
+/// helper, and like the other double boundary helpers it takes a finite input.
+FIX_ALWAYS_INLINE fixed30_t fix30FromDouble( double x )
+{
+	double d = x * (double)FIX30_ONE;
+	d = ( d >= 0.0 ? d + 0.5 : d - 0.5 );
+	if ( d >= (double)INT32_MAX )
+	{
+		d = (double)INT32_MAX;
+	}
+	else if ( d <= (double)INT32_MIN )
+	{
+		d = (double)INT32_MIN;
+	}
+	fixed30_t result = { (int32_t)d };
+	return result;
 }
 
 /**@}*/ // fixed

--- a/extern/fixed/include/fixed/fixed_int128.h
+++ b/extern/fixed/include/fixed/fixed_int128.h
@@ -1,0 +1,715 @@
+// SPDX-FileCopyrightText: 2026 Más Bandwidth LLC
+// SPDX-License-Identifier: MIT
+//
+// 128-BIT INTEGERS ON EVERY COMPILER, INCLUDING PLAIN MSVC.
+//
+// The fixed-point core needs 128-bit intermediates: fixMul widens before it rounds,
+// fixDiv shifts a 64-bit numerator up by 16 before dividing, fixLength accumulates an
+// exact sum of squares, and the whole wide-world family is 128-bit by definition. GCC,
+// clang and clang-cl provide __int128. Plain MSVC does not, and Visual C++ support is a
+// hard requirement, so this header supplies the missing arithmetic instead of excluding
+// the compiler.
+//
+// TWO LAYERS, AND THE SEPARATION IS THE POINT:
+//
+//   1. fixEmuUInt128 / fixEmuInt128 -- an emulated pair of two uint64_t lanes with a
+//      complete operation vocabulary. COMPILED ON EVERY PLATFORM, unconditionally, even
+//      where native __int128 exists. That is what lets test/int128_test.c check every
+//      emulated operation against the native one, input by input, on the machines that
+//      have both. An emulation that only compiles where it cannot be checked is an
+//      emulation nobody has checked.
+//
+//   2. fixInt128 / fixUInt128 plus the fixInt128*/fixUInt128* vocabulary -- the types the
+//      rest of the library speaks. They are native __int128 where the compiler has it,
+//      and the emulated pair where it does not. The vocabulary functions are
+//      FIX_ALWAYS_INLINE one-liners over the native operators, so native builds get
+//      byte-identical code generation to the operators they replaced -- verified by
+//      diffing the compiled library, not assumed.
+//
+// The emulated semantics are captured from the serialize library's serialize_uint128_t /
+// serialize_int128_t pair (a sibling project under the same estate), renamed into this
+// library's namespace per Glenn's ruling: fixed does not depend on serialize. serialize's
+// pair is C++-operator-shaped and this one is C-function-shaped, because fixed is a C
+// library; the arithmetic and every documented edge choice are the same.
+//
+// SEMANTICS MATCH NATIVE __int128 EXACTLY, with documented choices where native has none:
+//
+//   - Shift counts outside [0, 127] yield zero for << and for the unsigned >>, and all
+//     sign bits for the signed arithmetic >> (0 for non-negative, -1 for negative), which
+//     is the limit of shifting further. Native shifts by 128 or more are undefined
+//     behavior, so there is no native answer to match.
+//   - Signed INT128_MIN / -1 wraps to INT128_MIN with a zero remainder, the bit pattern
+//     two's complement hardware produces.
+//   - DIVISION BY ZERO IS UNDEFINED, exactly as it is for native __int128. arm64 and
+//     x86-64 do not even agree with each other (arm64 returns zero, x86-64 raises a
+//     hardware exception), so there is no portable behavior available to match. What the
+//     emulation guarantees is only that it is TOTAL: it returns a zero quotient rather
+//     than trapping, so a caller's mistake cannot kill a process. That is an
+//     implementation detail and not a contract, and the differential test deliberately
+//     excludes zero divisors because agreement there is not a property either side can
+//     promise. Every divide in this library guards its divisor first.
+//
+// FORCING THE EMULATED PATH: define FIX_FORCE_EMULATED_INT128 and the whole library runs
+// on the emulated pair even where native __int128 exists. CI builds the entire test suite
+// that way on all three operating systems and asserts THE SAME FROZEN DETERMINISM HASHES,
+// so the emulated arithmetic is held to bit-identity with native by every test in the
+// repository rather than by one dedicated test.
+#pragma once
+
+// Self-contained, and deliberately does NOT include base.h: the FIX_ALWAYS_INLINE
+// definition below keys off whether the consumer has already pulled in base.h's macro
+// block, so including base.h from here would answer its own question.
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+// The always-inline spelling this library's header-inline math uses. A consumer that has
+// supplied base.h's macros gets FIX_FORCE_INLINE, which it may have overridden; a
+// consumer including this header on its own gets the compiler's spelling directly.
+#ifndef FIX_INLINE
+	#if defined( _MSC_VER )
+		#define FIX_ALWAYS_INLINE static __forceinline
+	#elif defined( __GNUC__ ) || defined( __clang__ )
+		#define FIX_ALWAYS_INLINE static inline __attribute__( ( always_inline ) )
+	#else
+		#define FIX_ALWAYS_INLINE static inline
+	#endif
+#else
+	#define FIX_ALWAYS_INLINE FIX_FORCE_INLINE
+#endif
+
+// ================================================================================
+// LAYER 1: the emulated pair. Always compiled, on every platform.
+// ================================================================================
+
+/// Emulated unsigned 128-bit integer: two 64-bit lanes, low half first to match the
+/// little-endian layout and the wire order of the sibling projects that carry this shape.
+typedef struct fixEmuUInt128
+{
+	uint64_t lo;
+	uint64_t hi;
+} fixEmuUInt128;
+
+/// Emulated signed 128-bit integer. The same two lanes; the top bit of hi is the sign.
+/// Addition, subtraction, multiplication and the bitwise operations produce identical bit
+/// patterns to the unsigned type (two's complement), so they delegate to it rather than
+/// duplicating the arithmetic. The signed-specific pieces are the comparisons, the
+/// arithmetic right shift, division, and negation.
+typedef struct fixEmuInt128
+{
+	uint64_t lo;
+	uint64_t hi;
+} fixEmuInt128;
+
+// ---- unsigned construction and lane access -------------------------------------
+
+FIX_ALWAYS_INLINE fixEmuUInt128 fixEmuUInt128Make( uint64_t hi, uint64_t lo )
+{
+	fixEmuUInt128 r;
+	r.lo = lo;
+	r.hi = hi;
+	return r;
+}
+
+/// Zero-extend a 64-bit unsigned value, matching native conversion to unsigned __int128.
+FIX_ALWAYS_INLINE fixEmuUInt128 fixEmuUInt128FromU64( uint64_t v )
+{
+	return fixEmuUInt128Make( 0, v );
+}
+
+/// Sign-extend a 64-bit signed value. Native conversion of a negative int64_t to
+/// unsigned __int128 wraps modulo 2^128, which fills the high lane with ones.
+FIX_ALWAYS_INLINE fixEmuUInt128 fixEmuUInt128FromI64( int64_t v )
+{
+	return fixEmuUInt128Make( v < 0 ? UINT64_C( 0xFFFFFFFFFFFFFFFF ) : 0, (uint64_t)v );
+}
+
+FIX_ALWAYS_INLINE uint64_t fixEmuUInt128Lo( fixEmuUInt128 a )
+{
+	return a.lo;
+}
+
+FIX_ALWAYS_INLINE uint64_t fixEmuUInt128Hi( fixEmuUInt128 a )
+{
+	return a.hi;
+}
+
+// ---- signed construction and lane access ---------------------------------------
+
+FIX_ALWAYS_INLINE fixEmuInt128 fixEmuInt128Make( uint64_t hi, uint64_t lo )
+{
+	fixEmuInt128 r;
+	r.lo = lo;
+	r.hi = hi;
+	return r;
+}
+
+/// Sign-extend a 64-bit signed value, matching native conversion to __int128.
+FIX_ALWAYS_INLINE fixEmuInt128 fixEmuInt128FromI64( int64_t v )
+{
+	return fixEmuInt128Make( v < 0 ? UINT64_C( 0xFFFFFFFFFFFFFFFF ) : 0, (uint64_t)v );
+}
+
+/// Zero-extend a 64-bit unsigned value. Every uint64_t is below 2^127, so native
+/// conversion to __int128 is value-preserving with a zero high lane.
+FIX_ALWAYS_INLINE fixEmuInt128 fixEmuInt128FromU64( uint64_t v )
+{
+	return fixEmuInt128Make( 0, v );
+}
+
+/// The low lane, wrapping two's complement like a native narrowing conversion.
+FIX_ALWAYS_INLINE int64_t fixEmuInt128ToI64( fixEmuInt128 a )
+{
+	return (int64_t)a.lo;
+}
+
+FIX_ALWAYS_INLINE uint64_t fixEmuInt128Lo( fixEmuInt128 a )
+{
+	return a.lo;
+}
+
+FIX_ALWAYS_INLINE uint64_t fixEmuInt128Hi( fixEmuInt128 a )
+{
+	return a.hi;
+}
+
+/// Bit-preserving conversions between the two emulated types, matching a native cast.
+FIX_ALWAYS_INLINE fixEmuUInt128 fixEmuToUnsigned( fixEmuInt128 a )
+{
+	return fixEmuUInt128Make( a.hi, a.lo );
+}
+
+FIX_ALWAYS_INLINE fixEmuInt128 fixEmuToSigned( fixEmuUInt128 a )
+{
+	return fixEmuInt128Make( a.hi, a.lo );
+}
+
+FIX_ALWAYS_INLINE bool fixEmuInt128IsNegative( fixEmuInt128 a )
+{
+	return ( a.hi >> 63 ) != 0;
+}
+
+// ---- unsigned comparison --------------------------------------------------------
+
+FIX_ALWAYS_INLINE bool fixEmuUInt128Eq( fixEmuUInt128 a, fixEmuUInt128 b )
+{
+	return a.lo == b.lo && a.hi == b.hi;
+}
+
+FIX_ALWAYS_INLINE bool fixEmuUInt128Lt( fixEmuUInt128 a, fixEmuUInt128 b )
+{
+	return ( a.hi != b.hi ) ? ( a.hi < b.hi ) : ( a.lo < b.lo );
+}
+
+FIX_ALWAYS_INLINE bool fixEmuUInt128Gt( fixEmuUInt128 a, fixEmuUInt128 b )
+{
+	return fixEmuUInt128Lt( b, a );
+}
+
+FIX_ALWAYS_INLINE bool fixEmuUInt128Le( fixEmuUInt128 a, fixEmuUInt128 b )
+{
+	return !fixEmuUInt128Lt( b, a );
+}
+
+FIX_ALWAYS_INLINE bool fixEmuUInt128Ge( fixEmuUInt128 a, fixEmuUInt128 b )
+{
+	return !fixEmuUInt128Lt( a, b );
+}
+
+// ---- signed comparison ----------------------------------------------------------
+
+FIX_ALWAYS_INLINE bool fixEmuInt128Eq( fixEmuInt128 a, fixEmuInt128 b )
+{
+	return a.lo == b.lo && a.hi == b.hi;
+}
+
+/// Signed ordering: the high lanes compare signed, the low lanes break ties unsigned.
+FIX_ALWAYS_INLINE bool fixEmuInt128Lt( fixEmuInt128 a, fixEmuInt128 b )
+{
+	if ( a.hi != b.hi )
+	{
+		return (int64_t)a.hi < (int64_t)b.hi;
+	}
+	return a.lo < b.lo;
+}
+
+FIX_ALWAYS_INLINE bool fixEmuInt128Gt( fixEmuInt128 a, fixEmuInt128 b )
+{
+	return fixEmuInt128Lt( b, a );
+}
+
+FIX_ALWAYS_INLINE bool fixEmuInt128Le( fixEmuInt128 a, fixEmuInt128 b )
+{
+	return !fixEmuInt128Lt( b, a );
+}
+
+FIX_ALWAYS_INLINE bool fixEmuInt128Ge( fixEmuInt128 a, fixEmuInt128 b )
+{
+	return !fixEmuInt128Lt( a, b );
+}
+
+// ---- unsigned bitwise -----------------------------------------------------------
+
+FIX_ALWAYS_INLINE fixEmuUInt128 fixEmuUInt128Not( fixEmuUInt128 a )
+{
+	return fixEmuUInt128Make( ~a.hi, ~a.lo );
+}
+
+FIX_ALWAYS_INLINE fixEmuUInt128 fixEmuUInt128And( fixEmuUInt128 a, fixEmuUInt128 b )
+{
+	return fixEmuUInt128Make( a.hi & b.hi, a.lo & b.lo );
+}
+
+FIX_ALWAYS_INLINE fixEmuUInt128 fixEmuUInt128Or( fixEmuUInt128 a, fixEmuUInt128 b )
+{
+	return fixEmuUInt128Make( a.hi | b.hi, a.lo | b.lo );
+}
+
+FIX_ALWAYS_INLINE fixEmuUInt128 fixEmuUInt128Xor( fixEmuUInt128 a, fixEmuUInt128 b )
+{
+	return fixEmuUInt128Make( a.hi ^ b.hi, a.lo ^ b.lo );
+}
+
+// ---- unsigned shifts ------------------------------------------------------------
+
+/// Shifting a uint64_t lane by 64 is undefined behavior, so the half boundary is an
+/// explicit branch. Shift counts outside [0, 127] yield zero.
+FIX_ALWAYS_INLINE fixEmuUInt128 fixEmuUInt128Shl( fixEmuUInt128 a, int shift )
+{
+	if ( shift == 0 )
+	{
+		return a;
+	}
+	if ( shift > 0 && shift < 64 )
+	{
+		return fixEmuUInt128Make( ( a.hi << shift ) | ( a.lo >> ( 64 - shift ) ), a.lo << shift );
+	}
+	if ( shift >= 64 && shift < 128 )
+	{
+		return fixEmuUInt128Make( a.lo << ( shift - 64 ), 0 );
+	}
+	return fixEmuUInt128Make( 0, 0 );
+}
+
+/// Logical right shift. Shift counts outside [0, 127] yield zero.
+FIX_ALWAYS_INLINE fixEmuUInt128 fixEmuUInt128Shr( fixEmuUInt128 a, int shift )
+{
+	if ( shift == 0 )
+	{
+		return a;
+	}
+	if ( shift > 0 && shift < 64 )
+	{
+		return fixEmuUInt128Make( a.hi >> shift, ( a.lo >> shift ) | ( a.hi << ( 64 - shift ) ) );
+	}
+	if ( shift >= 64 && shift < 128 )
+	{
+		return fixEmuUInt128Make( 0, a.hi >> ( shift - 64 ) );
+	}
+	return fixEmuUInt128Make( 0, 0 );
+}
+
+// ---- unsigned arithmetic --------------------------------------------------------
+
+FIX_ALWAYS_INLINE fixEmuUInt128 fixEmuUInt128Add( fixEmuUInt128 a, fixEmuUInt128 b )
+{
+	uint64_t lo = a.lo + b.lo;
+	uint64_t hi = a.hi + b.hi + ( ( lo < a.lo ) ? 1 : 0 ); // carry out of the low lane
+	return fixEmuUInt128Make( hi, lo );
+}
+
+FIX_ALWAYS_INLINE fixEmuUInt128 fixEmuUInt128Sub( fixEmuUInt128 a, fixEmuUInt128 b )
+{
+	uint64_t lo = a.lo - b.lo;
+	uint64_t hi = a.hi - b.hi - ( ( a.lo < b.lo ) ? 1 : 0 ); // borrow out of the low lane
+	return fixEmuUInt128Make( hi, lo );
+}
+
+FIX_ALWAYS_INLINE fixEmuUInt128 fixEmuUInt128Neg( fixEmuUInt128 a )
+{
+	return fixEmuUInt128Sub( fixEmuUInt128Make( 0, 0 ), a );
+}
+
+/// Exact 64x64 -> 128 unsigned product, schoolbook in 32-bit limbs. This is the
+/// PORTABLE spelling, kept under its own name so test/int128_test.c can hold the
+/// intrinsic-accelerated fixEmuUInt128MulU64 below to it on the compilers that have an
+/// intrinsic. On every other compiler the two are the same function and the check is a
+/// tautology -- which is exactly why it must not be the only test of this multiply.
+FIX_ALWAYS_INLINE fixEmuUInt128 fixEmuUInt128MulU64Schoolbook( uint64_t a, uint64_t b )
+{
+	const uint64_t aLow = a & UINT64_C( 0xFFFFFFFF );
+	const uint64_t aHigh = a >> 32;
+	const uint64_t bLow = b & UINT64_C( 0xFFFFFFFF );
+	const uint64_t bHigh = b >> 32;
+
+	const uint64_t productLowLow = aLow * bLow;
+	const uint64_t productLowHigh = aLow * bHigh;
+	const uint64_t productHighLow = aHigh * bLow;
+	const uint64_t productHighHigh = aHigh * bHigh;
+
+	const uint64_t carry =
+		( ( productLowLow >> 32 ) + ( productLowHigh & UINT64_C( 0xFFFFFFFF ) ) + ( productHighLow & UINT64_C( 0xFFFFFFFF ) ) ) >> 32;
+
+	uint64_t lo = productLowLow + ( productLowHigh << 32 ) + ( productHighLow << 32 );
+	uint64_t hi = productHighHigh + ( productLowHigh >> 32 ) + ( productHighLow >> 32 ) + carry;
+	return fixEmuUInt128Make( hi, lo );
+}
+
+// The one place an intrinsic earns its keep: this multiply is on the path of every
+// fixMul, so an emulated build runs it once per multiply in the solver. _umul128 and
+// __umulh are the exact 128-bit product -- there is no semantic freedom in "the exact
+// product", so the substitution cannot change a result, and the schoolbook form above
+// stays compiled as the differential partner.
+#if defined( _MSC_VER ) && !defined( __clang__ ) && ( defined( _M_X64 ) || defined( _M_ARM64 ) )
+	#include <intrin.h>
+	#define FIX_INT128_HAS_MUL_INTRINSIC 1
+#else
+	#define FIX_INT128_HAS_MUL_INTRINSIC 0
+#endif
+
+FIX_ALWAYS_INLINE fixEmuUInt128 fixEmuUInt128MulU64( uint64_t a, uint64_t b )
+{
+#if FIX_INT128_HAS_MUL_INTRINSIC && defined( _M_X64 )
+	uint64_t hi;
+	uint64_t lo = _umul128( a, b, &hi );
+	return fixEmuUInt128Make( hi, lo );
+#elif FIX_INT128_HAS_MUL_INTRINSIC && defined( _M_ARM64 )
+	return fixEmuUInt128Make( __umulh( a, b ), a * b );
+#else
+	return fixEmuUInt128MulU64Schoolbook( a, b );
+#endif
+}
+
+/// Full 128x128 -> 128 product (the high half of the true 256-bit product is discarded,
+/// exactly as native two's complement multiplication discards it).
+FIX_ALWAYS_INLINE fixEmuUInt128 fixEmuUInt128Mul( fixEmuUInt128 a, fixEmuUInt128 b )
+{
+	fixEmuUInt128 r = fixEmuUInt128MulU64( a.lo, b.lo );
+	r.hi += a.lo * b.hi + a.hi * b.lo;
+	return r;
+}
+
+/// Shift-subtract long division, producing quotient and remainder together.
+/// Division by zero is undefined; this returns zero for both to stay total (see the
+/// header comment). Out-parameters may be NULL if only one half is wanted.
+FIX_ALWAYS_INLINE void fixEmuUInt128DivMod( fixEmuUInt128 dividend, fixEmuUInt128 divisor, fixEmuUInt128* quotientOut,
+											fixEmuUInt128* remainderOut )
+{
+	fixEmuUInt128 quotient = fixEmuUInt128Make( 0, 0 );
+	fixEmuUInt128 remainder = fixEmuUInt128Make( 0, 0 );
+
+	if ( divisor.hi == 0 && divisor.lo == 0 )
+	{
+		if ( quotientOut != NULL ) *quotientOut = quotient;
+		if ( remainderOut != NULL ) *remainderOut = remainder;
+		return;
+	}
+
+	if ( dividend.hi == 0 && divisor.hi == 0 )
+	{
+		quotient = fixEmuUInt128FromU64( dividend.lo / divisor.lo );
+		remainder = fixEmuUInt128FromU64( dividend.lo % divisor.lo );
+		if ( quotientOut != NULL ) *quotientOut = quotient;
+		if ( remainderOut != NULL ) *remainderOut = remainder;
+		return;
+	}
+
+	for ( int i = 127; i >= 0; i-- )
+	{
+		// The reference spells this ( dividend >> i ).lo & 1; selecting the lane directly
+		// is the same bit for every i in [0, 127] and skips a 128-bit shift per iteration.
+		uint64_t bit = ( i < 64 ) ? ( ( dividend.lo >> i ) & 1 ) : ( ( dividend.hi >> ( i - 64 ) ) & 1 );
+
+		remainder = fixEmuUInt128Shl( remainder, 1 );
+		remainder.lo |= bit;
+
+		if ( fixEmuUInt128Ge( remainder, divisor ) )
+		{
+			remainder = fixEmuUInt128Sub( remainder, divisor );
+			quotient = fixEmuUInt128Or( quotient, fixEmuUInt128Shl( fixEmuUInt128FromU64( 1 ), i ) );
+		}
+	}
+
+	if ( quotientOut != NULL ) *quotientOut = quotient;
+	if ( remainderOut != NULL ) *remainderOut = remainder;
+}
+
+FIX_ALWAYS_INLINE fixEmuUInt128 fixEmuUInt128Div( fixEmuUInt128 a, fixEmuUInt128 b )
+{
+	fixEmuUInt128 quotient;
+	fixEmuUInt128DivMod( a, b, &quotient, NULL );
+	return quotient;
+}
+
+FIX_ALWAYS_INLINE fixEmuUInt128 fixEmuUInt128Mod( fixEmuUInt128 a, fixEmuUInt128 b )
+{
+	fixEmuUInt128 remainder;
+	fixEmuUInt128DivMod( a, b, NULL, &remainder );
+	return remainder;
+}
+
+// ---- signed arithmetic ----------------------------------------------------------
+//
+// Two's complement: addition, subtraction, multiplication and the bitwise operations
+// are the same bit patterns as unsigned, so they delegate. Signed overflow wraps by
+// construction, exactly like the underlying hardware.
+
+FIX_ALWAYS_INLINE fixEmuInt128 fixEmuInt128Add( fixEmuInt128 a, fixEmuInt128 b )
+{
+	return fixEmuToSigned( fixEmuUInt128Add( fixEmuToUnsigned( a ), fixEmuToUnsigned( b ) ) );
+}
+
+FIX_ALWAYS_INLINE fixEmuInt128 fixEmuInt128Sub( fixEmuInt128 a, fixEmuInt128 b )
+{
+	return fixEmuToSigned( fixEmuUInt128Sub( fixEmuToUnsigned( a ), fixEmuToUnsigned( b ) ) );
+}
+
+FIX_ALWAYS_INLINE fixEmuInt128 fixEmuInt128Mul( fixEmuInt128 a, fixEmuInt128 b )
+{
+	return fixEmuToSigned( fixEmuUInt128Mul( fixEmuToUnsigned( a ), fixEmuToUnsigned( b ) ) );
+}
+
+/// Two's complement negation. -INT128_MIN wraps to itself, like native.
+FIX_ALWAYS_INLINE fixEmuInt128 fixEmuInt128Neg( fixEmuInt128 a )
+{
+	return fixEmuToSigned( fixEmuUInt128Neg( fixEmuToUnsigned( a ) ) );
+}
+
+/// Widening signed 64x64 -> 128 product. The hot one: this is the multiply inside
+/// fixMul, fixDot, fixCofactor128 and every other exact accumulation in the library.
+/// Computed as the unsigned product of the bit patterns, which is the same low 128 bits
+/// as the signed product in two's complement.
+FIX_ALWAYS_INLINE fixEmuInt128 fixEmuInt128MulI64( int64_t a, int64_t b )
+{
+	fixEmuUInt128 product = fixEmuUInt128MulU64( (uint64_t)a, (uint64_t)b );
+	// Fold in the sign-extension lanes: the full product of the sign-extended operands is
+	// unsigned_product - ( a < 0 ? b : 0 ) * 2^64 - ( b < 0 ? a : 0 ) * 2^64.
+	if ( a < 0 )
+	{
+		product.hi -= (uint64_t)b;
+	}
+	if ( b < 0 )
+	{
+		product.hi -= (uint64_t)a;
+	}
+	return fixEmuToSigned( product );
+}
+
+/// Logical left shift of the bit pattern, matching native two's complement hardware.
+/// Shift counts outside [0, 127] yield zero.
+FIX_ALWAYS_INLINE fixEmuInt128 fixEmuInt128Shl( fixEmuInt128 a, int shift )
+{
+	return fixEmuToSigned( fixEmuUInt128Shl( fixEmuToUnsigned( a ), shift ) );
+}
+
+/// ARITHMETIC right shift: the vacated high bits fill with the sign. Shift counts
+/// outside [0, 127] yield all sign bits, the limit of shifting further.
+FIX_ALWAYS_INLINE fixEmuInt128 fixEmuInt128Shr( fixEmuInt128 a, int shift )
+{
+	if ( shift < 0 || shift >= 128 )
+	{
+		return fixEmuInt128IsNegative( a ) ? fixEmuInt128FromI64( -1 ) : fixEmuInt128FromI64( 0 );
+	}
+
+	fixEmuUInt128 result = fixEmuUInt128Shr( fixEmuToUnsigned( a ), shift );
+	if ( fixEmuInt128IsNegative( a ) && shift > 0 )
+	{
+		result = fixEmuUInt128Or( result, fixEmuUInt128Shl( fixEmuUInt128Not( fixEmuUInt128Make( 0, 0 ) ), 128 - shift ) );
+	}
+	return fixEmuToSigned( result );
+}
+
+/// Sign extraction, unsigned division on the magnitudes, sign application: C semantics,
+/// truncation toward zero with the remainder's sign following the dividend.
+FIX_ALWAYS_INLINE void fixEmuInt128DivMod( fixEmuInt128 dividend, fixEmuInt128 divisor, fixEmuInt128* quotientOut,
+										   fixEmuInt128* remainderOut )
+{
+	const bool dividendNegative = fixEmuInt128IsNegative( dividend );
+	const bool divisorNegative = fixEmuInt128IsNegative( divisor );
+
+	fixEmuUInt128 dividendMagnitude = fixEmuToUnsigned( dividend );
+	fixEmuUInt128 divisorMagnitude = fixEmuToUnsigned( divisor );
+	if ( dividendNegative ) dividendMagnitude = fixEmuUInt128Neg( dividendMagnitude );
+	if ( divisorNegative ) divisorMagnitude = fixEmuUInt128Neg( divisorMagnitude );
+
+	fixEmuUInt128 quotient;
+	fixEmuUInt128 remainder;
+	fixEmuUInt128DivMod( dividendMagnitude, divisorMagnitude, &quotient, &remainder );
+
+	if ( quotientOut != NULL )
+	{
+		*quotientOut = fixEmuToSigned( ( dividendNegative != divisorNegative ) ? fixEmuUInt128Neg( quotient ) : quotient );
+	}
+	if ( remainderOut != NULL )
+	{
+		*remainderOut = fixEmuToSigned( dividendNegative ? fixEmuUInt128Neg( remainder ) : remainder );
+	}
+}
+
+FIX_ALWAYS_INLINE fixEmuInt128 fixEmuInt128Div( fixEmuInt128 a, fixEmuInt128 b )
+{
+	fixEmuInt128 quotient;
+	fixEmuInt128DivMod( a, b, &quotient, NULL );
+	return quotient;
+}
+
+FIX_ALWAYS_INLINE fixEmuInt128 fixEmuInt128Mod( fixEmuInt128 a, fixEmuInt128 b )
+{
+	fixEmuInt128 remainder;
+	fixEmuInt128DivMod( a, b, NULL, &remainder );
+	return remainder;
+}
+
+// ================================================================================
+// LAYER 2: fixInt128 / fixUInt128 -- the types the library speaks.
+// ================================================================================
+
+#if defined( __SIZEOF_INT128__ ) && !defined( FIX_FORCE_EMULATED_INT128 )
+
+/// 1 when this build carries 128-bit integers. Always 1 -- the emulated pair covers the
+/// compilers that lack __int128. Kept as a macro because consumers test it.
+#define FIX_HAS_INT128 1
+
+/// 1 when fixInt128 is the emulated pair rather than a compiler __int128.
+#define FIX_INT128_EMULATED 0
+
+// __extension__ keeps -Wpedantic quiet: __int128 is not ISO C.
+__extension__ typedef __int128 fixInt128;
+__extension__ typedef unsigned __int128 fixUInt128;
+
+#else
+
+#define FIX_HAS_INT128 1
+#define FIX_INT128_EMULATED 1
+
+typedef fixEmuInt128 fixInt128;
+typedef fixEmuUInt128 fixUInt128;
+
+#endif
+
+// The vocabulary. Every 128-bit operation in this library goes through one of these
+// names, which is what makes the emulated arm possible at all: there is no bare
+// operator on a fixInt128 anywhere in the headers or the sources.
+//
+// On the native arm each one is a FIX_ALWAYS_INLINE one-liner over the operator it
+// replaced, so -O2 code generation is unchanged. That is checked rather than asserted:
+// the pull request that introduced this header diffed the compiled library object
+// before and after and found the instruction stream identical.
+
+#if FIX_INT128_EMULATED == 0
+
+FIX_ALWAYS_INLINE fixUInt128 fixUInt128Make( uint64_t hi, uint64_t lo ) { return ( (fixUInt128)hi << 64 ) | lo; }
+FIX_ALWAYS_INLINE fixUInt128 fixUInt128FromU64( uint64_t v ) { return (fixUInt128)v; }
+FIX_ALWAYS_INLINE uint64_t fixUInt128Lo( fixUInt128 a ) { return (uint64_t)a; }
+FIX_ALWAYS_INLINE uint64_t fixUInt128Hi( fixUInt128 a ) { return (uint64_t)( a >> 64 ); }
+FIX_ALWAYS_INLINE fixUInt128 fixUInt128Add( fixUInt128 a, fixUInt128 b ) { return a + b; }
+FIX_ALWAYS_INLINE fixUInt128 fixUInt128Sub( fixUInt128 a, fixUInt128 b ) { return a - b; }
+FIX_ALWAYS_INLINE fixUInt128 fixUInt128Mul( fixUInt128 a, fixUInt128 b ) { return a * b; }
+FIX_ALWAYS_INLINE fixUInt128 fixUInt128MulU64( uint64_t a, uint64_t b ) { return (fixUInt128)a * b; }
+FIX_ALWAYS_INLINE fixUInt128 fixUInt128Neg( fixUInt128 a ) { return -a; }
+// The shifts are the plain operators, with no guard on the count. That is deliberate and
+// it is the one place the two arms differ: a shift count outside [0, 127] is undefined
+// behavior for native __int128, so there is no native answer for the emulation to match,
+// and a guard here would put a compare and a select on the path of every fixMul and
+// fixDiv to defend against an input this library never produces. The emulated arm is
+// TOTAL instead (zero, or all sign bits) so that it cannot trap; the differential test
+// restricts itself to [0, 127] for the same reason it excludes zero divisors.
+FIX_ALWAYS_INLINE fixUInt128 fixUInt128Shl( fixUInt128 a, int shift ) { return a << shift; }
+FIX_ALWAYS_INLINE fixUInt128 fixUInt128Shr( fixUInt128 a, int shift ) { return a >> shift; }
+FIX_ALWAYS_INLINE fixUInt128 fixUInt128Or( fixUInt128 a, fixUInt128 b ) { return a | b; }
+FIX_ALWAYS_INLINE fixUInt128 fixUInt128And( fixUInt128 a, fixUInt128 b ) { return a & b; }
+FIX_ALWAYS_INLINE fixUInt128 fixUInt128Xor( fixUInt128 a, fixUInt128 b ) { return a ^ b; }
+FIX_ALWAYS_INLINE fixUInt128 fixUInt128Not( fixUInt128 a ) { return ~a; }
+FIX_ALWAYS_INLINE bool fixUInt128Eq( fixUInt128 a, fixUInt128 b ) { return a == b; }
+FIX_ALWAYS_INLINE bool fixUInt128Lt( fixUInt128 a, fixUInt128 b ) { return a < b; }
+FIX_ALWAYS_INLINE bool fixUInt128Gt( fixUInt128 a, fixUInt128 b ) { return a > b; }
+FIX_ALWAYS_INLINE bool fixUInt128Le( fixUInt128 a, fixUInt128 b ) { return a <= b; }
+FIX_ALWAYS_INLINE bool fixUInt128Ge( fixUInt128 a, fixUInt128 b ) { return a >= b; }
+
+FIX_ALWAYS_INLINE fixInt128 fixInt128Make( uint64_t hi, uint64_t lo ) { return (fixInt128)( ( (fixUInt128)hi << 64 ) | lo ); }
+FIX_ALWAYS_INLINE fixInt128 fixInt128FromI64( int64_t v ) { return (fixInt128)v; }
+FIX_ALWAYS_INLINE fixInt128 fixInt128FromU64( uint64_t v ) { return (fixInt128)v; }
+FIX_ALWAYS_INLINE int64_t fixInt128ToI64( fixInt128 a ) { return (int64_t)a; }
+FIX_ALWAYS_INLINE uint64_t fixInt128Lo( fixInt128 a ) { return (uint64_t)a; }
+FIX_ALWAYS_INLINE uint64_t fixInt128Hi( fixInt128 a ) { return (uint64_t)( (fixUInt128)a >> 64 ); }
+FIX_ALWAYS_INLINE fixUInt128 fixInt128ToUnsigned( fixInt128 a ) { return (fixUInt128)a; }
+FIX_ALWAYS_INLINE fixInt128 fixInt128FromUnsigned( fixUInt128 a ) { return (fixInt128)a; }
+// THROUGH THE UNSIGNED TYPE, and this is a correctness matter rather than a style one.
+// The emulated arm wraps on overflow because two's complement lanes wrap; native signed
+// overflow is UNDEFINED. If the native arm kept the bare signed operators the two arms
+// would not agree at the boundary -- which is the one thing this seam exists to promise --
+// and the difference would be invisible until a compiler decided to exploit the UB. The
+// cast is free: the same instruction, with defined semantics, verified by diffing the
+// compiled consumer. It is the idiom fixShiftLeft already uses for the same reason.
+FIX_ALWAYS_INLINE fixInt128 fixInt128Add( fixInt128 a, fixInt128 b )
+{
+	return (fixInt128)( (fixUInt128)a + (fixUInt128)b );
+}
+FIX_ALWAYS_INLINE fixInt128 fixInt128Sub( fixInt128 a, fixInt128 b )
+{
+	return (fixInt128)( (fixUInt128)a - (fixUInt128)b );
+}
+FIX_ALWAYS_INLINE fixInt128 fixInt128Mul( fixInt128 a, fixInt128 b )
+{
+	return (fixInt128)( (fixUInt128)a * (fixUInt128)b );
+}
+// The widening multiply cannot overflow: the largest product of two int64 values is 2^126.
+FIX_ALWAYS_INLINE fixInt128 fixInt128MulI64( int64_t a, int64_t b ) { return (fixInt128)a * b; }
+FIX_ALWAYS_INLINE fixInt128 fixInt128Neg( fixInt128 a ) { return (fixInt128)( -(fixUInt128)a ); }
+FIX_ALWAYS_INLINE fixInt128 fixInt128Shr( fixInt128 a, int shift ) { return a >> shift; }
+FIX_ALWAYS_INLINE bool fixInt128Eq( fixInt128 a, fixInt128 b ) { return a == b; }
+FIX_ALWAYS_INLINE bool fixInt128Lt( fixInt128 a, fixInt128 b ) { return a < b; }
+FIX_ALWAYS_INLINE bool fixInt128Gt( fixInt128 a, fixInt128 b ) { return a > b; }
+FIX_ALWAYS_INLINE bool fixInt128Le( fixInt128 a, fixInt128 b ) { return a <= b; }
+FIX_ALWAYS_INLINE bool fixInt128Ge( fixInt128 a, fixInt128 b ) { return a >= b; }
+FIX_ALWAYS_INLINE bool fixInt128IsNegative( fixInt128 a ) { return a < 0; }
+
+#else
+
+FIX_ALWAYS_INLINE fixUInt128 fixUInt128Make( uint64_t hi, uint64_t lo ) { return fixEmuUInt128Make( hi, lo ); }
+FIX_ALWAYS_INLINE fixUInt128 fixUInt128FromU64( uint64_t v ) { return fixEmuUInt128FromU64( v ); }
+FIX_ALWAYS_INLINE uint64_t fixUInt128Lo( fixUInt128 a ) { return fixEmuUInt128Lo( a ); }
+FIX_ALWAYS_INLINE uint64_t fixUInt128Hi( fixUInt128 a ) { return fixEmuUInt128Hi( a ); }
+FIX_ALWAYS_INLINE fixUInt128 fixUInt128Add( fixUInt128 a, fixUInt128 b ) { return fixEmuUInt128Add( a, b ); }
+FIX_ALWAYS_INLINE fixUInt128 fixUInt128Sub( fixUInt128 a, fixUInt128 b ) { return fixEmuUInt128Sub( a, b ); }
+FIX_ALWAYS_INLINE fixUInt128 fixUInt128Mul( fixUInt128 a, fixUInt128 b ) { return fixEmuUInt128Mul( a, b ); }
+FIX_ALWAYS_INLINE fixUInt128 fixUInt128MulU64( uint64_t a, uint64_t b ) { return fixEmuUInt128MulU64( a, b ); }
+FIX_ALWAYS_INLINE fixUInt128 fixUInt128Neg( fixUInt128 a ) { return fixEmuUInt128Neg( a ); }
+FIX_ALWAYS_INLINE fixUInt128 fixUInt128Shl( fixUInt128 a, int shift ) { return fixEmuUInt128Shl( a, shift ); }
+FIX_ALWAYS_INLINE fixUInt128 fixUInt128Shr( fixUInt128 a, int shift ) { return fixEmuUInt128Shr( a, shift ); }
+FIX_ALWAYS_INLINE fixUInt128 fixUInt128Or( fixUInt128 a, fixUInt128 b ) { return fixEmuUInt128Or( a, b ); }
+FIX_ALWAYS_INLINE fixUInt128 fixUInt128And( fixUInt128 a, fixUInt128 b ) { return fixEmuUInt128And( a, b ); }
+FIX_ALWAYS_INLINE fixUInt128 fixUInt128Xor( fixUInt128 a, fixUInt128 b ) { return fixEmuUInt128Xor( a, b ); }
+FIX_ALWAYS_INLINE fixUInt128 fixUInt128Not( fixUInt128 a ) { return fixEmuUInt128Not( a ); }
+FIX_ALWAYS_INLINE bool fixUInt128Eq( fixUInt128 a, fixUInt128 b ) { return fixEmuUInt128Eq( a, b ); }
+FIX_ALWAYS_INLINE bool fixUInt128Lt( fixUInt128 a, fixUInt128 b ) { return fixEmuUInt128Lt( a, b ); }
+FIX_ALWAYS_INLINE bool fixUInt128Gt( fixUInt128 a, fixUInt128 b ) { return fixEmuUInt128Gt( a, b ); }
+FIX_ALWAYS_INLINE bool fixUInt128Le( fixUInt128 a, fixUInt128 b ) { return fixEmuUInt128Le( a, b ); }
+FIX_ALWAYS_INLINE bool fixUInt128Ge( fixUInt128 a, fixUInt128 b ) { return fixEmuUInt128Ge( a, b ); }
+
+FIX_ALWAYS_INLINE fixInt128 fixInt128Make( uint64_t hi, uint64_t lo ) { return fixEmuInt128Make( hi, lo ); }
+FIX_ALWAYS_INLINE fixInt128 fixInt128FromI64( int64_t v ) { return fixEmuInt128FromI64( v ); }
+FIX_ALWAYS_INLINE fixInt128 fixInt128FromU64( uint64_t v ) { return fixEmuInt128FromU64( v ); }
+FIX_ALWAYS_INLINE int64_t fixInt128ToI64( fixInt128 a ) { return fixEmuInt128ToI64( a ); }
+FIX_ALWAYS_INLINE uint64_t fixInt128Lo( fixInt128 a ) { return fixEmuInt128Lo( a ); }
+FIX_ALWAYS_INLINE uint64_t fixInt128Hi( fixInt128 a ) { return fixEmuInt128Hi( a ); }
+FIX_ALWAYS_INLINE fixUInt128 fixInt128ToUnsigned( fixInt128 a ) { return fixEmuToUnsigned( a ); }
+FIX_ALWAYS_INLINE fixInt128 fixInt128FromUnsigned( fixUInt128 a ) { return fixEmuToSigned( a ); }
+FIX_ALWAYS_INLINE fixInt128 fixInt128Add( fixInt128 a, fixInt128 b ) { return fixEmuInt128Add( a, b ); }
+FIX_ALWAYS_INLINE fixInt128 fixInt128Sub( fixInt128 a, fixInt128 b ) { return fixEmuInt128Sub( a, b ); }
+FIX_ALWAYS_INLINE fixInt128 fixInt128Mul( fixInt128 a, fixInt128 b ) { return fixEmuInt128Mul( a, b ); }
+FIX_ALWAYS_INLINE fixInt128 fixInt128MulI64( int64_t a, int64_t b ) { return fixEmuInt128MulI64( a, b ); }
+FIX_ALWAYS_INLINE fixInt128 fixInt128Neg( fixInt128 a ) { return fixEmuInt128Neg( a ); }
+FIX_ALWAYS_INLINE fixInt128 fixInt128Shr( fixInt128 a, int shift ) { return fixEmuInt128Shr( a, shift ); }
+FIX_ALWAYS_INLINE bool fixInt128Eq( fixInt128 a, fixInt128 b ) { return fixEmuInt128Eq( a, b ); }
+FIX_ALWAYS_INLINE bool fixInt128Lt( fixInt128 a, fixInt128 b ) { return fixEmuInt128Lt( a, b ); }
+FIX_ALWAYS_INLINE bool fixInt128Gt( fixInt128 a, fixInt128 b ) { return fixEmuInt128Gt( a, b ); }
+FIX_ALWAYS_INLINE bool fixInt128Le( fixInt128 a, fixInt128 b ) { return fixEmuInt128Le( a, b ); }
+FIX_ALWAYS_INLINE bool fixInt128Ge( fixInt128 a, fixInt128 b ) { return fixEmuInt128Ge( a, b ); }
+FIX_ALWAYS_INLINE bool fixInt128IsNegative( fixInt128 a ) { return fixEmuInt128IsNegative( a ); }
+
+#endif
+
+/// Zero and one, spelled once so call sites do not have to.
+#define FIX_INT128_ZERO fixInt128FromI64( 0 )
+#define FIX_UINT128_ZERO fixUInt128FromU64( 0 )

--- a/extern/fixed/include/fixed/fixed_int256.h
+++ b/extern/fixed/include/fixed/fixed_int256.h
@@ -1,0 +1,261 @@
+// SPDX-FileCopyrightText: 2026 Más Bandwidth LLC
+// SPDX-License-Identifier: MIT
+//
+// 256-BIT INTERMEDIATES FOR THE EXACT 3x3 MATRIX INVERSE.
+//
+// The inverse of a Q48.16 matrix is a ratio of two quantities that do not both fit in
+// 128 bits. The cofactors are Q32.32 products of two Q48.16 entries, so a cofactor
+// reaches 126 bits; the determinant is a cofactor multiplied by another entry, so it
+// reaches 190; and the numerator of an inverse entry is a cofactor shifted up 32 places,
+// so it reaches 158. Any reduction that squeezes those into 128 bits either truncates
+// the cofactor or overflows the determinant, and both failures are silent -- they return
+// a number of arbitrary sign rather than refusing.
+//
+// So the wide arm of fixInvertMatrix carries the full width instead, and this header is
+// the arithmetic it needs: unsigned 256-bit add, subtract, shift, compare, a 128x64
+// widening multiply, and a division. Nothing more. It is NOT a general big-integer
+// facility and should not grow into one -- every operation here exists because one
+// specific line of the inverse needs it.
+//
+// BUILT ON THE 128-BIT SEAM, NOT ON __int128. Every operation below is expressed in the
+// fixUInt128 vocabulary from fixed_int128.h, so the 256-bit layer is native where the
+// compiler has __int128 and emulated where it does not, with no second implementation to
+// keep in step. The emulated arm of the test suite therefore covers this header for free.
+//
+// WHERE THE COST LANDS: the wide arm runs at mass-data time (body creation, SetMassData),
+// never in the solver. The division is an unrolled shift-subtract, which is slow by the
+// standards of a hardware divide and irrelevant by the standards of the thing that calls
+// it. The solver's arm of fixInvertMatrix is 128-bit and unchanged.
+#pragma once
+
+#include "fixed/fixed_int128.h"
+
+/// Unsigned 256-bit integer as an ordered pair of 128-bit halves.
+typedef struct fixUInt256
+{
+	fixUInt128 hi;
+	fixUInt128 lo;
+} fixUInt256;
+
+/// Widen a 128-bit value. Exact.
+FIX_ALWAYS_INLINE fixUInt256 fixUInt256FromU128( fixUInt128 a )
+{
+	fixUInt256 r;
+	r.hi = FIX_UINT128_ZERO;
+	r.lo = a;
+	return r;
+}
+
+FIX_ALWAYS_INLINE fixUInt256 fixUInt256FromU64( uint64_t a )
+{
+	return fixUInt256FromU128( fixUInt128FromU64( a ) );
+}
+
+FIX_ALWAYS_INLINE bool fixUInt256IsZero( fixUInt256 a )
+{
+	return fixUInt128Eq( a.hi, FIX_UINT128_ZERO ) && fixUInt128Eq( a.lo, FIX_UINT128_ZERO );
+}
+
+/// Wrapping 256-bit addition. The carry out of the low half is detected by the
+/// standard unsigned test -- a sum that wrapped is smaller than either addend.
+FIX_ALWAYS_INLINE fixUInt256 fixUInt256Add( fixUInt256 a, fixUInt256 b )
+{
+	fixUInt256 r;
+	r.lo = fixUInt128Add( a.lo, b.lo );
+	fixUInt128 carry = fixUInt128Lt( r.lo, a.lo ) ? fixUInt128FromU64( 1 ) : FIX_UINT128_ZERO;
+	r.hi = fixUInt128Add( fixUInt128Add( a.hi, b.hi ), carry );
+	return r;
+}
+
+/// Wrapping 256-bit subtraction.
+FIX_ALWAYS_INLINE fixUInt256 fixUInt256Sub( fixUInt256 a, fixUInt256 b )
+{
+	fixUInt256 r;
+	r.lo = fixUInt128Sub( a.lo, b.lo );
+	fixUInt128 borrow = fixUInt128Lt( a.lo, b.lo ) ? fixUInt128FromU64( 1 ) : FIX_UINT128_ZERO;
+	r.hi = fixUInt128Sub( fixUInt128Sub( a.hi, b.hi ), borrow );
+	return r;
+}
+
+/// Two's complement negation.
+FIX_ALWAYS_INLINE fixUInt256 fixUInt256Neg( fixUInt256 a )
+{
+	fixUInt256 zero;
+	zero.hi = FIX_UINT128_ZERO;
+	zero.lo = FIX_UINT128_ZERO;
+	return fixUInt256Sub( zero, a );
+}
+
+FIX_ALWAYS_INLINE bool fixUInt256Eq( fixUInt256 a, fixUInt256 b )
+{
+	return fixUInt128Eq( a.hi, b.hi ) && fixUInt128Eq( a.lo, b.lo );
+}
+
+FIX_ALWAYS_INLINE bool fixUInt256Lt( fixUInt256 a, fixUInt256 b )
+{
+	if ( !fixUInt128Eq( a.hi, b.hi ) )
+	{
+		return fixUInt128Lt( a.hi, b.hi );
+	}
+	return fixUInt128Lt( a.lo, b.lo );
+}
+
+FIX_ALWAYS_INLINE bool fixUInt256Ge( fixUInt256 a, fixUInt256 b )
+{
+	return !fixUInt256Lt( a, b );
+}
+
+/// Left shift by 0..255. Shifts of 128 or more move the low half into the high half
+/// wholesale; the cross-half term is guarded because a 128-place shift of a 128-bit
+/// value has no defined answer on the native arm.
+FIX_ALWAYS_INLINE fixUInt256 fixUInt256Shl( fixUInt256 a, int shift )
+{
+	fixUInt256 r;
+	if ( shift <= 0 )
+	{
+		return a;
+	}
+	if ( shift >= 256 )
+	{
+		r.hi = FIX_UINT128_ZERO;
+		r.lo = FIX_UINT128_ZERO;
+		return r;
+	}
+	if ( shift >= 128 )
+	{
+		r.hi = fixUInt128Shl( a.lo, shift - 128 );
+		r.lo = FIX_UINT128_ZERO;
+		return r;
+	}
+	fixUInt128 spill = fixUInt128Shr( a.lo, 128 - shift );
+	r.hi = fixUInt128Or( fixUInt128Shl( a.hi, shift ), spill );
+	r.lo = fixUInt128Shl( a.lo, shift );
+	return r;
+}
+
+/// Right shift by 0..255.
+FIX_ALWAYS_INLINE fixUInt256 fixUInt256Shr( fixUInt256 a, int shift )
+{
+	fixUInt256 r;
+	if ( shift <= 0 )
+	{
+		return a;
+	}
+	if ( shift >= 256 )
+	{
+		r.hi = FIX_UINT128_ZERO;
+		r.lo = FIX_UINT128_ZERO;
+		return r;
+	}
+	if ( shift >= 128 )
+	{
+		r.lo = fixUInt128Shr( a.hi, shift - 128 );
+		r.hi = FIX_UINT128_ZERO;
+		return r;
+	}
+	fixUInt128 spill = fixUInt128Shl( a.hi, 128 - shift );
+	r.lo = fixUInt128Or( fixUInt128Shr( a.lo, shift ), spill );
+	r.hi = fixUInt128Shr( a.hi, shift );
+	return r;
+}
+
+/// Index of the highest set bit plus one; zero for zero. Used to start the division at
+/// the first bit that can matter instead of at bit 255.
+FIX_ALWAYS_INLINE int fixUInt256BitLength( fixUInt256 a )
+{
+	for ( int i = 255; i >= 0; --i )
+	{
+		fixUInt128 half = i >= 128 ? a.hi : a.lo;
+		int bit = i >= 128 ? i - 128 : i;
+		if ( !fixUInt128Eq( fixUInt128And( fixUInt128Shr( half, bit ), fixUInt128FromU64( 1 ) ), FIX_UINT128_ZERO ) )
+		{
+			return i + 1;
+		}
+	}
+	return 0;
+}
+
+FIX_ALWAYS_INLINE bool fixUInt256Bit( fixUInt256 a, int i )
+{
+	fixUInt128 half = i >= 128 ? a.hi : a.lo;
+	int bit = i >= 128 ? i - 128 : i;
+	return !fixUInt128Eq( fixUInt128And( fixUInt128Shr( half, bit ), fixUInt128FromU64( 1 ) ), FIX_UINT128_ZERO );
+}
+
+/// Widening multiply of a 128-bit value by a 64-bit value. Exact: the product of a
+/// 128-bit and a 64-bit value needs at most 192 bits.
+FIX_ALWAYS_INLINE fixUInt256 fixUInt256MulU128ByU64( fixUInt128 a, uint64_t b )
+{
+	fixUInt128 lowPart = fixUInt128MulU64( fixUInt128Lo( a ), b );
+	fixUInt128 highPart = fixUInt128MulU64( fixUInt128Hi( a ), b );
+
+	// highPart occupies bits 64..191, so it splits across the halves.
+	fixUInt256 shifted;
+	shifted.hi = fixUInt128Shr( highPart, 64 );
+	shifted.lo = fixUInt128Shl( highPart, 64 );
+
+	return fixUInt256Add( shifted, fixUInt256FromU128( lowPart ) );
+}
+
+/// Exact unsigned division with remainder. Shift-subtract, entered at the highest bit
+/// that can contribute, so the loop length tracks the operands rather than the type.
+/// A zero divisor yields a zero quotient and remainder: every caller in this library
+/// tests the divisor first, and returning rather than trapping keeps a caller's mistake
+/// from killing a process.
+FIX_ALWAYS_INLINE void fixUInt256DivMod( fixUInt256 dividend, fixUInt256 divisor, fixUInt256* quotientOut, fixUInt256* remainderOut )
+{
+	fixUInt256 quotient;
+	quotient.hi = FIX_UINT128_ZERO;
+	quotient.lo = FIX_UINT128_ZERO;
+	fixUInt256 remainder = quotient;
+
+	if ( fixUInt256IsZero( divisor ) )
+	{
+		*quotientOut = quotient;
+		*remainderOut = remainder;
+		return;
+	}
+
+	for ( int i = fixUInt256BitLength( dividend ) - 1; i >= 0; --i )
+	{
+		remainder = fixUInt256Shl( remainder, 1 );
+		if ( fixUInt256Bit( dividend, i ) )
+		{
+			remainder = fixUInt256Add( remainder, fixUInt256FromU64( 1 ) );
+		}
+		if ( fixUInt256Ge( remainder, divisor ) )
+		{
+			remainder = fixUInt256Sub( remainder, divisor );
+			quotient = fixUInt256Add( quotient, fixUInt256Shl( fixUInt256FromU64( 1 ), i ) );
+		}
+	}
+
+	*quotientOut = quotient;
+	*remainderOut = remainder;
+}
+
+/// True if a two's complement 256-bit value is negative.
+FIX_ALWAYS_INLINE bool fixInt256IsNegative( fixUInt256 a )
+{
+	return !fixUInt128Eq( fixUInt128And( fixUInt128Shr( a.hi, 127 ), fixUInt128FromU64( 1 ) ), FIX_UINT128_ZERO );
+}
+
+/// Magnitude of a two's complement 256-bit value.
+FIX_ALWAYS_INLINE fixUInt256 fixInt256Abs( fixUInt256 a )
+{
+	return fixInt256IsNegative( a ) ? fixUInt256Neg( a ) : a;
+}
+
+/// Widening signed multiply of a 128-bit value by a 64-bit value, result in two's
+/// complement 256-bit form.
+FIX_ALWAYS_INLINE fixUInt256 fixInt256MulI128ByI64( fixInt128 a, int64_t b )
+{
+	bool negative = fixInt128IsNegative( a ) != ( b < 0 );
+
+	fixUInt128 absA = fixInt128IsNegative( a ) ? fixUInt128Neg( fixInt128ToUnsigned( a ) ) : fixInt128ToUnsigned( a );
+	// Negating through unsigned so the most negative value has a defined magnitude.
+	uint64_t absB = b < 0 ? (uint64_t)0 - (uint64_t)b : (uint64_t)b;
+
+	fixUInt256 product = fixUInt256MulU128ByU64( absA, absB );
+	return negative ? fixUInt256Neg( product ) : product;
+}

--- a/extern/fixed/include/fixed/fixed_math.h
+++ b/extern/fixed/include/fixed/fixed_math.h
@@ -28,5 +28,54 @@ FIX_INLINE fixed_t fixUnwindAngle( fixed_t radians )
 {
 	const fixed_t twoPi = FIX( 6.28318530718 );
 	int64_t n = ( fixDiv( radians, twoPi ) + FIX_HALF ) >> FIX_FRACTION_BITS;
-	return (fixed_t)( radians - (fixInt128)n * twoPi );
+	return (fixed_t)fixInt128ToI64( fixInt128Sub( fixInt128FromI64( radians ), fixInt128MulI64( n, twoPi ) ) );
 }
+
+/// Interpolate a scalar.
+FIX_INLINE fixed_t fixLerp( fixed_t a, fixed_t b, fixed_t alpha )
+{
+	return fixMul( ( FIX( 1.0f ) - alpha ) , a ) + fixMul( alpha , b );
+}
+
+// ---------------------------------------------------------------------------------------------
+// The exp2 / log2 / pow ladder. Determinism over accuracy: every operation is pure integer
+// arithmetic, so the results are bit-identical on every platform, which libm's pow is not.
+// ---------------------------------------------------------------------------------------------
+
+/// Base-2 logarithm. The mantissa's log2 bits are produced exactly by repeated squaring, so
+/// this is deterministic. Returns INT64_MIN for a <= 0, log2 having no value there.
+FIX_API fixed_t fixLog2( fixed_t a );
+
+/// Base-2 exponential, by binary exponentiation over the fraction bits. Saturates to
+/// INT64_MAX at and above 2^47 (the top of the Q48.16 whole-unit domain) and returns 0
+/// below the smallest representable value.
+FIX_API fixed_t fixExp2( fixed_t a );
+
+/// base raised to exponent, as fixExp2( exponent * fixLog2( base ) ). Returns 0 for
+/// base <= 0 and one for a zero exponent.
+FIX_API fixed_t fixPow( fixed_t base, fixed_t exponent );
+
+// ---------------------------------------------------------------------------------------------
+// Q2.30 normalization
+// ---------------------------------------------------------------------------------------------
+
+/// One normalized Q2.30 component: raw * 2^30 / length, rounded to nearest and clamped to
+/// [-1, 1] (the rounded divide can otherwise overshoot one by an ulp). length must be
+/// non-zero; a zero length has no direction to normalize toward.
+FIX_API int32_t fixNormalizeComponent30( int64_t raw, uint64_t length );
+
+// ---------------------------------------------------------------------------------------------
+// Critically damped smoothing on fixed point (deterministic control dynamics).
+// Mirrors the double-precision formula: omega = 2 pi / smoothTime;
+// velocity = ( velocity - omega^2 * dt * ( current - target ) ) / ( 1 + omega * dt )^2;
+// result = current + velocity * dt.
+// ---------------------------------------------------------------------------------------------
+
+/// Critically damped smoothing toward a target. Updates velocity in place.
+FIX_API fixed_t fixSmoothCriticallyDamped( fixed_t current, fixed_t target, fixed_t* velocity, fixed_t smoothTime,
+										   fixed_t deltaTime );
+
+/// Critically damped smoothing with separate smoothing times for moving up (toward a larger
+/// magnitude) and down. The time is selected by comparing |target| to |current|.
+FIX_API fixed_t fixSmoothCriticallyDampedUpDown( fixed_t current, fixed_t target, fixed_t* velocity,
+												 fixed_t smoothTimeUp, fixed_t smoothTimeDown, fixed_t deltaTime );

--- a/extern/fixed/include/fixed/fixed_quantize.h
+++ b/extern/fixed/include/fixed/fixed_quantize.h
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: 2026 Más Bandwidth LLC
+// SPDX-License-Identifier: MIT
+//
+// DOMAIN CROSSING: arbitrary-scale conversion, and moving between two Q formats.
+//
+// The rest of this library is pinned to its own formats -- fixFromDouble speaks Q48.16,
+// fix30FromFix speaks Q48.16 to Q2.30. This header is the general case: any scale, and
+// any shift between two integer domains. It exists because a consumer's wire format is
+// rarely one of this library's formats. A rotation sent at 10 fraction bits, a position
+// in hundredths of a unit, a component held at 30 bits in simulation and sent at 10 --
+// none of those have a pinned converter and all of them are the same two operations.
+//
+// Ported from delta (mas-bandwidth/delta, delta_quantize.h), whose spelling is the
+// reference: delta and this library must agree bit for bit, because delta is about to
+// depend on fixed and delete its own copies. test/quantize_test.c holds every function
+// here to a verbatim transcription of delta's body.
+//
+// THE ONE RULE THAT MATTERS MORE THAN ALL THE FUNCTIONS BELOW, carried over from delta
+// because it is the thing that actually goes wrong:
+//
+//     QUANTIZE ON THE AUTHORITY, ONCE, AND TREAT THE RESULT AS THE TRUTH.
+//
+// The quantized integer is what goes into the baseline, what a delta is computed against,
+// and what the client decodes. If instead the float stays the truth and each side
+// quantizes independently, there are two simulations rounding separately, the baselines
+// drift apart, and the delta decodes to a value the server never held. That failure is
+// subtle, delayed, and invisible until scale.
+//
+// TWO DIFFERENT ROUNDING RULES LIVE IN THIS HEADER, and the asymmetry is deliberate:
+//
+//   fixQuantize rounds HALF AWAY FROM ZERO. It is symmetric about the origin, which
+//   matters for a signed world -- half up would bias every negative coordinate toward
+//   the origin and every positive one away from it. It runs on ONE machine (the
+//   authority), so it can afford symmetry, and it takes a double, so it could not be
+//   made portable anyway.
+//
+//   fixNarrow rounds HALF TOWARD POSITIVE INFINITY, which is what the arithmetic shift
+//   gives for free. BOTH SIDES run it, so it can afford only agreement, and it is
+//   integer-only for exactly that reason. This is the same rule the Q2.30 converters in
+//   fixed.h already use -- fixFromFix30( a ) is fixNarrow( a.raw, FIX30_SHIFT ), and the
+//   test asserts it -- so the general form and the pinned form are one rule, not two.
+//
+// NOT TO BE CONFUSED WITH THE WIDE FAMILY. fixNarrow and fixWiden move a value between
+// two Q formats inside 64 bits by shifting the fraction point. fixWideToFixed and
+// fixWideFromFixed in fixed_wide.h move between 64-bit and 128-bit STORAGE at the same
+// fraction point. Different axis entirely: one changes precision, the other changes
+// range.
+#pragma once
+
+#include "fixed/base.h"
+#include "fixed/fixed.h"
+
+#include <stdint.h>
+
+// ---------------------------------------------------------------------------------------------
+// ARBITRARY SCALE
+//
+// `scale` is the integer value that represents 1.0 in the target domain: FIX_ONE for a
+// Q48.16 component, 1024 for a rotation at 10 fraction bits, 100 for hundredths of a unit.
+// ---------------------------------------------------------------------------------------------
+
+/// Convert a value to its raw integer at an arbitrary scale, rounding half away from zero.
+///
+/// A BOUNDARY HELPER, and the caveat is the same one fixFromDouble carries: this takes a
+/// double, so the compiler's choice of instruction can move the result by one unit at a
+/// tie. That is fine where quantization happens on the authority only -- one machine, one
+/// answer, distributed as an integer. It is NOT fine anywhere both sides must agree, which
+/// is why fixNarrow and fixWiden below are integer-only.
+FIX_ALWAYS_INLINE int64_t fixQuantize( double value, int64_t scale )
+{
+	FIX_ASSERT( scale > 0 );
+
+	const double scaled = value * (double)scale;
+
+	return ( scaled >= 0.0 ) ? (int64_t)( scaled + 0.5 ) : -(int64_t)( -scaled + 0.5 );
+}
+
+/// Convert a raw integer at an arbitrary scale back to a value. Debug, display, and the
+/// far side of a boundary that has already been crossed once.
+FIX_ALWAYS_INLINE double fixDequantize( int64_t raw, int64_t scale )
+{
+	FIX_ASSERT( scale > 0 );
+
+	return (double)raw / (double)scale;
+}
+
+/// The same crossing with the domain bound applied. USE THIS ONE at the authority
+/// boundary rather than the bare form above, and treat the clamp as a DIAGNOSTIC rather
+/// than a convenience: an object outside the declared world is a simulation bug, and
+/// whatever consumes the raw value next will complain about it somewhere further from the
+/// cause.
+///
+/// minRaw and maxRaw are in the RAW domain -- for a Q(i.f) field they are
+/// minUnits << f and maxUnits << f.
+FIX_ALWAYS_INLINE int64_t fixQuantizeClamped( double value, int64_t scale, int64_t minRaw, int64_t maxRaw )
+{
+	FIX_ASSERT( minRaw <= maxRaw );
+
+	int64_t raw = fixQuantize( value, scale );
+
+	if ( raw < minRaw )
+	{
+		raw = minRaw;
+	}
+	else if ( raw > maxRaw )
+	{
+		raw = maxRaw;
+	}
+
+	return raw;
+}
+
+/// Is this raw value inside the declared domain? The predicate behind the clamp above,
+/// separated so a caller can treat the answer as a bug report instead of clamping.
+FIX_ALWAYS_INLINE bool fixFits( int64_t raw, int64_t minRaw, int64_t maxRaw )
+{
+	return raw >= minRaw && raw <= maxRaw;
+}
+
+// ---------------------------------------------------------------------------------------------
+// NARROWING AND WIDENING BETWEEN TWO INTEGER DOMAINS
+//
+// The pair for carrying a value at one precision in simulation and a coarser one on the
+// wire. BOTH SIDES RUN THIS, so it is integer-only and exactly specified.
+//
+// fixWiden is exact and lossless, and fixNarrow( fixWiden( v, n ), n ) is the identity.
+// The other order is not, and that is the whole point -- narrowing is where the bits go.
+// ---------------------------------------------------------------------------------------------
+
+/// Drop `shift` fraction bits, rounding half toward positive infinity.
+///
+/// The rounding is the arithmetic shift's own behaviour rather than a choice layered on
+/// top, which is why this is the rule both sides can rely on: there is nothing here for a
+/// compiler to do differently.
+FIX_ALWAYS_INLINE int64_t fixNarrow( int64_t raw, int shift )
+{
+	FIX_ASSERT( shift >= 0 );
+	FIX_ASSERT( shift < 63 );
+
+	const int64_t half = ( (int64_t)1 << shift ) >> 1;
+
+	FIX_ASSERT( raw <= INT64_MAX - half );
+
+	// The add is unsigned so that a caller who ignores the assertion above gets defined
+	// two's-complement wrap instead of signed-overflow undefined behaviour. Identical bits
+	// for every input the assertion admits; the same form fixRoundToInt already uses.
+	return (int64_t)( (uint64_t)raw + (uint64_t)half ) >> shift;
+}
+
+/// Add `shift` fraction bits. Exact and lossless within the asserted range.
+FIX_ALWAYS_INLINE int64_t fixWiden( int64_t raw, int shift )
+{
+	FIX_ASSERT( shift >= 0 );
+	FIX_ASSERT( shift < 63 );
+	FIX_ASSERT( raw >= ( INT64_MIN >> shift ) && raw <= ( INT64_MAX >> shift ) );
+
+	// Through fixShiftLeft: shifting a negative value left is undefined behaviour in C
+	// even when it does not overflow, and half the values a signed world produces are
+	// negative. Same bits as the raw shift, and it keeps UBSan quiet.
+	return fixShiftLeft( raw, shift );
+}

--- a/extern/fixed/include/fixed/fixed_time.h
+++ b/extern/fixed/include/fixed/fixed_time.h
@@ -50,10 +50,6 @@ FIX_ALWAYS_INLINE double fixTimeToSeconds( fixTime t )
 /// Scale a time by a Q48.16 factor, rounding to nearest. 128-bit interior.
 FIX_ALWAYS_INLINE fixTime fixTimeMulFixed( fixTime t, fixed_t s )
 {
-#if FIX_HAS_INT128
-	fixInt128 product = (fixInt128)t * s;
-	return (fixTime)( ( product + FIX_HALF ) >> FIX_FRACTION_BITS );
-#else
-#error "fixTimeMulFixed requires 128-bit integer support"
-#endif
+	fixInt128 product = fixInt128MulI64( t, s );
+	return (fixTime)fixInt128ToI64( fixInt128Shr( fixInt128Add( product, fixInt128FromI64( FIX_HALF ) ), FIX_FRACTION_BITS ) );
 }

--- a/extern/fixed/include/fixed/fixed_vec.h
+++ b/extern/fixed/include/fixed/fixed_vec.h
@@ -7,6 +7,7 @@
 #pragma once
 #include "fixed/base.h"
 #include "fixed/fixed.h"
+#include "fixed/fixed_int256.h"
 #include "fixed/fixed_math.h"
 
 /// A 2D vector.
@@ -120,15 +121,11 @@ FIX_INLINE int fixClampInt( int a, int lower, int upper )
 
 // fixAbs, fixMin, fixMax, and fixClamp live in fixed.h
 
-/// Interpolate a scalar.
-FIX_INLINE fixed_t fixLerp( fixed_t a, fixed_t b, fixed_t alpha )
-{
-	return fixMul( ( FIX( 1.0f ) - alpha ) , a ) + fixMul( alpha , b );
-}
-
-// fixAtan2, fixComputeCosSin, fixSin, fixCos, and fixUnwindAngle are provided by
-// fixed/fixed_math.h (included above). fixed3d's physics calls them; the vendored
-// `fixed` library owns their declarations and definitions.
+// fixLerp, fixAtan2, fixComputeCosSin, fixSin, fixCos, and fixUnwindAngle are provided
+// by fixed/fixed_math.h (included above). fixed3d's physics calls them; the vendored
+// `fixed` library owns their declarations and definitions. fixLerp is scalar math and
+// lives with the rest of the scalar math, not in the vector header that happens to have
+// been its first caller.
 
 /// Vector addition.
 FIX_INLINE fixVec3 fixVecAdd( fixVec3 a, fixVec3 b )
@@ -159,25 +156,26 @@ FIX_INLINE fixVec3 fixVecNeg( fixVec3 a )
 /// raw value are exact even for sub-resolution results.
 FIX_INLINE fixInt128 fixDotRaw( fixVec3 a, fixVec3 b )
 {
-	return (fixInt128)a.x * b.x + (fixInt128)a.y * b.y + (fixInt128)a.z * b.z;
+	return fixInt128Add( fixInt128Add( fixInt128MulI64( a.x, b.x ), fixInt128MulI64( a.y, b.y ) ),
+						 fixInt128MulI64( a.z, b.z ) );
 }
 
 /// Round a raw 128-bit dot product to fixed point with a single round-half-up
 /// step (divide last), matching fixMul rounding and overflow policy.
 FIX_INLINE fixed_t fixFromDotRaw( fixInt128 raw )
 {
-	fixInt128 r = ( raw + FIX_HALF ) >> FIX_FRACTION_BITS;
+	fixInt128 r = fixInt128Shr( fixInt128Add( raw, fixInt128FromI64( FIX_HALF ) ), FIX_FRACTION_BITS );
 #if defined( FIX_SATURATE )
-	if ( r > (fixInt128)INT64_MAX )
+	if ( fixInt128Gt( r, fixInt128FromI64( INT64_MAX ) ) )
 	{
 		return FIX_MAX;
 	}
-	if ( r < -(fixInt128)INT64_MAX )
+	if ( fixInt128Lt( r, fixInt128FromI64( -INT64_MAX ) ) )
 	{
 		return FIX_MIN;
 	}
 #endif
-	return (fixed_t)r;
+	return (fixed_t)fixInt128ToI64( r );
 }
 
 /// Vector dot product. Accumulated at 128 bits with a single rounding (divide last).
@@ -190,8 +188,8 @@ FIX_INLINE fixed_t fixDot( fixVec3 a, fixVec3 b )
 /// it is accurate even for vectors far below unit length.
 FIX_INLINE fixed_t fixLength( fixVec3 v )
 {
-	fixInt128 ls = (fixInt128)v.x * v.x + (fixInt128)v.y * v.y + (fixInt128)v.z * v.z; // Q32.32 in 128 bits
-	return (fixed_t)fixISqrt128High( (uint64_t)( (fixUInt128)ls >> 64 ), (uint64_t)ls );
+	fixInt128 ls = fixDotRaw( v, v ); // Q32.32 in 128 bits
+	return (fixed_t)fixISqrt128High( fixInt128Hi( ls ), fixInt128Lo( ls ) );
 }
 
 /// Vector length squared. One rounding on the exact 128-bit sum of squares.
@@ -219,10 +217,10 @@ FIX_INLINE fixed_t fixDistanceSquared( fixVec3 a, fixVec3 b )
 /// vectors far below unit length normalize to within an ulp of unit length.
 FIX_INLINE fixVec3 fixNormalize( fixVec3 a )
 {
-	fixInt128 ls = (fixInt128)a.x * a.x + (fixInt128)a.y * a.y + (fixInt128)a.z * a.z; // Q32.32 in 128 bits
-	if ( ls > 0 )
+	fixInt128 ls = fixDotRaw( a, a ); // Q32.32 in 128 bits
+	if ( fixInt128Gt( ls, FIX_INT128_ZERO ) )
 	{
-		fixed_t length = (fixed_t)fixISqrt128High( (uint64_t)( (fixUInt128)ls >> 64 ), (uint64_t)ls );
+		fixed_t length = (fixed_t)fixISqrt128High( fixInt128Hi( ls ), fixInt128Lo( ls ) );
 		// fixDiv computes the same truncating 128-bit quotient, with a single
 		// hardware divide when the component fits in 47 bits (the common case)
 		fixVec3 u = {
@@ -428,8 +426,7 @@ FIX_INLINE fixVec3 fixInvRotateVector( fixQuat q, fixVec3 v )
 /// One rounding on the exact 128-bit sum.
 FIX_INLINE fixed_t fixDotQuat( fixQuat a, fixQuat b )
 {
-	return fixFromDotRaw( (fixInt128)a.v.x * b.v.x + (fixInt128)a.v.y * b.v.y + (fixInt128)a.v.z * b.v.z +
-							(fixInt128)a.s * b.s );
+	return fixFromDotRaw( fixInt128Add( fixDotRaw( a.v, b.v ), fixInt128MulI64( a.s, b.s ) ) );
 }
 
 /// Multiply two quaternions. Each component is a fused 128-bit reduction with
@@ -440,15 +437,20 @@ FIX_INLINE fixQuat fixMulQuat( fixQuat q1, fixQuat q2 )
 	// s = q1.s * q2.s - dot(q1.v, q2.v)
 	fixQuat q = {
 		{
-			fixFromDotRaw( (fixInt128)q1.v.y * q2.v.z - (fixInt128)q1.v.z * q2.v.y + (fixInt128)q1.s * q2.v.x +
-							 (fixInt128)q2.s * q1.v.x ),
-			fixFromDotRaw( (fixInt128)q1.v.z * q2.v.x - (fixInt128)q1.v.x * q2.v.z + (fixInt128)q1.s * q2.v.y +
-							 (fixInt128)q2.s * q1.v.y ),
-			fixFromDotRaw( (fixInt128)q1.v.x * q2.v.y - (fixInt128)q1.v.y * q2.v.x + (fixInt128)q1.s * q2.v.z +
-							 (fixInt128)q2.s * q1.v.z ),
+			fixFromDotRaw( fixInt128Add(
+				fixInt128Add( fixInt128Sub( fixInt128MulI64( q1.v.y, q2.v.z ), fixInt128MulI64( q1.v.z, q2.v.y ) ),
+							  fixInt128MulI64( q1.s, q2.v.x ) ),
+				fixInt128MulI64( q2.s, q1.v.x ) ) ),
+			fixFromDotRaw( fixInt128Add(
+				fixInt128Add( fixInt128Sub( fixInt128MulI64( q1.v.z, q2.v.x ), fixInt128MulI64( q1.v.x, q2.v.z ) ),
+							  fixInt128MulI64( q1.s, q2.v.y ) ),
+				fixInt128MulI64( q2.s, q1.v.y ) ) ),
+			fixFromDotRaw( fixInt128Add(
+				fixInt128Add( fixInt128Sub( fixInt128MulI64( q1.v.x, q2.v.y ), fixInt128MulI64( q1.v.y, q2.v.x ) ),
+							  fixInt128MulI64( q1.s, q2.v.z ) ),
+				fixInt128MulI64( q2.s, q1.v.z ) ) ),
 		},
-		fixFromDotRaw( (fixInt128)q1.s * q2.s - (fixInt128)q1.v.x * q2.v.x - (fixInt128)q1.v.y * q2.v.y -
-						 (fixInt128)q1.v.z * q2.v.z ),
+		fixFromDotRaw( fixInt128Sub( fixInt128MulI64( q1.s, q2.s ), fixDotRaw( q1.v, q2.v ) ) ),
 	};
 	return q;
 }
@@ -461,15 +463,20 @@ FIX_INLINE fixQuat fixInvMulQuat( fixQuat q1, fixQuat q2 )
 	// s = q1.s * q2.s + dot(q1.v, q2.v)
 	fixQuat q = {
 		{
-			fixFromDotRaw( (fixInt128)q2.v.y * q1.v.z - (fixInt128)q2.v.z * q1.v.y + (fixInt128)q1.s * q2.v.x -
-							 (fixInt128)q2.s * q1.v.x ),
-			fixFromDotRaw( (fixInt128)q2.v.z * q1.v.x - (fixInt128)q2.v.x * q1.v.z + (fixInt128)q1.s * q2.v.y -
-							 (fixInt128)q2.s * q1.v.y ),
-			fixFromDotRaw( (fixInt128)q2.v.x * q1.v.y - (fixInt128)q2.v.y * q1.v.x + (fixInt128)q1.s * q2.v.z -
-							 (fixInt128)q2.s * q1.v.z ),
+			fixFromDotRaw( fixInt128Sub(
+				fixInt128Add( fixInt128Sub( fixInt128MulI64( q2.v.y, q1.v.z ), fixInt128MulI64( q2.v.z, q1.v.y ) ),
+							  fixInt128MulI64( q1.s, q2.v.x ) ),
+				fixInt128MulI64( q2.s, q1.v.x ) ) ),
+			fixFromDotRaw( fixInt128Sub(
+				fixInt128Add( fixInt128Sub( fixInt128MulI64( q2.v.z, q1.v.x ), fixInt128MulI64( q2.v.x, q1.v.z ) ),
+							  fixInt128MulI64( q1.s, q2.v.y ) ),
+				fixInt128MulI64( q2.s, q1.v.y ) ) ),
+			fixFromDotRaw( fixInt128Sub(
+				fixInt128Add( fixInt128Sub( fixInt128MulI64( q2.v.x, q1.v.y ), fixInt128MulI64( q2.v.y, q1.v.x ) ),
+							  fixInt128MulI64( q1.s, q2.v.z ) ),
+				fixInt128MulI64( q2.s, q1.v.z ) ) ),
 		},
-		fixFromDotRaw( (fixInt128)q1.s * q2.s + (fixInt128)q1.v.x * q2.v.x + (fixInt128)q1.v.y * q2.v.y +
-						 (fixInt128)q1.v.z * q2.v.z ),
+		fixFromDotRaw( fixInt128Add( fixInt128MulI64( q1.s, q2.s ), fixDotRaw( q1.v, q2.v ) ) ),
 	};
 	return q;
 }
@@ -489,10 +496,10 @@ FIX_INLINE fixQuat fixNegateQuat( fixQuat q )
 /// Normalize a quaternion at 128-bit precision, see fixNormalize.
 FIX_INLINE fixQuat fixNormalizeQuat( fixQuat q )
 {
-	fixInt128 ls = (fixInt128)q.v.x * q.v.x + (fixInt128)q.v.y * q.v.y + (fixInt128)q.v.z * q.v.z + (fixInt128)q.s * q.s;
-	if ( ls > 0 )
+	fixInt128 ls = fixInt128Add( fixDotRaw( q.v, q.v ), fixInt128MulI64( q.s, q.s ) );
+	if ( fixInt128Gt( ls, FIX_INT128_ZERO ) )
 	{
-		fixed_t length = (fixed_t)fixISqrt128High( (uint64_t)( (fixUInt128)ls >> 64 ), (uint64_t)ls );
+		fixed_t length = (fixed_t)fixISqrt128High( fixInt128Hi( ls ), fixInt128Lo( ls ) );
 		// fixDiv computes the same truncating quotient, with a single hardware
 		// divide for the near-unit components this always sees
 		fixQuat qn = {
@@ -734,14 +741,47 @@ FIX_INLINE fixed_t fixDet( fixMatrix3 m )
 	return fixDot( m.cx, fixCross( m.cy, m.cz ) );
 }
 
-#if FIX_HAS_INT128
 // Internal: 3x3 cofactors at Q32.32 in 128 bits and the determinant at Q16.48.
 // The Q48.16 determinant of a matrix with small entries (like the inertia of a
 // small body) underflows to zero, so the inverse and solve helpers work at
 // full precision internally.
 FIX_INLINE fixInt128 fixCofactor128( fixed_t a, fixed_t b, fixed_t c, fixed_t d )
 {
-	return (fixInt128)a * b - (fixInt128)c * d; // Q32.32
+	return fixInt128Sub( fixInt128MulI64( a, b ), fixInt128MulI64( c, d ) ); // Q32.32
+}
+
+/// Internal: ( numerator << shift ) / denominator, truncated to Q48.16. The shift routes
+/// through fixInt128ShiftLeft because the numerators here are signed cofactors and a raw
+/// left shift of a negative value is undefined.
+///
+/// SATURATES rather than truncating to 64 bits. A ratio outside Q48.16 range -- the
+/// inverse of a matrix close enough to singular that its inverse does not fit -- used to
+/// keep the low 64 bits of the quotient, which is a value of arbitrary magnitude AND
+/// arbitrary sign. Saturating keeps the one property every caller relies on: a large
+/// inverse reads as large, and its sign is the sign of the true ratio.
+FIX_INLINE fixed_t fixDivShifted( fixInt128 numerator, int shift, fixInt128 denominator )
+{
+	fixInt128 quotient = fixInt128Div( fixInt128ShiftLeft( numerator, shift ), denominator );
+
+	bool representable = fixInt128Le( quotient, fixInt128FromI64( FIX_MAX ) ) && fixInt128Ge( quotient, fixInt128FromI64( FIX_MIN ) );
+	FIX_VALIDATE( representable );
+	if ( representable == false )
+	{
+		return fixInt128IsNegative( quotient ) ? FIX_MIN : FIX_MAX;
+	}
+
+	return (fixed_t)fixInt128ToI64( quotient );
+}
+
+/// Internal: is a 128-bit value strictly inside +/- limit?
+///
+/// The range test that decides whether the 128-bit arm of the inverse and the solve can
+/// stay exact. Those arms cast cofactors to int64 and shift numerators left, so every
+/// value they touch has to be small enough for both -- which is why the tests below name
+/// all nine cofactors rather than the three the determinant expands along.
+FIX_ALWAYS_INLINE bool fixInt128InRange( fixInt128 c, fixInt128 limit )
+{
+	return fixInt128Lt( fixInt128Neg( limit ), c ) && fixInt128Lt( c, limit );
 }
 
 /// Validity predicates for the fixed-point math types.
@@ -957,8 +997,6 @@ FIX_INLINE bool fixIsValidAABB( fixAABB a )
 	return true;
 }
 
-#endif
-
 /// Multiply a matrix times a column vector.
 FIX_INLINE fixVec3 fixMulMV( fixMatrix3 m, fixVec3 a )
 {
@@ -1037,7 +1075,113 @@ FIX_INLINE fixMatrix3 fixTranspose( fixMatrix3 m )
 	return out;
 }
 
+/// Internal: the exact ratio ( cofactor << shift ) / determinant, at 256 bits.
+///
+/// The wide arm's counterpart to fixDivShifted, and the reason the wide arm exists: the
+/// numerator reaches 158 bits and the denominator 190, so neither the shift nor the
+/// division fits in 128. Truncated toward zero, matching fixInt128Div, and saturating on
+/// a ratio outside Q48.16 range, matching fixDivShifted.
+///
+/// A ratio whose magnitude is below one quantum comes back as zero. That is the exact
+/// answer and not a failure: the inverse of a matrix this large IS smaller than Q48.16
+/// can hold, and the honest report of an unrepresentable inverse is that it rounds away.
+/// Callers that care about the difference between "zero because static" and "zero because
+/// too large to invert" test the input, not the output -- see fixed3d's b3UpdateBodyMassData.
+FIX_INLINE fixed_t fixDivShifted256( fixUInt256 numerator, int shift, fixUInt256 absDeterminant, bool determinantNegative )
+{
+	bool numeratorNegative = fixInt256IsNegative( numerator );
+	fixUInt256 scaled = fixUInt256Shl( fixInt256Abs( numerator ), shift );
+
+	fixUInt256 quotient;
+	fixUInt256 remainder;
+	fixUInt256DivMod( scaled, absDeterminant, &quotient, &remainder );
+
+	bool negative = numeratorNegative != determinantNegative;
+
+	bool representable = fixUInt128Eq( quotient.hi, FIX_UINT128_ZERO ) &&
+						 fixUInt128Le( quotient.lo, fixUInt128FromU64( (uint64_t)FIX_MAX ) );
+	FIX_VALIDATE( representable );
+	if ( representable == false )
+	{
+		return negative ? FIX_MIN : FIX_MAX;
+	}
+
+	int64_t magnitude = (int64_t)fixUInt128Lo( quotient.lo );
+	return negative ? -magnitude : magnitude;
+}
+
+/// Internal: the same ratio for a numerator that is still only 128 bits wide, which is
+/// every entry of the inverse. Widening first and dividing once keeps one implementation
+/// of the rounding and the saturation rather than two that must be kept in step.
+FIX_INLINE fixed_t fixDivShiftedWide( fixInt128 numerator, int shift, fixUInt256 absDeterminant, bool determinantNegative )
+{
+	bool numeratorNegative = fixInt128IsNegative( numerator );
+	fixUInt128 absNumerator =
+		numeratorNegative ? fixUInt128Neg( fixInt128ToUnsigned( numerator ) ) : fixInt128ToUnsigned( numerator );
+
+	fixUInt256 widened = fixUInt256FromU128( absNumerator );
+	return fixDivShifted256( numeratorNegative ? fixUInt256Neg( widened ) : widened, shift, absDeterminant, determinantNegative );
+}
+
+/// Internal: the exact inverse of a matrix whose cofactors are too large for 128-bit
+/// arithmetic. Same value the 128-bit arm computes, carried at a width that cannot
+/// overflow, so the two arms differ only in cost.
+///
+/// This replaces a reduction that dropped 16 fraction bits from each cofactor and then
+/// cast the result to int64 to accumulate the determinant. Both steps were silent: the
+/// cast wrapped for any cofactor past 2^79, and the determinant itself overflowed 128
+/// bits shortly after, so the answer became a number of arbitrary sign rather than a
+/// refusal. Nothing about the wide arm can wrap -- the determinant is exact at 256 bits,
+/// every entry is the exact truncated ratio, and a ratio outside Q48.16 saturates.
+///
+/// The cofactors are recomputed rather than handed in. This arm runs at mass-data time,
+/// where nine extra multiplies cost nothing, and a nine-argument signature would be
+/// carried by the 128-bit arm as well.
+FIX_INLINE fixMatrix3 fixInvertMatrixWide( fixMatrix3 m )
+{
+	fixInt128 c00 = fixCofactor128( m.cy.y, m.cz.z, m.cy.z, m.cz.y );
+	fixInt128 c01 = fixCofactor128( m.cy.z, m.cz.x, m.cy.x, m.cz.z );
+	fixInt128 c02 = fixCofactor128( m.cy.x, m.cz.y, m.cy.y, m.cz.x );
+	fixInt128 c10 = fixCofactor128( m.cz.y, m.cx.z, m.cz.z, m.cx.y );
+	fixInt128 c11 = fixCofactor128( m.cz.z, m.cx.x, m.cz.x, m.cx.z );
+	fixInt128 c12 = fixCofactor128( m.cz.x, m.cx.y, m.cz.y, m.cx.x );
+	fixInt128 c20 = fixCofactor128( m.cx.y, m.cy.z, m.cx.z, m.cy.y );
+	fixInt128 c21 = fixCofactor128( m.cx.z, m.cy.x, m.cx.x, m.cy.z );
+	fixInt128 c22 = fixCofactor128( m.cx.x, m.cy.y, m.cx.y, m.cy.x );
+
+	// Determinant by expansion along the first row of the cofactor matrix, exact at
+	// Q**.48 in 256 bits.
+	fixUInt256 det = fixUInt256Add( fixUInt256Add( fixInt256MulI128ByI64( c00, m.cx.x ), fixInt256MulI128ByI64( c10, m.cy.x ) ),
+									fixInt256MulI128ByI64( c20, m.cz.x ) );
+
+	if ( fixUInt256IsZero( det ) )
+	{
+		return fixMat3_zero;
+	}
+
+	bool negative = fixInt256IsNegative( det );
+	fixUInt256 absDet = fixInt256Abs( det );
+
+	// inverse_ij = cofactor_ji / det: (Q32.32 << 32) / Q**.48 -> Q48.16
+	fixMatrix3 out;
+	out.cx = FIX_LITERAL( fixVec3 ){ fixDivShiftedWide( c00, 32, absDet, negative ), fixDivShiftedWide( c10, 32, absDet, negative ),
+								   fixDivShiftedWide( c20, 32, absDet, negative ) };
+	out.cy = FIX_LITERAL( fixVec3 ){ fixDivShiftedWide( c01, 32, absDet, negative ), fixDivShiftedWide( c11, 32, absDet, negative ),
+								   fixDivShiftedWide( c21, 32, absDet, negative ) };
+	out.cz = FIX_LITERAL( fixVec3 ){ fixDivShiftedWide( c02, 32, absDet, negative ), fixDivShiftedWide( c12, 32, absDet, negative ),
+								   fixDivShiftedWide( c22, 32, absDet, negative ) };
+	return out;
+}
+
 /// General matrix inverse.
+///
+/// REPRESENTABILITY. The result is Q48.16, so an inverse entry below one quantum
+/// (1/65536) rounds to zero and an entry past FIX_MAX saturates. For an inertia tensor
+/// that means a body whose principal inertia exceeds 65,536 units has no representable
+/// inverse inertia at all and gets a zero matrix -- a uniform solid cube crosses that
+/// line at about 13.1 units on a side. This is a property of the format, not of the
+/// algorithm: both arms below compute the same exact ratio, and both round it the same
+/// way. What changed is that they now say so instead of returning wrapped bits.
 FIX_INLINE fixMatrix3 fixInvertMatrix( fixMatrix3 m )
 {
 	// Full precision cofactors (Q32.32 in 128 bits) so small matrices like the
@@ -1052,51 +1196,88 @@ FIX_INLINE fixMatrix3 fixInvertMatrix( fixMatrix3 m )
 	fixInt128 c21 = fixCofactor128( m.cx.z, m.cy.x, m.cx.x, m.cy.z );
 	fixInt128 c22 = fixCofactor128( m.cx.x, m.cy.y, m.cx.y, m.cy.x );
 
-	fixInt128 limit = (fixInt128)1 << 62;
-	if ( -limit < c00 && c00 < limit && -limit < c10 && c10 < limit && -limit < c20 && c20 < limit )
+	// EVERY cofactor inside the limit, not just the three the determinant expands along.
+	// The arm below casts all nine to int64 and shifts all nine left by 32, so a large
+	// off-column cofactor overflows it just as surely as a large in-column one -- it was
+	// simply never tested, because the three checked cofactors dominate for a symmetric
+	// inertia tensor and hid the rest.
+	fixInt128 limit = fixInt128ShiftLeft( fixInt128FromI64( 1 ), 62 );
+	if ( fixInt128InRange( c00, limit ) && fixInt128InRange( c01, limit ) && fixInt128InRange( c02, limit ) &&
+		 fixInt128InRange( c10, limit ) && fixInt128InRange( c11, limit ) && fixInt128InRange( c12, limit ) &&
+		 fixInt128InRange( c20, limit ) && fixInt128InRange( c21, limit ) && fixInt128InRange( c22, limit ) )
 	{
-		// Exact path: cofactors fit in 64 bits, determinant at Q16.48
-		fixInt128 det = (fixInt128)m.cx.x * (int64_t)c00 + (fixInt128)m.cy.x * (int64_t)c10 + (fixInt128)m.cz.x * (int64_t)c20;
-		if ( det != 0 )
+		// Exact path: cofactors fit in 64 bits, determinant at Q16.48. Every product
+		// below is bounded by 2^125 and the sum of three by 2^127, so nothing here can
+		// overflow -- the limit is what buys that.
+		fixInt128 det = fixInt128Add( fixInt128Add( fixInt128MulI64( m.cx.x, fixInt128ToI64( c00 ) ),
+												   fixInt128MulI64( m.cy.x, fixInt128ToI64( c10 ) ) ),
+									  fixInt128MulI64( m.cz.x, fixInt128ToI64( c20 ) ) );
+		if ( !fixInt128Eq( det, FIX_INT128_ZERO ) )
 		{
 			// inverse_ij = cofactor_ji / det: (Q32.32 << 32) / Q16.48 -> Q48.16
 			fixMatrix3 out;
-			out.cx = FIX_LITERAL( fixVec3 ){ (fixed_t)fixInt128Div( fixInt128ShiftLeft( c00, 32 ), det ),
-										   (fixed_t)fixInt128Div( fixInt128ShiftLeft( c10, 32 ), det ),
-										   (fixed_t)fixInt128Div( fixInt128ShiftLeft( c20, 32 ), det ) };
-			out.cy = FIX_LITERAL( fixVec3 ){ (fixed_t)fixInt128Div( fixInt128ShiftLeft( c01, 32 ), det ),
-										   (fixed_t)fixInt128Div( fixInt128ShiftLeft( c11, 32 ), det ),
-										   (fixed_t)fixInt128Div( fixInt128ShiftLeft( c21, 32 ), det ) };
-			out.cz = FIX_LITERAL( fixVec3 ){ (fixed_t)fixInt128Div( fixInt128ShiftLeft( c02, 32 ), det ),
-										   (fixed_t)fixInt128Div( fixInt128ShiftLeft( c12, 32 ), det ),
-										   (fixed_t)fixInt128Div( fixInt128ShiftLeft( c22, 32 ), det ) };
+			out.cx = FIX_LITERAL( fixVec3 ){ fixDivShifted( c00, 32, det ), fixDivShifted( c10, 32, det ),
+										   fixDivShifted( c20, 32, det ) };
+			out.cy = FIX_LITERAL( fixVec3 ){ fixDivShifted( c01, 32, det ), fixDivShifted( c11, 32, det ),
+										   fixDivShifted( c21, 32, det ) };
+			out.cz = FIX_LITERAL( fixVec3 ){ fixDivShifted( c02, 32, det ), fixDivShifted( c12, 32, det ),
+										   fixDivShifted( c22, 32, det ) };
 			return out;
 		}
 		return fixMat3_zero;
 	}
 
-	// Huge matrix path: drop 16 fraction bits from the cofactors to keep the
-	// determinant accumulation in range
-	fixInt128 det = (fixInt128)m.cx.x * (int64_t)( c00 >> 16 ) + (fixInt128)m.cy.x * (int64_t)( c10 >> 16 ) +
-				   (fixInt128)m.cz.x * (int64_t)( c20 >> 16 ); // ~Q16.32
-	if ( det != 0 )
+	// Anything larger goes wide, where the same ratio is computed at a width that cannot
+	// overflow. The two arms agree exactly wherever both are defined, so which one runs
+	// is a question of cost and never of answer.
+	return fixInvertMatrixWide( m );
+}
+
+/// Internal: the exact solve of a system whose cofactors are too large for 128-bit
+/// arithmetic. The wide counterpart of the direct solve, not of the inverse -- it keeps
+/// the one-division-per-component form all the way out to the top of the range.
+///
+/// Each numerator is a cofactor (126 bits) against a component (64), summed three ways
+/// and then shifted up 16, which reaches 208 bits. The determinant reaches 190. Both are
+/// exact here, so the result is the same truncated rational the 128-bit arm computes and
+/// the two arms differ only in cost.
+FIX_INLINE fixVec3 fixSolve3Wide( fixMatrix3 m, fixVec3 a )
+{
+	fixInt128 c00 = fixCofactor128( m.cy.y, m.cz.z, m.cy.z, m.cz.y );
+	fixInt128 c01 = fixCofactor128( m.cy.z, m.cz.x, m.cy.x, m.cz.z );
+	fixInt128 c02 = fixCofactor128( m.cy.x, m.cz.y, m.cy.y, m.cz.x );
+	fixInt128 c10 = fixCofactor128( m.cz.y, m.cx.z, m.cz.z, m.cx.y );
+	fixInt128 c11 = fixCofactor128( m.cz.z, m.cx.x, m.cz.x, m.cx.z );
+	fixInt128 c12 = fixCofactor128( m.cz.x, m.cx.y, m.cz.y, m.cx.x );
+	fixInt128 c20 = fixCofactor128( m.cx.y, m.cy.z, m.cx.z, m.cy.y );
+	fixInt128 c21 = fixCofactor128( m.cx.z, m.cy.x, m.cx.x, m.cy.z );
+	fixInt128 c22 = fixCofactor128( m.cx.x, m.cy.y, m.cx.y, m.cy.x );
+
+	fixUInt256 det = fixUInt256Add( fixUInt256Add( fixInt256MulI128ByI64( c00, m.cx.x ), fixInt256MulI128ByI64( c10, m.cy.x ) ),
+									fixInt256MulI128ByI64( c20, m.cz.x ) );
+	if ( fixUInt256IsZero( det ) )
 	{
-		// fixInt128ShiftLeft: the raw << the float era used here is UB for the
-		// negative cofactors this path exists for (same bits, defined behavior)
-		fixMatrix3 out;
-		out.cx = FIX_LITERAL( fixVec3 ){ (fixed_t)fixInt128Div( fixInt128ShiftLeft( c00, 16 ), det ),
-									   (fixed_t)fixInt128Div( fixInt128ShiftLeft( c10, 16 ), det ),
-									   (fixed_t)fixInt128Div( fixInt128ShiftLeft( c20, 16 ), det ) };
-		out.cy = FIX_LITERAL( fixVec3 ){ (fixed_t)fixInt128Div( fixInt128ShiftLeft( c01, 16 ), det ),
-									   (fixed_t)fixInt128Div( fixInt128ShiftLeft( c11, 16 ), det ),
-									   (fixed_t)fixInt128Div( fixInt128ShiftLeft( c21, 16 ), det ) };
-		out.cz = FIX_LITERAL( fixVec3 ){ (fixed_t)fixInt128Div( fixInt128ShiftLeft( c02, 16 ), det ),
-									   (fixed_t)fixInt128Div( fixInt128ShiftLeft( c12, 16 ), det ),
-									   (fixed_t)fixInt128Div( fixInt128ShiftLeft( c22, 16 ), det ) };
-		return out;
+		return fixVec3_zero;
 	}
 
-	return fixMat3_zero;
+	bool negative = fixInt256IsNegative( det );
+	fixUInt256 absDet = fixInt256Abs( det );
+
+	// Two's complement sums: a wrapping 256-bit add is the signed add, and nothing here
+	// comes close to the width.
+	fixUInt256 nx = fixUInt256Add( fixUInt256Add( fixInt256MulI128ByI64( c00, a.x ), fixInt256MulI128ByI64( c01, a.y ) ),
+								   fixInt256MulI128ByI64( c02, a.z ) );
+	fixUInt256 ny = fixUInt256Add( fixUInt256Add( fixInt256MulI128ByI64( c10, a.x ), fixInt256MulI128ByI64( c11, a.y ) ),
+								   fixInt256MulI128ByI64( c12, a.z ) );
+	fixUInt256 nz = fixUInt256Add( fixUInt256Add( fixInt256MulI128ByI64( c20, a.x ), fixInt256MulI128ByI64( c21, a.y ) ),
+								   fixInt256MulI128ByI64( c22, a.z ) );
+
+	fixVec3 b = {
+		fixDivShifted256( nx, 16, absDet, negative ),
+		fixDivShifted256( ny, 16, absDet, negative ),
+		fixDivShifted256( nz, 16, absDet, negative ),
+	};
+	return b;
 }
 
 /// Solve a matrix equation.
@@ -1115,31 +1296,63 @@ FIX_INLINE fixVec3 fixSolve3( fixMatrix3 m, fixVec3 a )
 	fixInt128 c21 = fixCofactor128( m.cx.z, m.cy.x, m.cx.x, m.cy.z );
 	fixInt128 c22 = fixCofactor128( m.cx.x, m.cy.y, m.cx.y, m.cy.x );
 
-	fixInt128 limit = (fixInt128)1 << 62;
-	if ( -limit < c00 && c00 < limit && -limit < c10 && c10 < limit && -limit < c20 && c20 < limit )
+	// EVERY cofactor inside the limit. The numerators below multiply all nine through
+	// fixInt128ToI64, not just the three the determinant expands along, so the three-way
+	// test this replaces let the other six wrap silently -- and unlike the inverse, this
+	// runs per substep in fixed3d's gyroscopic solve, where a wrapped cofactor becomes an
+	// angular velocity.
+	fixInt128 limit = fixInt128ShiftLeft( fixInt128FromI64( 1 ), 62 );
+	if ( fixInt128InRange( c00, limit ) && fixInt128InRange( c01, limit ) && fixInt128InRange( c02, limit ) &&
+		 fixInt128InRange( c10, limit ) && fixInt128InRange( c11, limit ) && fixInt128InRange( c12, limit ) &&
+		 fixInt128InRange( c20, limit ) && fixInt128InRange( c21, limit ) && fixInt128InRange( c22, limit ) )
 	{
 		// Exact path: cofactors fit in 64 bits, determinant at Q16.48
-		fixInt128 det = (fixInt128)m.cx.x * (int64_t)c00 + (fixInt128)m.cy.x * (int64_t)c10 + (fixInt128)m.cz.x * (int64_t)c20;
-		if ( det != 0 )
+		fixInt128 det = fixInt128Add( fixInt128Add( fixInt128MulI64( m.cx.x, fixInt128ToI64( c00 ) ),
+												   fixInt128MulI64( m.cy.x, fixInt128ToI64( c10 ) ) ),
+									  fixInt128MulI64( m.cz.x, fixInt128ToI64( c20 ) ) );
+		if ( !fixInt128Eq( det, FIX_INT128_ZERO ) )
 		{
 			// x_i = ( sum_j cofactor_ji * a_j ) / det: (Q32.32 * Q48.16 << 16) / Q16.48 -> Q48.16
-			fixInt128 nx = (fixInt128)(int64_t)c00 * a.x + (fixInt128)(int64_t)c01 * a.y + (fixInt128)(int64_t)c02 * a.z;
-			fixInt128 ny = (fixInt128)(int64_t)c10 * a.x + (fixInt128)(int64_t)c11 * a.y + (fixInt128)(int64_t)c12 * a.z;
-			fixInt128 nz = (fixInt128)(int64_t)c20 * a.x + (fixInt128)(int64_t)c21 * a.y + (fixInt128)(int64_t)c22 * a.z;
+			fixInt128 nx = fixInt128Add( fixInt128Add( fixInt128MulI64( fixInt128ToI64( c00 ), a.x ),
+													  fixInt128MulI64( fixInt128ToI64( c01 ), a.y ) ),
+										 fixInt128MulI64( fixInt128ToI64( c02 ), a.z ) );
+			fixInt128 ny = fixInt128Add( fixInt128Add( fixInt128MulI64( fixInt128ToI64( c10 ), a.x ),
+													  fixInt128MulI64( fixInt128ToI64( c11 ), a.y ) ),
+										 fixInt128MulI64( fixInt128ToI64( c12 ), a.z ) );
+			fixInt128 nz = fixInt128Add( fixInt128Add( fixInt128MulI64( fixInt128ToI64( c20 ), a.x ),
+													  fixInt128MulI64( fixInt128ToI64( c21 ), a.y ) ),
+										 fixInt128MulI64( fixInt128ToI64( c22 ), a.z ) );
 
-			fixVec3 b = {
-				(fixed_t)fixInt128Div( fixInt128ShiftLeft( nx, 16 ), det ),
-				(fixed_t)fixInt128Div( fixInt128ShiftLeft( ny, 16 ), det ),
-				(fixed_t)fixInt128Div( fixInt128ShiftLeft( nz, 16 ), det ),
-			};
-			return b;
+			// The numerators are about to be shifted left 16 places, so they need room
+			// for it. A cofactor inside the limit bounds each product by 2^125 and each
+			// numerator by 2^127, which is NOT enough -- the shift needs 2^111. Simulation
+			// values land far below this (a in-range angular residual keeps the
+			// numerators near 2^102), so the wide arm is the rare case rather than the
+			// working one, but "rare" and "impossible" are different words.
+			fixInt128 shiftLimit = fixInt128ShiftLeft( fixInt128FromI64( 1 ), 110 );
+			if ( fixInt128InRange( nx, shiftLimit ) && fixInt128InRange( ny, shiftLimit ) &&
+				 fixInt128InRange( nz, shiftLimit ) )
+			{
+				fixVec3 b = {
+					fixDivShifted( nx, 16, det ),
+					fixDivShifted( ny, 16, det ),
+					fixDivShifted( nz, 16, det ),
+				};
+				return b;
+			}
 		}
-		return fixVec3_zero;
+		else
+		{
+			return fixVec3_zero;
+		}
 	}
 
-	// Huge matrix path
-	fixMatrix3 inv = fixInvertMatrix( m );
-	return fixMulMV( inv, a );
+	// Anything larger solves wide, which is still one division per component and still
+	// one rounding. Inverting and multiplying was the old fallback and it is a worse
+	// answer for the same work: the inverse of a large matrix is a handful of quanta or
+	// none at all, so rounding it to Q48.16 and then multiplying rounds twice through the
+	// coarsest value in the calculation.
+	return fixSolve3Wide( m, a );
 }
 
 /// Inverse transpose of a matrix. Identical to the inverse for the symmetric

--- a/extern/fixed/include/fixed/fixed_wide.h
+++ b/extern/fixed/include/fixed/fixed_wide.h
@@ -11,12 +11,14 @@
 #include "fixed/fixed.h"
 #include "fixed/fixed_vec.h"
 
-#if !FIX_HAS_INT128
-#error "fixed_wide.h requires 128-bit integer support (clang, gcc, or clang-cl)"
-#endif
-
 /// Wide fixed-point scalar: Q112.16 in a 128-bit integer. Same resolution as
 /// fixed_t (1/65536); all 64 extra bits go to integer range (~±2.6e33 units).
+///
+/// On a compiler with __int128 this is that type and the operators work on it directly.
+/// On plain MSVC it is the emulated pair from fixed_int128.h and the operators do not,
+/// so PORTABLE CONSUMER CODE USES THE FUNCTIONS BELOW rather than `+` and `<`. Every
+/// operation this header needs has a named form for exactly that reason, comparisons
+/// included.
 typedef fixInt128 fixedWide_t;
 
 /// Wide world position: three Q112.16 coordinates.
@@ -28,34 +30,67 @@ typedef struct fixPosWide
 /// Widen a local Q48.16 value to Q112.16. Exact: the fraction points align.
 FIX_ALWAYS_INLINE fixedWide_t fixWideFromFixed( fixed_t a )
 {
-	return (fixedWide_t)a;
+	return fixInt128FromI64( a );
 }
 
 /// Narrow a Q112.16 value to local Q48.16, saturating out-of-range values to
 /// INT64_MAX/INT64_MIN. Exact whenever the value fits local range.
 FIX_ALWAYS_INLINE fixed_t fixWideToFixed( fixedWide_t a )
 {
-	if ( a > (fixedWide_t)INT64_MAX )
+	if ( fixInt128Gt( a, fixInt128FromI64( INT64_MAX ) ) )
 	{
 		return INT64_MAX;
 	}
-	if ( a < (fixedWide_t)INT64_MIN )
+	if ( fixInt128Lt( a, fixInt128FromI64( INT64_MIN ) ) )
 	{
 		return INT64_MIN;
 	}
-	return (fixed_t)a;
+	return (fixed_t)fixInt128ToI64( a );
 }
 
 /// Wide add. Exact 128-bit integer addition.
 FIX_ALWAYS_INLINE fixedWide_t fixWideAdd( fixedWide_t a, fixedWide_t b )
 {
-	return a + b;
+	return fixInt128Add( a, b );
 }
 
 /// Wide subtract. Exact 128-bit integer subtraction.
 FIX_ALWAYS_INLINE fixedWide_t fixWideSub( fixedWide_t a, fixedWide_t b )
 {
-	return a - b;
+	return fixInt128Sub( a, b );
+}
+
+/// Wide comparison. These exist because `<` does not compile on the emulated
+/// representation: a consumer that compares wide coordinates portably needs a name.
+FIX_ALWAYS_INLINE bool fixWideEq( fixedWide_t a, fixedWide_t b )
+{
+	return fixInt128Eq( a, b );
+}
+
+FIX_ALWAYS_INLINE bool fixWideLt( fixedWide_t a, fixedWide_t b )
+{
+	return fixInt128Lt( a, b );
+}
+
+FIX_ALWAYS_INLINE bool fixWideGt( fixedWide_t a, fixedWide_t b )
+{
+	return fixInt128Gt( a, b );
+}
+
+FIX_ALWAYS_INLINE bool fixWideLe( fixedWide_t a, fixedWide_t b )
+{
+	return fixInt128Le( a, b );
+}
+
+FIX_ALWAYS_INLINE bool fixWideGe( fixedWide_t a, fixedWide_t b )
+{
+	return fixInt128Ge( a, b );
+}
+
+/// Wide negation.
+FIX_ALWAYS_INLINE fixedWide_t fixWideNeg( fixedWide_t a )
+{
+	return fixInt128Neg( a );
 }
 
 /// Min/max on the wide (128-bit) fixed-point type.
@@ -66,19 +101,19 @@ FIX_ALWAYS_INLINE fixedWide_t fixWideSub( fixedWide_t a, fixedWide_t b )
 /// type it uses, not by a compile flag that changes an ABI.
 FIX_ALWAYS_INLINE fixedWide_t fixWideMin( fixedWide_t a, fixedWide_t b )
 {
-	return a < b ? a : b;
+	return fixInt128Lt( a, b ) ? a : b;
 }
 
 FIX_ALWAYS_INLINE fixedWide_t fixWideMax( fixedWide_t a, fixedWide_t b )
 {
-	return a > b ? a : b;
+	return fixInt128Gt( a, b ) ? a : b;
 }
 
 /// Offset a wide coordinate by a local delta (the once-per-step delta-fold).
 /// Exact: int128 += widened int64, fraction points aligned.
 FIX_ALWAYS_INLINE fixedWide_t fixWideOffset( fixedWide_t a, fixed_t d )
 {
-	return a + (fixedWide_t)d;
+	return fixInt128Add( a, fixInt128FromI64( d ) );
 }
 
 /// The boundary operation: difference two wide world coordinates into local
@@ -87,13 +122,13 @@ FIX_ALWAYS_INLINE fixedWide_t fixWideOffset( fixedWide_t a, fixed_t d )
 /// fixed-point replacement for float's entire directed-rounding apparatus.
 FIX_ALWAYS_INLINE fixed_t fixWideSubToFixed( fixedWide_t a, fixedWide_t b )
 {
-	return fixWideToFixed( a - b );
+	return fixWideToFixed( fixInt128Sub( a, b ) );
 }
 
 /// Widen a local position/vector to a wide world position. Exact.
 FIX_ALWAYS_INLINE fixPosWide fixPosWideFromVec3( fixVec3 v )
 {
-	fixPosWide p = { (fixedWide_t)v.x, (fixedWide_t)v.y, (fixedWide_t)v.z };
+	fixPosWide p = { fixInt128FromI64( v.x ), fixInt128FromI64( v.y ), fixInt128FromI64( v.z ) };
 	return p;
 }
 
@@ -130,7 +165,7 @@ typedef struct fixWorldTransformWide
 /// quantity except the 128-bit minimum, which is reserved so negation cannot overflow.
 FIX_ALWAYS_INLINE bool fixIsValidWideCoord( fixedWide_t x )
 {
-	return x != (fixedWide_t)( (fixUInt128)1 << 127 );
+	return !fixInt128Eq( x, fixInt128Make( UINT64_C( 0x8000000000000000 ), 0 ) );
 }
 
 FIX_ALWAYS_INLINE bool fixIsValidPosWide( fixPosWide p )
@@ -168,9 +203,9 @@ FIX_ALWAYS_INLINE bool fixIsValidWorldTransformWide( fixWorldTransformWide t )
 FIX_ALWAYS_INLINE fixPosWide fixLerpPositionWide( fixPosWide a, fixPosWide b, fixed_t t )
 {
 	fixPosWide out = {
-		a.x + fixMul( t, fixWideSubToFixed( b.x, a.x ) ),
-		a.y + fixMul( t, fixWideSubToFixed( b.y, a.y ) ),
-		a.z + fixMul( t, fixWideSubToFixed( b.z, a.z ) ),
+		fixWideOffset( a.x, fixMul( t, fixWideSubToFixed( b.x, a.x ) ) ),
+		fixWideOffset( a.y, fixMul( t, fixWideSubToFixed( b.y, a.y ) ) ),
+		fixWideOffset( a.z, fixMul( t, fixWideSubToFixed( b.z, a.z ) ) ),
 	};
 	return out;
 }
@@ -250,8 +285,15 @@ FIX_ALWAYS_INLINE fixAABBWide fixMakeAABBWide( const fixPosWide* points, int cou
 		a.upperBound.z = fixWideMax( a.upperBound.z, points[i].z );
 	}
 
-	a.lowerBound.x -= radius; a.lowerBound.y -= radius; a.lowerBound.z -= radius;
-	a.upperBound.x += radius; a.upperBound.y += radius; a.upperBound.z += radius;
+	// Subtracting the widened radius rather than offsetting by its negation: the two agree
+	// everywhere except at INT64_MIN, where negating a fixed_t has no value.
+	fixedWide_t wideRadius = fixWideFromFixed( radius );
+	a.lowerBound.x = fixWideSub( a.lowerBound.x, wideRadius );
+	a.lowerBound.y = fixWideSub( a.lowerBound.y, wideRadius );
+	a.lowerBound.z = fixWideSub( a.lowerBound.z, wideRadius );
+	a.upperBound.x = fixWideAdd( a.upperBound.x, wideRadius );
+	a.upperBound.y = fixWideAdd( a.upperBound.y, wideRadius );
+	a.upperBound.z = fixWideAdd( a.upperBound.z, wideRadius );
 
 	return a;
 }
@@ -259,9 +301,9 @@ FIX_ALWAYS_INLINE fixAABBWide fixMakeAABBWide( const fixPosWide* points, int cou
 /// Does a fully contain b?
 FIX_ALWAYS_INLINE bool fixAABBWide_Contains( fixAABBWide a, fixAABBWide b )
 {
-	if ( a.lowerBound.x > b.lowerBound.x || b.upperBound.x > a.upperBound.x ) return false;
-	if ( a.lowerBound.y > b.lowerBound.y || b.upperBound.y > a.upperBound.y ) return false;
-	if ( a.lowerBound.z > b.lowerBound.z || b.upperBound.z > a.upperBound.z ) return false;
+	if ( fixWideGt( a.lowerBound.x, b.lowerBound.x ) || fixWideGt( b.upperBound.x, a.upperBound.x ) ) return false;
+	if ( fixWideGt( a.lowerBound.y, b.lowerBound.y ) || fixWideGt( b.upperBound.y, a.upperBound.y ) ) return false;
+	if ( fixWideGt( a.lowerBound.z, b.lowerBound.z ) || fixWideGt( b.upperBound.z, a.upperBound.z ) ) return false;
 	return true;
 }
 
@@ -337,18 +379,23 @@ FIX_ALWAYS_INLINE fixAABBWide fixAABBWide_Union( fixAABBWide a, fixAABBWide b )
 /// Add uniform local padding to a wide box.
 FIX_ALWAYS_INLINE fixAABBWide fixAABBWide_Inflate( fixAABBWide a, fixed_t extension )
 {
+	fixedWide_t wideExtension = fixWideFromFixed( extension );
 	fixAABBWide out = a;
-	out.lowerBound.x -= extension; out.lowerBound.y -= extension; out.lowerBound.z -= extension;
-	out.upperBound.x += extension; out.upperBound.y += extension; out.upperBound.z += extension;
+	out.lowerBound.x = fixWideSub( out.lowerBound.x, wideExtension );
+	out.lowerBound.y = fixWideSub( out.lowerBound.y, wideExtension );
+	out.lowerBound.z = fixWideSub( out.lowerBound.z, wideExtension );
+	out.upperBound.x = fixWideAdd( out.upperBound.x, wideExtension );
+	out.upperBound.y = fixWideAdd( out.upperBound.y, wideExtension );
+	out.upperBound.z = fixWideAdd( out.upperBound.z, wideExtension );
 	return out;
 }
 
 /// Do two wide boxes overlap?
 FIX_ALWAYS_INLINE bool fixAABBWide_Overlaps( fixAABBWide a, fixAABBWide b )
 {
-	if ( a.upperBound.x < b.lowerBound.x || a.lowerBound.x > b.upperBound.x ) return false;
-	if ( a.upperBound.y < b.lowerBound.y || a.lowerBound.y > b.upperBound.y ) return false;
-	if ( a.upperBound.z < b.lowerBound.z || a.lowerBound.z > b.upperBound.z ) return false;
+	if ( fixWideLt( a.upperBound.x, b.lowerBound.x ) || fixWideGt( a.lowerBound.x, b.upperBound.x ) ) return false;
+	if ( fixWideLt( a.upperBound.y, b.lowerBound.y ) || fixWideGt( a.lowerBound.y, b.upperBound.y ) ) return false;
+	if ( fixWideLt( a.upperBound.z, b.lowerBound.z ) || fixWideGt( a.lowerBound.z, b.upperBound.z ) ) return false;
 	return true;
 }
 
@@ -417,8 +464,8 @@ FIX_ALWAYS_INLINE bool fixIsValidAABBWide( fixAABBWide a )
 {
 	if ( fixIsValidPosWide( a.lowerBound ) == false ) return false;
 	if ( fixIsValidPosWide( a.upperBound ) == false ) return false;
-	if ( a.lowerBound.x > a.upperBound.x ) return false;
-	if ( a.lowerBound.y > a.upperBound.y ) return false;
-	if ( a.lowerBound.z > a.upperBound.z ) return false;
+	if ( fixWideGt( a.lowerBound.x, a.upperBound.x ) ) return false;
+	if ( fixWideGt( a.lowerBound.y, a.upperBound.y ) ) return false;
+	if ( fixWideGt( a.lowerBound.z, a.upperBound.z ) ) return false;
 	return true;
 }

--- a/extern/fixed/src/fixed_math.c
+++ b/extern/fixed/src/fixed_math.c
@@ -2,15 +2,36 @@
 // SPDX-FileCopyrightText: 2026 Más Bandwidth LLC -- fixed-point conversion
 // SPDX-License-Identifier: MIT
 #include "fixed/fixed_math.h"
+// For FIX_PI, which the smoothing dynamics need. The vector header defines it and
+// includes this one, so the dependency only exists in this translation unit.
+#include "fixed/fixed_vec.h"
+
+// Index of the highest set bit of a NON-ZERO 64-bit value. gcc and clang have
+// __builtin_clzll; plain MSVC has _BitScanReverse64. Both compile to one instruction, and
+// the callers below all guard against zero, where the answer is undefined for either.
+#if defined( _MSC_VER ) && !defined( __clang__ )
+	#include <intrin.h>
+static inline int fixMostSignificantBit64( uint64_t v )
+{
+	unsigned long index;
+	_BitScanReverse64( &index, v );
+	return (int)index;
+}
+#else
+static inline int fixMostSignificantBit64( uint64_t v )
+{
+	return 63 - __builtin_clzll( v );
+}
+#endif
 
 static inline int64_t fixQ32Mul( int64_t a, int64_t b )
 {
-	return (int64_t)( ( (fixInt128)a * b ) >> 32 );
+	return fixInt128ToI64( fixInt128Shr( fixInt128MulI64( a, b ), 32 ) );
 }
 
 static inline int64_t fixQ32Div( int64_t a, int64_t b )
 {
-	return (int64_t)fixInt128Div( fixInt128ShiftLeft( a, 32 ), b );
+	return fixInt128ToI64( fixInt128Div( fixInt128ShiftLeft( fixInt128FromI64( a ), 32 ), fixInt128FromI64( b ) ) );
 }
 
 
@@ -49,7 +70,7 @@ fixed_t fixAtan2( fixed_t y, fixed_t x )
 
 	// a = mn / mx in [0, 1], evaluated in Q32.32. mn >= 0 so the raw shift
 	// would be fine, but the helper is the convention for signed shifts.
-	int64_t a = (int64_t)fixInt128Div( fixInt128ShiftLeft( (fixInt128)mn, 32 ), mx );
+	int64_t a = fixQ32Div( mn, mx );
 
 	// Minimax polynomial approximation to atan(a) on [0,1]
 	int64_t s = fixQ32Mul( a, a );
@@ -136,4 +157,201 @@ fixCosSin fixComputeCosSin( fixed_t radians )
 
 	fixCosSin cs = { fixQ32ToFix( c ), fixQ32ToFix( s ) };
 	return cs;
+}
+
+// ---------------------------------------------------------------------------------------------
+// The exp2 / log2 / pow ladder. Pure integer arithmetic throughout, so the results are
+// bit-identical on every platform.
+// ---------------------------------------------------------------------------------------------
+
+// 2^(2^-k) in Q32, k = 1..16: the binary-exponentiation table for the fractional part of exp2.
+static const uint64_t fixExp2Table[16] = {
+	0x000000016A09E668ull, // 2^(2^-1)
+	0x00000001306FE0A3ull, // 2^(2^-2)
+	0x00000001172B83C8ull, // 2^(2^-3)
+	0x000000010B5586D0ull, // 2^(2^-4)
+	0x00000001059B0D31ull, // 2^(2^-5)
+	0x0000000102C9A3E7ull, // 2^(2^-6)
+	0x000000010163DAA0ull, // 2^(2^-7)
+	0x0000000100B1AFA6ull, // 2^(2^-8)
+	0x000000010058C86Eull, // 2^(2^-9)
+	0x00000001002C605Eull, // 2^(2^-10)
+	0x0000000100162F39ull, // 2^(2^-11)
+	0x00000001000B175Full, // 2^(2^-12)
+	0x0000000100058BA0ull, // 2^(2^-13)
+	0x000000010002C5CCull, // 2^(2^-14)
+	0x00000001000162E5ull, // 2^(2^-15)
+	0x000000010000B172ull, // 2^(2^-16)
+};
+
+fixed_t fixLog2( fixed_t a )
+{
+	if ( a <= 0 )
+	{
+		return INT64_MIN;
+	}
+
+	// integer part: position of the leading bit relative to the fraction point
+	int msb = fixMostSignificantBit64( (uint64_t)a );
+	int64_t integerPart = (int64_t)( msb - FIX_FRACTION_BITS );
+
+	// mantissa m in [1, 2), carried in Q2.62 (fits u64: raw in [2^62, 2^63)): the exact binary
+	// digits of log2( m ) fall out of repeated squaring -- square m; if the square reaches
+	// [2, 4), the digit is 1 and the square halves back into [1, 2).
+	uint64_t m;
+	if ( msb <= 62 )
+	{
+		m = (uint64_t)a << ( 62 - msb );
+	}
+	else
+	{
+		m = (uint64_t)a >> ( msb - 62 );
+	}
+
+	const fixUInt128 half4 = fixUInt128Shl( fixUInt128FromU64( 1 ), 125 );
+	uint64_t fraction32 = 0;
+	for ( int i = 0; i < 32; ++i )
+	{
+		fixUInt128 sq = fixUInt128MulU64( m, m ); // Q4.124, value in [1, 4)
+		fraction32 <<= 1;
+		if ( fixUInt128Ge( sq, half4 ) )
+		{
+			fraction32 |= 1;
+			m = fixUInt128Lo( fixUInt128Shr( sq, 63 ) ); // halve back into [1, 2) at Q2.62
+		}
+		else
+		{
+			m = fixUInt128Lo( fixUInt128Shr( sq, 62 ) ); // renormalize to Q2.62
+		}
+	}
+
+	// assemble: integer part in Q48.16 plus the 32 exact fraction bits rounded to 16.
+	// The integer part is negative for a < 1, so the shift routes through fixShiftLeft.
+	int64_t fraction16 = (int64_t)( ( fraction32 + ( 1ull << 15 ) ) >> 16 );
+	return fixShiftLeft( integerPart, FIX_FRACTION_BITS ) + fraction16;
+}
+
+fixed_t fixExp2( fixed_t a )
+{
+	// split into integer floor and fractional part in [0, 1)
+	int64_t n = a >> FIX_FRACTION_BITS;
+
+	// The saturation tests come BEFORE the fractional split. box3d computed the split
+	// first, and n << FIX_FRACTION_BITS is signed overflow once |a| leaves the saturating
+	// range; the split is unused on both early-return paths, so the order is free. Same
+	// answer for every input, no undefined behavior.
+	if ( n >= 47 )
+	{
+		return INT64_MAX; // saturate: 2^47 is the top of the Q48.16 whole-unit domain
+	}
+
+	if ( n < -17 )
+	{
+		return 0; // underflow below the smallest representable value
+	}
+
+	// n is negative for a < 1, and shifting a negative value left is undefined even when
+	// it does not overflow, so the split routes through fixShiftLeft. Same bits.
+	uint64_t f = (uint64_t)( a - fixShiftLeft( n, FIX_FRACTION_BITS ) ); // Q16 fraction, [0, 2^16)
+
+	// 2^f as a product over the set bits of f, in Q32: r in [ 2^32, 2^33 )
+	uint64_t r = 1ull << 32;
+	for ( int k = 0; k < 16; ++k )
+	{
+		// bit for 2^-( k + 1 ) is fraction bit ( 15 - k )
+		if ( f & ( 1ull << ( 15 - k ) ) )
+		{
+			r = fixUInt128Lo( fixUInt128Shr( fixUInt128MulU64( r, fixExp2Table[k] ), 32 ) );
+		}
+	}
+
+	// scale by 2^n: result raw = r * 2^n / 2^16 (r is Q32, output is Q16)
+	int shift = 16 - (int)n;
+	if ( shift <= 0 )
+	{
+		return (fixed_t)( r << ( -shift ) );
+	}
+	if ( shift >= 64 )
+	{
+		return 0;
+	}
+	// round to nearest on the dropped bits, the pinned ( raw + half ) >> drop form
+	return (fixed_t)( ( r + ( 1ull << ( shift - 1 ) ) ) >> shift );
+}
+
+fixed_t fixPow( fixed_t base, fixed_t exponent )
+{
+	if ( base <= 0 )
+	{
+		return 0;
+	}
+
+	if ( exponent == 0 )
+	{
+		return FIX_ONE;
+	}
+
+	return fixExp2( fixMul( exponent, fixLog2( base ) ) );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Q2.30 normalization
+// ---------------------------------------------------------------------------------------------
+
+int32_t fixNormalizeComponent30( int64_t raw, uint64_t length )
+{
+	FIX_ASSERT( length != 0 );
+
+	// Unsigned negation rather than -raw: the magnitude is identical for every input and
+	// stays defined at INT64_MIN, where negating the signed value is not.
+	uint64_t magnitude = raw < 0 ? -(uint64_t)raw : (uint64_t)raw;
+	fixUInt128 numerator = fixUInt128Add( fixUInt128Shl( fixUInt128FromU64( magnitude ), FIX30_FRACTION_BITS ),
+										  fixUInt128FromU64( length >> 1 ) );
+
+	// Through fixInt128Div rather than the native 128-bit divide. Both operands are
+	// non-negative and well inside the signed 128-bit range, so the truncated quotient is
+	// the same; the library's own divide is the one that works on ClangCL, which does not
+	// link the compiler-rt 128-bit division builtins.
+	uint64_t q = (uint64_t)fixInt128ToI64( fixInt128Div( fixInt128FromUnsigned( numerator ), fixInt128FromU64( length ) ) );
+	if ( q > (uint64_t)FIX30_ONE )
+	{
+		q = (uint64_t)FIX30_ONE; // the rounded divide can overshoot one by an ulp
+	}
+
+	return raw < 0 ? -(int32_t)q : (int32_t)q;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Critically damped smoothing (deterministic control dynamics on fixed point)
+// ---------------------------------------------------------------------------------------------
+
+fixed_t fixSmoothCriticallyDamped( fixed_t current, fixed_t target, fixed_t* velocity, fixed_t smoothTime,
+								   fixed_t deltaTime )
+{
+	if ( smoothTime <= 0 )
+	{
+		return target;
+	}
+
+	if ( deltaTime <= 0 )
+	{
+		return current;
+	}
+
+	fixed_t omega = fixDiv( 2 * FIX_PI, smoothTime );
+	fixed_t onePlus = FIX_ONE + fixMul( omega, deltaTime );
+	fixed_t denominator = fixMul( onePlus, onePlus );
+
+	fixed_t spring = fixMul( fixMul( fixMul( omega, omega ), deltaTime ), current - target );
+
+	*velocity = fixDiv( *velocity - spring, denominator );
+
+	return current + fixMul( *velocity, deltaTime );
+}
+
+fixed_t fixSmoothCriticallyDampedUpDown( fixed_t current, fixed_t target, fixed_t* velocity, fixed_t smoothTimeUp,
+										 fixed_t smoothTimeDown, fixed_t deltaTime )
+{
+	fixed_t smoothTime = fixAbs( target ) >= fixAbs( current ) ? smoothTimeUp : smoothTimeDown;
+	return fixSmoothCriticallyDamped( current, target, velocity, smoothTime, deltaTime );
 }

--- a/src/body.c
+++ b/src/body.c
@@ -58,6 +58,23 @@ b3BodySim* b3GetBodySim( b3World* world, b3Body* body )
 	return bodySim;
 }
 
+// Write the local inverse inertia and the local inertia together.
+//
+// The gyroscopic solve needs the inertia, not its inverse, and it used to recover it by
+// inverting the inverse inside the substep loop -- nine 128-bit divisions per body per
+// substep, recomputing a value that is constant for the whole step. Caching it here is
+// the same value by construction: this is the identical b3InvertMatrix call, simply made
+// once when the input changes instead of four times per step for every awake body.
+//
+// The single writer is the point. Two fields holding two views of one quantity drift the
+// moment one of them is assigned somewhere the other is not, and this is the only
+// function that assigns either.
+static void b3SetLocalInverseInertia( b3BodySim* bodySim, b3Matrix3 invInertiaLocal )
+{
+	bodySim->invInertiaLocal = invInertiaLocal;
+	bodySim->inertiaLocal = b3InvertMatrix( invInertiaLocal );
+}
+
 b3BodyState* b3GetBodyState( b3World* world, b3Body* body )
 {
 	if ( body->setIndex == b3_awakeSet )
@@ -230,7 +247,7 @@ b3BodyId b3CreateBody( b3WorldId worldId, const b3BodyDef* def )
 	bodySim->force = b3Vec3_zero;
 	bodySim->torque = b3Vec3_zero;
 	bodySim->invMass = B3_FIX( 0.0f );
-	bodySim->invInertiaLocal = b3Mat3_zero;
+	b3SetLocalInverseInertia( bodySim, b3Mat3_zero );
 	bodySim->minExtent = B3_HUGE;
 	bodySim->maxExtent = b3Vec3_zero;
 	bodySim->linearDamping = def->linearDamping;
@@ -834,7 +851,7 @@ void b3UpdateBodyMassData( b3World* world, b3Body* body )
 	body->inertia = b3Mat3_zero;
 
 	bodySim->invMass = B3_FIX( 0.0f );
-	bodySim->invInertiaLocal = b3Mat3_zero;
+	b3SetLocalInverseInertia( bodySim, b3Mat3_zero );
 	bodySim->invInertiaWorld = b3Mat3_zero;
 	bodySim->localCenter = b3Vec3_zero;
 	bodySim->minExtent = B3_HUGE;
@@ -927,7 +944,7 @@ void b3UpdateBodyMassData( b3World* world, b3Body* body )
 	// b3InvertT computes its determinant at full 128-bit precision internally and
 	// returns a zero matrix if the inertia is singular. A Q48.16 determinant would
 	// underflow for small bodies.
-	bodySim->invInertiaLocal = b3InvertT( body->inertia );
+	b3SetLocalInverseInertia( bodySim, b3InvertT( body->inertia ) );
 	if ( bodySim->invInertiaLocal.cx.x > 0 || bodySim->invInertiaLocal.cy.y > 0 || bodySim->invInertiaLocal.cz.z > 0 )
 	{
 		b3Matrix3 rotationMatrix = b3MakeMatrixFromQuat( bodySim->transform.q );
@@ -942,7 +959,7 @@ void b3UpdateBodyMassData( b3World* world, b3Body* body )
 		// the refusal lasted exactly until the next step and then undid itself. Zeroing
 		// both is what makes the decision stick. b3Body_SetMassData already did this;
 		// this path was the asymmetric one.
-		bodySim->invInertiaLocal = b3Mat3_zero;
+		b3SetLocalInverseInertia( bodySim, b3Mat3_zero );
 		bodySim->invInertiaWorld = b3Mat3_zero;
 	}
 
@@ -977,7 +994,7 @@ void b3UpdateBodyMassData( b3World* world, b3Body* body )
 	if ( ( bodySim->flags & b3_fixedRotation ) == b3_fixedRotation )
 	{
 		body->inertia = b3Mat3_zero;
-		bodySim->invInertiaLocal = b3Mat3_zero;
+		b3SetLocalInverseInertia( bodySim, b3Mat3_zero );
 		bodySim->invInertiaWorld = b3Mat3_zero;
 	}
 }
@@ -1831,7 +1848,7 @@ void b3Body_SetMassData( b3BodyId bodyId, b3MassData massData )
 	// b3InvertT computes its determinant at full 128-bit precision internally and
 	// returns a zero matrix if the inertia is singular. A Q48.16 determinant would
 	// underflow for small bodies.
-	bodySim->invInertiaLocal = b3InvertT( body->inertia );
+	b3SetLocalInverseInertia( bodySim, b3InvertT( body->inertia ) );
 	if ( bodySim->invInertiaLocal.cx.x > 0 || bodySim->invInertiaLocal.cy.y > 0 || bodySim->invInertiaLocal.cz.z > 0 )
 	{
 		b3Matrix3 rotationMatrix = b3MakeMatrixFromQuat( bodySim->transform.q );
@@ -1839,7 +1856,7 @@ void b3Body_SetMassData( b3BodyId bodyId, b3MassData massData )
 	}
 	else
 	{
-		bodySim->invInertiaLocal = b3Mat3_zero;
+		b3SetLocalInverseInertia( bodySim, b3Mat3_zero );
 		bodySim->invInertiaWorld = b3Mat3_zero;
 	}
 
@@ -1847,7 +1864,7 @@ void b3Body_SetMassData( b3BodyId bodyId, b3MassData massData )
 	if ( ( bodySim->flags & b3_fixedRotation ) == b3_fixedRotation )
 	{
 		body->inertia = b3Mat3_zero;
-		bodySim->invInertiaLocal = b3Mat3_zero;
+		b3SetLocalInverseInertia( bodySim, b3Mat3_zero );
 		bodySim->invInertiaWorld = b3Mat3_zero;
 	}
 

--- a/src/body.c
+++ b/src/body.c
@@ -933,6 +933,18 @@ void b3UpdateBodyMassData( b3World* world, b3Body* body )
 		b3Matrix3 rotationMatrix = b3MakeMatrixFromQuat( bodySim->transform.q );
 		bodySim->invInertiaWorld = b3MulMM( b3MulMM( rotationMatrix, bodySim->invInertiaLocal ), b3Transpose( rotationMatrix ) );
 	}
+	else
+	{
+		// A REFUSED TENSOR MUST NOT SURVIVE IN THE LOCAL FIELD. This branch used to leave
+		// invInertiaLocal holding the very matrix the test above just rejected, and only
+		// invInertiaWorld was withheld -- but the world tensor is recomputed from the
+		// local one, unguarded, by the solver every step and by b3Body_SetTransform, so
+		// the refusal lasted exactly until the next step and then undid itself. Zeroing
+		// both is what makes the decision stick. b3Body_SetMassData already did this;
+		// this path was the asymmetric one.
+		bodySim->invInertiaLocal = b3Mat3_zero;
+		bodySim->invInertiaWorld = b3Mat3_zero;
+	}
 
 	// Move center of mass.
 	b3Pos oldCenter = bodySim->center;

--- a/src/body.c
+++ b/src/body.c
@@ -783,6 +783,33 @@ int b3Body_CollideMover( b3BodyId bodyId, b3BodyPlaneResult* bodyPlanes, int pla
 // (a 4 cm box has inertia below the Q48.16 resolution). Floor the diagonal so
 // such bodies keep a finite, stable rotational response instead of a singular
 // inertia that locks rotation and prevents spin from ever damping.
+// The inverse of a finite dynamic mass, floored at one quantum.
+//
+// b3FixDiv truncates toward zero, so 1/mass is exactly 0 for every mass above 65,536
+// units. Zero inverse mass is how this engine spells STATIC -- it is what the static path
+// assigns deliberately -- so letting the arithmetic produce it turns a heavy body into an
+// immovable one that still reports itself dynamic. That is a category flip rather than a
+// rounding error, and it diverges from the float original, where 1/huge is tiny but never
+// zero.
+//
+// Flooring costs accuracy that Q48.16 does not have to give in the first place: one
+// quantum of inverse mass is an effective mass of 65,536 and the next is 32,768, so
+// nothing in that range resolves. A body past the line is therefore VERY HEAVY rather
+// than correctly heavy -- and very heavy is the answer that keeps the meaning of zero
+// intact. Consumers wanting graded response keep masses under the ceiling.
+//
+// Zero and negative mass are passed through untouched: they are the degenerate input, not
+// a large one, and the callers already treat them as such.
+static b3Fixed b3InverseMass( b3Fixed mass )
+{
+	if ( mass <= B3_FIX( 0.0f ) )
+	{
+		return B3_FIX( 0.0f );
+	}
+
+	return b3FixMax( b3FixDiv( B3_FIX( 1.0f ), mass ), 1 );
+}
+
 static void b3FloorInertia( b3Matrix3* inertia, b3Fixed mass )
 {
 	if ( mass > 0 )
@@ -873,8 +900,8 @@ void b3UpdateBodyMassData( b3World* world, b3Body* body )
 	// Compute center of mass.
 	if ( body->mass > B3_FIX( 0.0f ) )
 	{
-		bodySim->invMass = b3FixDiv( B3_FIX( 1.0f ) , body->mass );
-		localCenter = b3MulSV( bodySim->invMass, localCenter );
+		bodySim->invMass = b3InverseMass( body->mass );
+		localCenter = b3MulSV( b3FixDiv( B3_FIX( 1.0f ), body->mass ), localCenter );
 	}
 
 	// Second loop to accumulate the rotational inertia about the center of mass
@@ -1777,7 +1804,7 @@ void b3Body_SetMassData( b3BodyId bodyId, b3MassData massData )
 	b3Pos center = b3TransformWorldPoint( bodySim->transform, massData.center );
 	bodySim->center = center;
 	bodySim->center0 = center;
-	bodySim->invMass = body->mass > B3_FIX( 0.0f ) ? b3FixDiv( B3_FIX( 1.0f ) , body->mass ) : B3_FIX( 0.0f );
+	bodySim->invMass = b3InverseMass( body->mass );
 
 	// Update center of mass velocity
 	b3BodyState* state = b3GetBodyState( world, body );

--- a/src/body.h
+++ b/src/body.h
@@ -208,6 +208,18 @@ typedef struct b3BodySim
 	b3Matrix3 invInertiaLocal;
 	b3Matrix3 invInertiaWorld;
 
+	// The local inertia the gyroscopic solve needs, which is b3InvertMatrix of the field
+	// above. It is stored rather than derived because the solver used to recover it by
+	// inverting the inverse ONCE PER BODY PER SUBSTEP -- nine 128-bit divisions to
+	// recompute a value that cannot change between substeps, and the code said so with a
+	// "todo wasteful computation". Both fields are written together, by b3SetLocalInverseInertia
+	// alone, so they cannot drift apart.
+	//
+	// Deliberately the ROUND TRIP and not body->inertia, which is the same quantity by
+	// mathematics and a different one by rounding. Storing the round trip is what makes
+	// the hoist bit-identical to the recomputation it replaces.
+	b3Matrix3 inertiaLocal;
+
 	b3Fixed minExtent;
 	b3Vec3 maxExtent;
 	b3Fixed linearDamping;

--- a/src/solver.c
+++ b/src/solver.c
@@ -112,8 +112,10 @@ static void b3IntegrateVelocitiesTask( b3SolverBlock block, b3StepContext* conte
 			b3Quat q0 = sim->transform.q;
 			b3Quat q = b3MulQuat( state->deltaRotation, q0 );
 
-			// todo wasteful computation
-			b3Matrix3 inertiaLocal = b3InvertMatrix( sim->invInertiaLocal );
+			// Cached when the mass data was set, because it cannot change between
+			// substeps: this was b3InvertMatrix( sim->invInertiaLocal ) here, nine
+			// 128-bit divisions per body per substep to recompute a constant.
+			b3Matrix3 inertiaLocal = sim->inertiaLocal;
 
 			// Compute local angular velocity
 			b3Vec3 omega1 = b3InvRotateVector( q, w );

--- a/test/test_body.c
+++ b/test/test_body.c
@@ -384,8 +384,114 @@ static int SetMassDataConsistentVelocity( void )
 	return 0;
 }
 
+// Zero inverse mass has exactly one meaning in this engine: the body is static. It must
+// never also mean "your mass was large", which is what b3FixDiv( 1, mass ) produced --
+// truncating toward zero, so every mass above 65,536 units inverted to exactly 0 and the
+// body became immovable by any impulse while still reporting itself dynamic. A silent
+// dynamic-to-static category flip, and it diverges from the float reference, where 1/huge
+// is tiny but never zero.
+//
+// The boundary is pinned on both sides because it is the whole point: 65,536 is the
+// largest mass whose inverse is representable in Q48.16, and one unit past it the honest
+// answer is one quantum rather than none.
+//
+// COARSENESS NEAR THE CEILING is real and deliberate. One quantum of inverse mass is an
+// effective mass of 65,536, and the next quantum up is 32,768 -- so masses in that range
+// do not resolve. A consumer wanting graded response keeps configured masses well under
+// the ceiling; a consumer past it gets a body that is very heavy rather than one that is
+// secretly nailed down.
+static int InverseMassQuantumFloor( void )
+{
+	b3WorldDef worldDef = b3DefaultWorldDef();
+	b3WorldId worldId = b3CreateWorld( &worldDef );
+
+	b3BodyDef bodyDef = b3DefaultBodyDef();
+	bodyDef.type = b3_dynamicBody;
+
+	// At the line: 1 / 65,536 is exactly one quantum, with no clamping involved.
+	{
+		b3BodyId bodyId = b3CreateBody( worldId, &bodyDef );
+		b3MassData massData = { B3_FIX( 65536.0f ), b3Vec3_zero, kDiagInertia };
+		b3Body_SetMassData( bodyId, massData );
+		ENSURE( b3Body_GetInverseMass( bodyId ) == 1 );
+	}
+
+	// One unit past it, where the true inverse is 0.99998 of a quantum. Truncation gives
+	// zero; the floor gives the smallest inverse mass this format has.
+	{
+		b3BodyId bodyId = b3CreateBody( worldId, &bodyDef );
+		b3MassData massData = { B3_FIX( 65537.0f ), b3Vec3_zero, kDiagInertia };
+		b3Body_SetMassData( bodyId, massData );
+		ENSURE( b3Body_GetInverseMass( bodyId ) == 1 );
+	}
+
+	// Far past it, the case space actually contains. Still dynamic, still movable.
+	{
+		b3BodyId bodyId = b3CreateBody( worldId, &bodyDef );
+		b3MassData massData = { B3_FIX( 1.0e7f ), b3Vec3_zero, kDiagInertia };
+		b3Body_SetMassData( bodyId, massData );
+		ENSURE( b3Body_GetInverseMass( bodyId ) > 0 );
+	}
+
+	// And the floor is a floor, not a rewrite: an ordinary mass is unaffected.
+	{
+		b3BodyId bodyId = b3CreateBody( worldId, &bodyDef );
+		b3MassData massData = { B3_FIX( 4.0f ), b3Vec3_zero, kDiagInertia };
+		b3Body_SetMassData( bodyId, massData );
+		ENSURE( b3Body_GetInverseMass( bodyId ) == b3FixDiv( B3_FIX( 1.0f ), B3_FIX( 4.0f ) ) );
+	}
+
+	// A static body keeps zero inverse mass through its own explicit path, which is the
+	// distinction the floor exists to protect.
+	{
+		b3BodyDef staticDef = b3DefaultBodyDef();
+		staticDef.type = b3_staticBody;
+		b3BodyId bodyId = b3CreateBody( worldId, &staticDef );
+		ENSURE( b3Body_GetInverseMass( bodyId ) == 0 );
+	}
+
+	// Zero mass on a dynamic body is not a large mass and must not be floored -- the
+	// engine reads it as the degenerate case it is.
+	{
+		b3BodyId bodyId = b3CreateBody( worldId, &bodyDef );
+		b3MassData massData = { B3_FIX( 0.0f ), b3Vec3_zero, b3Mat3_zero };
+		b3Body_SetMassData( bodyId, massData );
+		ENSURE( b3Body_GetInverseMass( bodyId ) == 0 );
+	}
+
+	b3DestroyWorld( worldId );
+	return 0;
+}
+
+// The same floor on the path that computes mass from shapes and density rather than
+// taking it from the caller, which is how a real heavy body is usually built. A 40-unit
+// box at density 1 masses 64,000 -- under the line -- so the density is raised to carry
+// it past.
+static int InverseMassQuantumFloorFromShapes( void )
+{
+	b3WorldDef worldDef = b3DefaultWorldDef();
+	b3WorldId worldId = b3CreateWorld( &worldDef );
+
+	b3BodyDef bodyDef = b3DefaultBodyDef();
+	bodyDef.type = b3_dynamicBody;
+	b3BodyId bodyId = b3CreateBody( worldId, &bodyDef );
+
+	b3BoxHull hull = b3MakeBoxHull( B3_FIX( 20.0f ), B3_FIX( 20.0f ), B3_FIX( 20.0f ) );
+	b3ShapeDef shapeDef = b3DefaultShapeDef();
+	shapeDef.density = B3_FIX( 10.0f );
+	b3CreateHullShape( bodyId, &shapeDef, &hull.base );
+
+	ENSURE( b3Body_GetMass( bodyId ) > B3_FIX( 65536.0f ) );
+	ENSURE( b3Body_GetInverseMass( bodyId ) > 0 );
+
+	b3DestroyWorld( worldId );
+	return 0;
+}
+
 int BodyTest( void )
 {
+	RUN_SUBTEST( InverseMassQuantumFloor );
+	RUN_SUBTEST( InverseMassQuantumFloorFromShapes );
 	RUN_SUBTEST( FarSingleSphereMass );
 	RUN_SUBTEST( FarCubeSphereMass );
 	RUN_SUBTEST( DeferredMassExtents );

--- a/test/test_body.c
+++ b/test/test_body.c
@@ -488,9 +488,110 @@ static int InverseMassQuantumFloorFromShapes( void )
 	return 0;
 }
 
+// THE INVERSE INERTIA SCALE ENVELOPE.
+//
+// Inertia grows as the fifth power of size, so a body 20 times larger has an inertia
+// 3.2 million times larger, and the inverse the solver actually uses runs off the bottom
+// of Q48.16 long before anything else complains. Every dynamic body in this repository's
+// samples is under 2.5 units, a factor of five inside the range where the arithmetic was
+// correct, which is exactly why the failure past it went unseen for so long.
+//
+// What is asserted here is the contract, not a particular number:
+//
+//   - An inverse inertia is NEVER NEGATIVE. The tensor is positive-definite, so its
+//     inverse is too, and a negative diagonal is a body that accelerates against its own
+//     torque. This is what the wide arm used to produce -- measured at cube side 250 as
+//     an inverse of the wrong sign and 1.13e9 times the true magnitude.
+//   - It never grows with the body. A larger body has a smaller inverse inertia, at every
+//     size, monotonically. A wrapped reduction breaks that immediately.
+//   - Past the representability line it is exactly zero, and it STAYS zero through a
+//     transform change and a world step, which is where a refused tensor used to come
+//     back to life.
+//
+// The line falls at 65,536 units of inertia, which for a uniform cube of density 1 is
+// about 13.1 units on a side. A zero inverse inertia means the body does not rotate --
+// which is a real limitation of the storage format, and a separate question from this
+// test, which is only that the engine is honest about it rather than wrong about it.
+static int InverseInertiaScaleEnvelope( void )
+{
+	b3WorldDef worldDef = b3DefaultWorldDef();
+	b3WorldId worldId = b3CreateWorld( &worldDef );
+
+	// Cube sides spanning both cliffs, in half units so the arithmetic below is exact.
+	static const int halfSides[] = { 2, 10, 22, 26, 27, 40, 75, 88, 160, 240, 500, 1000 };
+
+	b3Fixed previousDiagonal = B3_FIXED_MAX;
+
+	for ( int i = 0; i < ARRAY_COUNT( halfSides ); ++i )
+	{
+		// Uniform solid cube of density 1: mass = s^3 and inertia = s^5/6, built from
+		// integers so the input carries no conversion error of its own.
+		int64_t s2 = halfSides[i];
+		int64_t massRaw = ( s2 * s2 * s2 * 65536 ) / 8;
+		int64_t inertiaRaw = ( ( ( s2 * s2 * s2 * s2 ) / 3 ) * s2 * 1024 );
+
+		b3Matrix3 inertia = b3Mat3_zero;
+		inertia.cx.x = (b3Fixed)inertiaRaw;
+		inertia.cy.y = (b3Fixed)inertiaRaw;
+		inertia.cz.z = (b3Fixed)inertiaRaw;
+
+		b3BodyDef bodyDef = b3DefaultBodyDef();
+		bodyDef.type = b3_dynamicBody;
+		b3BodyId bodyId = b3CreateBody( worldId, &bodyDef );
+
+		b3MassData massData = { (b3Fixed)massRaw, b3Vec3_zero, inertia };
+		b3Body_SetMassData( bodyId, massData );
+
+		// The body is created at identity rotation, so the world inverse tensor IS the
+		// local one here -- the similarity transform is by the identity matrix.
+		b3Matrix3 invLocal = b3Body_GetWorldInverseRotationalInertia( bodyId );
+
+		// Never negative, on any entry of a diagonal tensor's inverse.
+		ENSURE( invLocal.cx.x >= 0 && invLocal.cy.y >= 0 && invLocal.cz.z >= 0 );
+		ENSURE( invLocal.cx.y == 0 && invLocal.cx.z == 0 );
+		ENSURE( invLocal.cy.x == 0 && invLocal.cy.z == 0 );
+		ENSURE( invLocal.cz.x == 0 && invLocal.cz.y == 0 );
+
+		// Monotone: a bigger body never has a bigger inverse inertia.
+		ENSURE( invLocal.cx.x <= previousDiagonal );
+		previousDiagonal = invLocal.cx.x;
+
+		// The world tensor is a similarity transform of the local one, so it inherits the
+		// same contract. Rotating the body must not manufacture a negative entry or
+		// resurrect a refused tensor.
+		b3Body_SetTransform( bodyId, (b3Pos){ B3_FIX( 0.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) },
+							 b3MakeQuatFromAxisAngle( b3Normalize( (b3Vec3){ B3_FIX( 1.0f ), B3_FIX( 2.0f ), B3_FIX( 3.0f ) } ),
+													  B3_FIX( 0.7f ) ) );
+
+		b3Matrix3 invWorld = b3Body_GetWorldInverseRotationalInertia( bodyId );
+		ENSURE( invWorld.cx.x >= 0 && invWorld.cy.y >= 0 && invWorld.cz.z >= 0 );
+
+		if ( invLocal.cx.x == 0 )
+		{
+			// A refused tensor stays refused -- through the transform change above, and
+			// through a step of the world, which recomputes the world tensor from the
+			// local one without a guard of its own.
+			ENSURE( invWorld.cx.x == 0 && invWorld.cy.y == 0 && invWorld.cz.z == 0 );
+
+			b3World_Step( worldId, B3_FIX( 1.0f ) / 60, 4 );
+
+			invWorld = b3Body_GetWorldInverseRotationalInertia( bodyId );
+			ENSURE( invWorld.cx.x == 0 && invWorld.cy.y == 0 && invWorld.cz.z == 0 );
+		}
+	}
+
+	// The walk has to have arrived at zero rather than merely stayed small, or the
+	// monotonicity above would be satisfied by a constant.
+	ENSURE( previousDiagonal == 0 );
+
+	b3DestroyWorld( worldId );
+	return 0;
+}
+
 int BodyTest( void )
 {
 	RUN_SUBTEST( InverseMassQuantumFloor );
+	RUN_SUBTEST( InverseInertiaScaleEnvelope );
 	RUN_SUBTEST( InverseMassQuantumFloorFromShapes );
 	RUN_SUBTEST( FarSingleSphereMass );
 	RUN_SUBTEST( FarCubeSphereMass );

--- a/tools/revendor-fixed.sh
+++ b/tools/revendor-fixed.sh
@@ -18,10 +18,10 @@
 set -euo pipefail
 
 FIXED_REPO="https://github.com/mas-bandwidth/fixed.git"
-# v1.0.0. Pinned as a SHA rather than the tag name on purpose: a tag can be moved,
-# a commit cannot, and "vendored at v1.0.0" should mean one specific tree forever.
-FIXED_PIN="ba88f94cb9cc03951533daf7678d8980d4118163"
-FIXED_VERSION="v1.2.0"
+# v1.3.0. Pinned as a SHA rather than the tag name on purpose: a tag can be moved,
+# a commit cannot, and "vendored at v1.3.0" should mean one specific tree forever.
+FIXED_PIN="db2e4809f62a031e994b336cbada2d012f9c99df"
+FIXED_VERSION="v1.3.0"
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DEST="$ROOT/extern/fixed"


### PR DESCRIPTION
Closes #28. Closes #29. Addresses the arithmetic half of #30.

Space's asteroids spin at 13,619,661 rad/s per laser hit against a physically correct 0.012, and cannot be pushed by any linear impulse at all. Both are inverse-quantity bugs in this engine, and neither is visible at the scale of anything in this repository's corpus — every dynamic body in every sample is under 2.5 units, a factor of five inside the range where the arithmetic happened to work.

## What was wrong

**#29 — `invMass` underflow.** `b3FixDiv` truncates toward zero, so `1/mass` was exactly `0` for every mass above 65,536 units. Zero inverse mass is how this engine spells STATIC — it is what the static path assigns deliberately — so the arithmetic was performing a silent dynamic-to-static category flip. In space's Test level that was 512 of 512 asteroids: immovable, while still reporting themselves dynamic.

**#30 — the wide arm of the inverse.** A cofactor of a Q48.16 matrix reaches 126 bits and its determinant 190, and the wide arm squeezed both into 128 by dropping 16 fraction bits and casting to `int64_t`. Both steps were silent past their range. Fixed upstream in mas-bandwidth/fixed#17 and taken here as a pin move to v1.3.0.

**#30 — the refusal did not stick.** `b3UpdateBodyMassData` tested the inverted tensor before propagating it, but on failure left `invInertiaLocal` holding the matrix it had just rejected and withheld only `invInertiaWorld`. The world tensor is recomputed from the local one, unguarded, by the solver every step — so the refusal lasted until the next step and then undid itself.

**#28 — the wasteful inversion.** The gyroscopic solve recovered the local inertia by inverting the inverse, nine 128-bit divisions per body per substep, for a value constant across the step. The code said `todo wasteful computation`.

## The band, measured

Uniform solid cube of density 1, inverse inertia against the exact ratio:

| cube side | true 1/I in quanta | before | after |
|---|---|---|---|
| 1 – 13 | 393,200 – 1.06 | correct | correct, unchanged |
| 13.5 | 0.877 | 0 (rotation locked) | 0 — **still locked, now by an honest zero** |
| 37.5 | 0.0053 | 0 | 0 |
| 44 | 0.0024 | 0 | 0 |
| 120 | 1.6e-05 | 822,656x too large | 0 |
| 250 | 4.0e-07 | **negative, 1.13e9x too large** | 0 |
| 500 | 1.3e-08 | 1.21e10x too large | 0 |
| Destroyer 200x100x400 | — | **negative on all three axes** | 0 |
| Carrier 1000x250x500 | — | **mixed sign across axes** | 0 |

**Read that table honestly: this PR does not unlock the 13.5–44 band.** It converts wrapped garbage of arbitrary sign into an exact zero. Zero is the correct truncated answer — Q48.16 holds no value between zero and 1/65536, so a body past that line has no representable inverse inertia at all — but a zero inverse inertia is still a body that does not rotate. Making those sizes physically usable is a **storage-format** question (wider fractional storage for inverse quantities), which is deliberately not in this PR.

What this PR buys is that the engine is now *wrong in a way you can see* rather than wrong in a way that looks like physics. A negative inverse inertia is a body accelerating against its own torque; a zero one is a body that will not spin. Only the second can be reasoned about.

## Performance

Glenn's standing constraint is that fixed3d stays within ~2x of float, so this was measured as an interleaved A/B — alternating runs of both binaries in the same time window, min of each side — because a sequential before/after across a 40-minute window on a loaded laptop is not a measurement. My first sequential attempt showed a uniform 10–30% regression that the interleaved A/B showed to be background load.

**The two binaries were benched in-window together**, alternating: `base` is the benchmark binary built from `8e07d61` in a separate worktree, `head` is the benchmark binary from this branch's tip. Each pair runs back to back, so both sides see the same machine conditions, and the minimum over pairs is taken per side. Nothing here is compared against numbers banked earlier under different load.

Apple M2 8-core, RelWithDebInfo + LTO, `-w=4 -t=4`, 4 alternating pairs, min of each side:

| benchmark | base ms | head ms | delta |
|---|---|---|---|
| convex_pile | 15284.8 | 10384.2 | **-32.1%** |
| junkyard | 10814.1 | 10252.5 | -5.2% |
| large_world | 27.703 | 26.853 | -3.1% |
| rain | 1677.8 | 1632.6 | -2.7% |
| trees25 | 402.5 | 391.5 | -2.7% |
| washer | 16581.7 | 16310.0 | -1.6% |
| trees50 | 205.5 | 203.0 | -1.2% |
| trees100 | 167.1 | 165.4 | -1.0% |
| large_pyramid | 2487.0 | 2485.3 | -0.1% |
| many_pyramids | 2053.2 | 2056.7 | +0.2% |
| joint_grid | 929.8 | 944.7 | **+1.6%** |

Scene counts (bodies, shapes, contacts, joints) are identical on both sides, so convex_pile is doing the same work faster rather than less work.

**joint_grid is the one real regression, at +1.6%**, and it is the cost of the correctness fix landing where it was predicted to: the exact arm's range test now checks all nine cofactors instead of three, and `fixSolve3` checks its numerators have room for their shift — and joint_grid runs `fixSolve3` 19,800 times per substep. Before the #28 hoist that regression measured +5.3%; the hoist bought back most of it. `many_pyramids` first measured at +5.9% and proved to be noise at seven pairs (+0.2%) — reported here because the four-pair table is not tight enough to resolve a few percent, and only convex_pile's -32% and joint_grid's +1.6% survive more sampling.

## How it is held

- **`InverseMassQuantumFloor`** pins the boundary on both sides — mass 65,536 exactly, 65,537, a far heavier body, an ordinary mass, a static body, and a zero-mass dynamic body — across both construction paths.
- **`InverseInertiaScaleEnvelope`** walks cube sides 1 to 500 and asserts the contract rather than any number: never negative, never growing with the body, and zero past the line and *staying* zero through a transform change and a world step. **Verified red against the previous pin**, where the monotonicity check fails — the inverse inertia getting larger as the body gets bigger, which is the wrapped-reduction signature exactly.
- Upstream, `inverse_envelope_test.c` holds the arithmetic with an oracle that shares nothing with the implementation, and a negative control that is the historical bug restored verbatim.
- The **determinism goldens are unchanged**, which is the claim worth checking twice: nothing in this repository's corpus is over either line, so no existing body moves by a bit. It is also the bit-equality gate for the #28 hoist, since the goldens hash a full ragdoll trajectory.

## Behaviour change by design

Per Glenn's ruling on #29, the `invMass` floor changes simulation behaviour for any content with a body over 65,536 units of mass, so **captures made before this will not replay identically after it**. Nothing in this repository is over the line.

The #28 hoist adds 72 bytes to `b3BodySim` and therefore moves the snapshot layout hash. That hash exists to catch exactly this, so older snapshot images are refused rather than misread.

## Found and not fixed here

#32 — the centre of mass is computed by multiplying by the truncated reciprocal, so it collapses onto the body origin for bodies over 65,536 units of mass. The fix is a componentwise divide, it is more accurate for every body, and it makes the ragdoll scene fire a `fixLerp` alpha assert — which is either a fragile consumer or an over-tight canary, and is its own piece of work rather than a rider on this one.
