### PR TITLE
Widen inverse quantities to Q24.40: the band unlocks, +15% on joint scenes, HELD for the call

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,13 @@ jobs:
             msan-options: abort_on_error=1:halt_on_error=1
           - name: macos
             os: macos-latest
+            # 1m56s on main, past the 4-minute default on the inverse-widening branch.
+            # The widening puts 256-bit arithmetic on solver paths, and ASan/UBSan
+            # instrument exactly that shape hardest -- an optimized build pays about 15%
+            # on the joint-heavy benchmarks, this one pays more than double. Raised so the
+            # job reports a result rather than a timeout; the cost itself is part of what
+            # that branch is being judged on, not something to hide behind a limit.
+            timeout: 12
             args: -DBOX3D_SANITIZE=ON
             test: ./bin/test
           # Pure MSVC cannot build the fixed-point core (no __int128); all

--- a/extern/fixed/NOTES.md
+++ b/extern/fixed/NOTES.md
@@ -4,7 +4,7 @@ This directory is a **generated copy** of [mas-bandwidth/fixed](https://github.c
 the deterministic fixed-point math library that Fixed3D's own fixed-point core was
 extracted into.
 
-    Pinned at: v1.3.0  (db2e4809f62a031e994b336cbada2d012f9c99df)
+    Pinned at: v1.3.1  (cb48d9db245745292ec946b409a91bec07eb9d34)
 
 ## Do not edit anything in this directory
 

--- a/extern/fixed/include/fixed/fixed_int128.h
+++ b/extern/fixed/include/fixed/fixed_int128.h
@@ -607,6 +607,53 @@ FIX_ALWAYS_INLINE fixUInt128 fixUInt128Sub( fixUInt128 a, fixUInt128 b ) { retur
 FIX_ALWAYS_INLINE fixUInt128 fixUInt128Mul( fixUInt128 a, fixUInt128 b ) { return a * b; }
 FIX_ALWAYS_INLINE fixUInt128 fixUInt128MulU64( uint64_t a, uint64_t b ) { return (fixUInt128)a * b; }
 FIX_ALWAYS_INLINE fixUInt128 fixUInt128Neg( fixUInt128 a ) { return -a; }
+
+/// Divide a 128-bit value by a 64-bit divisor, returning the quotient and, through the
+/// pointer, the remainder.
+///
+/// PRECONDITION: fixUInt128Hi( a ) < d. That is what makes the quotient fit in 64 bits,
+/// and it is the caller's job -- this is the inner primitive of Knuth Algorithm D, whose
+/// normalization step establishes exactly that invariant, rather than a general-purpose
+/// divide. Violating it on the native arm truncates; there is no check, because the one
+/// caller proves the precondition and a branch here would sit inside the division loop.
+FIX_ALWAYS_INLINE uint64_t fixUInt128DivRemBy64( fixUInt128 a, uint64_t d, uint64_t* remainder )
+{
+#if defined( __x86_64__ )
+	// The hardware 128/64 divide, which is exactly this operation. divq traps when the
+	// quotient overflows 64 bits, and the precondition above -- high half below the
+	// divisor -- is precisely what rules that out, so it cannot fault here. volatile for
+	// the same reason fixInt128Div needs it: a non-volatile asm is assumed side-effect
+	// free and can be hoisted above the guard that makes it safe.
+	uint64_t quotient, rest;
+	uint64_t high = (uint64_t)( a >> 64 );
+	uint64_t low = (uint64_t)a;
+	__asm__ volatile( "divq %[v]" : "=a"( quotient ), "=d"( rest ) : [v] "r"( d ), "a"( low ), "d"( high ) );
+	*remainder = rest;
+	return quotient;
+#elif defined( _WIN32 )
+	// ClangCL does not link compiler-rt builtins, so native 128-bit division (__udivti3)
+	// is unavailable and this arm restores shift-subtract. Bit-identical, and reached only
+	// on Windows targets without the instruction above -- arm64 clang-cl today. The same
+	// reasoning and the same fallback as fixInt128Div.
+	fixUInt128 quotient = 0;
+	fixUInt128 rest = 0;
+	for ( int i = 127; i >= 0; i-- )
+	{
+		rest = ( rest << 1 ) | ( ( a >> i ) & 1 );
+		if ( rest >= (fixUInt128)d )
+		{
+			rest -= (fixUInt128)d;
+			quotient |= ( (fixUInt128)1 ) << i;
+		}
+	}
+	*remainder = (uint64_t)rest;
+	return (uint64_t)quotient;
+#else
+	fixUInt128 quotient = a / d;
+	*remainder = (uint64_t)( a - quotient * d );
+	return (uint64_t)quotient;
+#endif
+}
 // The shifts are the plain operators, with no guard on the count. That is deliberate and
 // it is the one place the two arms differ: a shift count outside [0, 127] is undefined
 // behavior for native __int128, so there is no native answer for the emulation to match,
@@ -675,6 +722,22 @@ FIX_ALWAYS_INLINE fixUInt128 fixUInt128Sub( fixUInt128 a, fixUInt128 b ) { retur
 FIX_ALWAYS_INLINE fixUInt128 fixUInt128Mul( fixUInt128 a, fixUInt128 b ) { return fixEmuUInt128Mul( a, b ); }
 FIX_ALWAYS_INLINE fixUInt128 fixUInt128MulU64( uint64_t a, uint64_t b ) { return fixEmuUInt128MulU64( a, b ); }
 FIX_ALWAYS_INLINE fixUInt128 fixUInt128Neg( fixUInt128 a ) { return fixEmuUInt128Neg( a ); }
+
+/// Divide a 128-bit value by a 64-bit divisor, returning the quotient and, through the
+/// pointer, the remainder.
+///
+/// PRECONDITION: fixUInt128Hi( a ) < d. That is what makes the quotient fit in 64 bits,
+/// and it is the caller's job -- this is the inner primitive of Knuth Algorithm D, whose
+/// normalization step establishes exactly that invariant, rather than a general-purpose
+/// divide. Violating it on the native arm truncates; there is no check, because the one
+/// caller proves the precondition and a branch here would sit inside the division loop.
+FIX_ALWAYS_INLINE uint64_t fixUInt128DivRemBy64( fixUInt128 a, uint64_t d, uint64_t* remainder )
+{
+	fixEmuUInt128 quotient, rest;
+	fixEmuUInt128DivMod( a, fixEmuUInt128FromU64( d ), &quotient, &rest );
+	*remainder = fixEmuUInt128Lo( rest );
+	return fixEmuUInt128Lo( quotient );
+}
 FIX_ALWAYS_INLINE fixUInt128 fixUInt128Shl( fixUInt128 a, int shift ) { return fixEmuUInt128Shl( a, shift ); }
 FIX_ALWAYS_INLINE fixUInt128 fixUInt128Shr( fixUInt128 a, int shift ) { return fixEmuUInt128Shr( a, shift ); }
 FIX_ALWAYS_INLINE fixUInt128 fixUInt128Or( fixUInt128 a, fixUInt128 b ) { return fixEmuUInt128Or( a, b ); }

--- a/extern/fixed/include/fixed/fixed_int256.h
+++ b/extern/fixed/include/fixed/fixed_int256.h
@@ -197,41 +197,256 @@ FIX_ALWAYS_INLINE fixUInt256 fixUInt256MulU128ByU64( fixUInt128 a, uint64_t b )
 	return fixUInt256Add( shifted, fixUInt256FromU128( lowPart ) );
 }
 
-/// Exact unsigned division with remainder. Shift-subtract, entered at the highest bit
-/// that can contribute, so the loop length tracks the operands rather than the type.
-/// A zero divisor yields a zero quotient and remainder: every caller in this library
-/// tests the divisor first, and returning rather than trapping keeps a caller's mistake
-/// from killing a process.
+/// Number of leading zero bits, written out rather than taken from a builtin so the
+/// plain-MSVC arm needs no intrinsic and every arm folds the same way.
+FIX_ALWAYS_INLINE int fixCountLeadingZeros64( uint64_t x )
+{
+	if ( x == 0 )
+	{
+		return 64;
+	}
+
+	int n = 0;
+	if ( ( x >> 32 ) == 0 ) { n += 32; x <<= 32; }
+	if ( ( x >> 48 ) == 0 ) { n += 16; x <<= 16; }
+	if ( ( x >> 56 ) == 0 ) { n += 8; x <<= 8; }
+	if ( ( x >> 60 ) == 0 ) { n += 4; x <<= 4; }
+	if ( ( x >> 62 ) == 0 ) { n += 2; x <<= 2; }
+	if ( ( x >> 63 ) == 0 ) { n += 1; }
+	return n;
+}
+
+FIX_ALWAYS_INLINE void fixUInt256ToLimbs( fixUInt256 a, uint64_t limbs[4] )
+{
+	limbs[0] = fixUInt128Lo( a.lo );
+	limbs[1] = fixUInt128Hi( a.lo );
+	limbs[2] = fixUInt128Lo( a.hi );
+	limbs[3] = fixUInt128Hi( a.hi );
+}
+
+FIX_ALWAYS_INLINE fixUInt256 fixUInt256FromLimbs( const uint64_t limbs[4] )
+{
+	fixUInt256 r;
+	r.lo = fixUInt128Make( limbs[1], limbs[0] );
+	r.hi = fixUInt128Make( limbs[3], limbs[2] );
+	return r;
+}
+
+/// Internal: shift a limb left by s, bringing in the top s bits of the limb below.
+/// The s == 0 case is spelled out because `x >> 64` is undefined, and that is the single
+/// most common way to get a normalizing shift wrong.
+FIX_ALWAYS_INLINE uint64_t fixShiftInLimb( uint64_t high, uint64_t low, int s )
+{
+	if ( s == 0 )
+	{
+		return high;
+	}
+
+	return ( high << s ) | ( low >> ( 64 - s ) );
+}
+
+/// Exact unsigned division with remainder: Knuth Algorithm D over 64-bit limbs.
+///
+/// This was a shift-subtract loop -- one iteration per bit of the dividend, around two
+/// hundred of them, each doing 256-bit shifts, compares and subtracts. Exact, and slow in
+/// a place that matters: a consumer storing inverse quantities at a wider scale puts a 3x3
+/// solve of large values in a per-substep path, and every one of those divisions landed
+/// here. Algorithm D replaces the bit loop with at most three 128-by-64 divides.
+///
+/// A zero divisor yields a zero quotient and remainder rather than trapping: every caller
+/// in this library tests the divisor first, and returning keeps a caller's mistake from
+/// killing a process. That contract is unchanged.
+///
+/// The three parts that are easy to get wrong, and how each is handled here:
+///
+///   NORMALIZATION shifts the divisor so its top limb has its top bit set, which is what
+///   bounds the quotient estimate's error at two. The shift of zero is spelled out
+///   separately in fixShiftInLimb, because `x >> 64` is undefined behavior and a
+///   normalized divisor is exactly the input that asks for it.
+///
+///   THE ESTIMATE can exceed the true quotient limb by at most two once normalized, and
+///   the loop below walks it down using the next limb of each operand. The rare case
+///   where the top limbs are equal is handled by starting at the largest possible limb
+///   rather than by dividing, since that division would overflow.
+///
+///   THE ADD-BACK fires when the estimate was still one too large after correction, which
+///   happens for roughly one input in 2^63. It is the step most likely to be missing from
+///   an implementation that passes a casual test, so test/int256_division_test.c carries
+///   constructed vectors for it rather than hoping a random sweep lands on one.
 FIX_ALWAYS_INLINE void fixUInt256DivMod( fixUInt256 dividend, fixUInt256 divisor, fixUInt256* quotientOut, fixUInt256* remainderOut )
 {
-	fixUInt256 quotient;
-	quotient.hi = FIX_UINT128_ZERO;
-	quotient.lo = FIX_UINT128_ZERO;
-	fixUInt256 remainder = quotient;
+	uint64_t u[4], v[4];
+	fixUInt256ToLimbs( dividend, u );
+	fixUInt256ToLimbs( divisor, v );
 
-	if ( fixUInt256IsZero( divisor ) )
+	uint64_t q[4] = { 0, 0, 0, 0 };
+
+	int n = 4;
+	while ( n > 0 && v[n - 1] == 0 ) { n--; }
+
+	if ( n == 0 )
 	{
-		*quotientOut = quotient;
-		*remainderOut = remainder;
+		fixUInt256 zero;
+		zero.hi = FIX_UINT128_ZERO;
+		zero.lo = FIX_UINT128_ZERO;
+		*quotientOut = zero;
+		*remainderOut = zero;
 		return;
 	}
 
-	for ( int i = fixUInt256BitLength( dividend ) - 1; i >= 0; --i )
+	int m = 4;
+	while ( m > 0 && u[m - 1] == 0 ) { m--; }
+
+	if ( m < n )
 	{
-		remainder = fixUInt256Shl( remainder, 1 );
-		if ( fixUInt256Bit( dividend, i ) )
+		// The quotient is zero and the dividend is the remainder. Also covers a zero
+		// dividend, where m is 0.
+		fixUInt256 zero;
+		zero.hi = FIX_UINT128_ZERO;
+		zero.lo = FIX_UINT128_ZERO;
+		*quotientOut = zero;
+		*remainderOut = dividend;
+		return;
+	}
+
+	if ( n == 1 )
+	{
+		// Short division: one 128-by-64 divide per limb, the remainder feeding the next.
+		// The precondition of fixUInt128DivRemBy64 holds inductively because each
+		// remainder is already below the divisor.
+		uint64_t rest = 0;
+		for ( int i = m - 1; i >= 0; i-- )
 		{
-			remainder = fixUInt256Add( remainder, fixUInt256FromU64( 1 ) );
+			q[i] = fixUInt128DivRemBy64( fixUInt128Make( rest, u[i] ), v[0], &rest );
 		}
-		if ( fixUInt256Ge( remainder, divisor ) )
+
+		*quotientOut = fixUInt256FromLimbs( q );
+		*remainderOut = fixUInt256FromU64( rest );
+		return;
+	}
+
+	// Normalize. un needs one limb more than the dividend for the bits shifted out of it.
+	int s = fixCountLeadingZeros64( v[n - 1] );
+
+	uint64_t vn[4];
+	for ( int i = n - 1; i > 0; i-- ) { vn[i] = fixShiftInLimb( v[i], v[i - 1], s ); }
+	vn[0] = v[0] << s;
+
+	uint64_t un[5];
+	un[m] = s == 0 ? 0 : ( u[m - 1] >> ( 64 - s ) );
+	for ( int i = m - 1; i > 0; i-- ) { un[i] = fixShiftInLimb( u[i], u[i - 1], s ); }
+	un[0] = u[0] << s;
+
+	for ( int j = m - n; j >= 0; j-- )
+	{
+		uint64_t qhat;
+		uint64_t rhat;
+		bool rhatFits;
+
+		if ( un[j + n] >= vn[n - 1] )
 		{
-			remainder = fixUInt256Sub( remainder, divisor );
-			quotient = fixUInt256Add( quotient, fixUInt256Shl( fixUInt256FromU64( 1 ), i ) );
+			// The estimate would be the base itself, which does not fit a limb; start at
+			// the largest limb there is and let the correction below walk it down.
+			qhat = UINT64_MAX;
+
+			fixUInt128 numerator = fixUInt128Make( un[j + n], un[j + n - 1] );
+			fixUInt128 product = fixUInt128MulU64( qhat, vn[n - 1] );
+			fixUInt128 rest = fixUInt128Sub( numerator, product );
+			rhatFits = fixUInt128Hi( rest ) == 0;
+			rhat = fixUInt128Lo( rest );
+		}
+		else
+		{
+			qhat = fixUInt128DivRemBy64( fixUInt128Make( un[j + n], un[j + n - 1] ), vn[n - 1], &rhat );
+			rhatFits = true;
+		}
+
+		// Walk the estimate down while it is provably too large. Once rhat leaves 64 bits
+		// the test cannot fire again, so the loop stops there.
+		while ( rhatFits && qhat != 0 &&
+				fixUInt128Gt( fixUInt128MulU64( qhat, vn[n - 2] ), fixUInt128Make( rhat, un[j + n - 2] ) ) )
+		{
+			qhat--;
+			fixUInt128 widened = fixUInt128Add( fixUInt128FromU64( rhat ), fixUInt128FromU64( vn[n - 1] ) );
+			rhatFits = fixUInt128Hi( widened ) == 0;
+			rhat = fixUInt128Lo( widened );
+		}
+
+		// Multiply and subtract, carrying the borrow at 128 bits so the wrap cases need no
+		// reasoning about which of two subtractions overflowed.
+		uint64_t borrow = 0;
+		uint64_t carry = 0;
+		for ( int i = 0; i < n; i++ )
+		{
+			fixUInt128 product = fixUInt128Add( fixUInt128MulU64( qhat, vn[i] ), fixUInt128FromU64( carry ) );
+			carry = fixUInt128Hi( product );
+
+			fixUInt128 left = fixUInt128FromU64( un[i + j] );
+			fixUInt128 right = fixUInt128Add( fixUInt128FromU64( fixUInt128Lo( product ) ), fixUInt128FromU64( borrow ) );
+			if ( fixUInt128Ge( left, right ) )
+			{
+				un[i + j] = fixUInt128Lo( fixUInt128Sub( left, right ) );
+				borrow = 0;
+			}
+			else
+			{
+				un[i + j] = fixUInt128Lo( fixUInt128Sub( fixUInt128Add( left, fixUInt128Shl( fixUInt128FromU64( 1 ), 64 ) ), right ) );
+				borrow = 1;
+			}
+		}
+
+		bool negative;
+		{
+			fixUInt128 left = fixUInt128FromU64( un[j + n] );
+			fixUInt128 right = fixUInt128Add( fixUInt128FromU64( carry ), fixUInt128FromU64( borrow ) );
+			if ( fixUInt128Ge( left, right ) )
+			{
+				un[j + n] = fixUInt128Lo( fixUInt128Sub( left, right ) );
+				negative = false;
+			}
+			else
+			{
+				un[j + n] = fixUInt128Lo( fixUInt128Sub( fixUInt128Add( left, fixUInt128Shl( fixUInt128FromU64( 1 ), 64 ) ), right ) );
+				negative = true;
+			}
+		}
+
+		q[j] = qhat;
+
+#ifdef FIX_INT256_NO_ADDBACK
+		// The negative control removes the add-back, which is the rarest branch here and
+		// the one an implementation is most likely to be missing. The control build MUST
+		// fail: if it passes, the suite has stopped reaching this path and has gone blind
+		// on it -- which is exactly what happened to an earlier version of the test, whose
+		// hand-written "add-back vectors" reached this branch zero times.
+		negative = false;
+#endif
+
+		if ( negative )
+		{
+			// The estimate was one too large after all: give the limb back and add the
+			// divisor in again. The carry out of that addition cancels the borrow above.
+			q[j] = qhat - 1;
+
+			uint64_t addCarry = 0;
+			for ( int i = 0; i < n; i++ )
+			{
+				fixUInt128 sum = fixUInt128Add( fixUInt128Add( fixUInt128FromU64( un[i + j] ), fixUInt128FromU64( vn[i] ) ),
+												fixUInt128FromU64( addCarry ) );
+				un[i + j] = fixUInt128Lo( sum );
+				addCarry = fixUInt128Hi( sum );
+			}
+			un[j + n] += addCarry;
 		}
 	}
 
-	*quotientOut = quotient;
-	*remainderOut = remainder;
+	// Denormalize the remainder. Limbs at or above n are zero by construction.
+	uint64_t r[4] = { 0, 0, 0, 0 };
+	for ( int i = 0; i < n - 1; i++ ) { r[i] = ( un[i] >> s ) | ( s == 0 ? 0 : ( un[i + 1] << ( 64 - s ) ) ); }
+	r[n - 1] = un[n - 1] >> s;
+
+	*quotientOut = fixUInt256FromLimbs( q );
+	*remainderOut = fixUInt256FromLimbs( r );
 }
 
 /// True if a two's complement 256-bit value is negative.

--- a/include/box3d/box3d.h
+++ b/include/box3d/box3d.h
@@ -633,11 +633,38 @@ B3_API b3Fixed b3Body_GetMass( b3BodyId bodyId );
 /// Get the rotational inertia of the body in local space, usually in kg*m^2
 B3_API b3Matrix3 b3Body_GetLocalRotationalInertia( b3BodyId bodyId );
 
-/// Get the inverse mass of the body, usually in 1/kilograms
+/// Get the inverse mass of the body, usually in 1/kilograms.
+///
+/// LOSSY FOR HEAVY BODIES, and unavoidably so: the solver stores inverse quantities with
+/// more fraction bits than b3Fixed has, because Q48.16 holds no positive value below
+/// 1/65536 and the inverse mass of anything above 65,536 units is smaller than that. The
+/// value returned here is that internal value converted to b3Fixed, truncated toward
+/// zero, so a heavy body reads ZERO from this function while being perfectly movable in
+/// the simulation. Use b3Body_GetInverseMassPrecise to see what the solver actually has.
 B3_API b3Fixed b3Body_GetInverseMass( b3BodyId bodyId );
 
-/// Get the inverse rotational inertia of the body in world space, usually in 1/kg*m^2
+/// Get the inverse rotational inertia of the body in world space, usually in 1/kg*m^2.
+/// Lossy in the same way and for the same reason as b3Body_GetInverseMass.
 B3_API b3Matrix3 b3Body_GetWorldInverseRotationalInertia( b3BodyId bodyId );
+
+/// PROVISIONAL API -- the shape of this pair is not settled.
+///
+/// The inverse mass and world inverse rotational inertia at the precision the solver
+/// stores them: fixed-point with b3GetInverseFractionBits() fraction bits rather than
+/// b3Fixed's 16. These exist because the two functions above cannot represent the inverse
+/// of a heavy body at all, and reporting zero for a body that moves is worse than
+/// reporting an awkward unit.
+///
+/// Added rather than substituted deliberately: nothing above changes meaning, signature
+/// or behaviour for any existing caller. If the eventual answer is a different type, a
+/// different unit or a different name, these can be withdrawn without having broken
+/// anything in the meantime.
+B3_API b3Fixed b3Body_GetInverseMassPrecise( b3BodyId bodyId );
+B3_API b3Matrix3 b3Body_GetWorldInverseRotationalInertiaPrecise( b3BodyId bodyId );
+
+/// The number of fraction bits in the values returned by the two functions above.
+/// Exposed as a function so the internal format constant is not part of the ABI.
+B3_API int b3GetInverseFractionBits( void );
 
 /// Get the center of mass position of the body in local space
 B3_API b3Vec3 b3Body_GetLocalCenter( b3BodyId bodyId );

--- a/src/body.c
+++ b/src/body.c
@@ -949,7 +949,7 @@ void b3UpdateBodyMassData( b3World* world, b3Body* body )
 
 	// Inverted at the inverse scale, which is the whole reason a large body has a usable
 	// inverse inertia at all. Returns a zero matrix for a singular tensor.
-	b3SetLocalInverseInertia( bodySim, b3InvertInertiaWide( body->inertia ), body->inertia );
+	b3SetLocalInverseInertia( bodySim, b3InvertAcrossScales( body->inertia ), body->inertia );
 	if ( bodySim->invInertiaLocal.cx.x > 0 || bodySim->invInertiaLocal.cy.y > 0 || bodySim->invInertiaLocal.cz.z > 0 )
 	{
 		b3Matrix3 rotationMatrix = b3MakeMatrixFromQuat( bodySim->transform.q );
@@ -1793,6 +1793,27 @@ b3Matrix3 b3Body_GetWorldInverseRotationalInertia( b3BodyId bodyId )
 	return b3FixedFromInvMatrix( sim->invInertiaWorld );
 }
 
+b3Fixed b3Body_GetInverseMassPrecise( b3BodyId bodyId )
+{
+	b3World* world = b3GetWorld( bodyId.world0 );
+	b3Body* body = b3GetBodyFullId( world, bodyId );
+	b3BodySim* sim = b3GetBodySim( world, body );
+	return sim->invMass;
+}
+
+b3Matrix3 b3Body_GetWorldInverseRotationalInertiaPrecise( b3BodyId bodyId )
+{
+	b3World* world = b3GetWorld( bodyId.world0 );
+	b3Body* body = b3GetBodyFullId( world, bodyId );
+	b3BodySim* sim = b3GetBodySim( world, body );
+	return sim->invInertiaWorld;
+}
+
+int b3GetInverseFractionBits( void )
+{
+	return B3_INVERSE_FRACTION_BITS;
+}
+
 b3Vec3 b3Body_GetLocalCenter( b3BodyId bodyId )
 {
 	b3World* world = b3GetWorld( bodyId.world0 );
@@ -1852,7 +1873,7 @@ void b3Body_SetMassData( b3BodyId bodyId, b3MassData massData )
 
 	// Inverted at the inverse scale, which is the whole reason a large body has a usable
 	// inverse inertia at all. Returns a zero matrix for a singular tensor.
-	b3SetLocalInverseInertia( bodySim, b3InvertInertiaWide( body->inertia ), body->inertia );
+	b3SetLocalInverseInertia( bodySim, b3InvertAcrossScales( body->inertia ), body->inertia );
 	if ( bodySim->invInertiaLocal.cx.x > 0 || bodySim->invInertiaLocal.cy.y > 0 || bodySim->invInertiaLocal.cz.z > 0 )
 	{
 		b3Matrix3 rotationMatrix = b3MakeMatrixFromQuat( bodySim->transform.q );

--- a/src/body.c
+++ b/src/body.c
@@ -69,10 +69,16 @@ b3BodySim* b3GetBodySim( b3World* world, b3Body* body )
 // The single writer is the point. Two fields holding two views of one quantity drift the
 // moment one of them is assigned somewhere the other is not, and this is the only
 // function that assigns either.
-static void b3SetLocalInverseInertia( b3BodySim* bodySim, b3Matrix3 invInertiaLocal )
+static void b3SetLocalInverseInertia( b3BodySim* bodySim, b3Matrix3 invInertiaLocal, b3Matrix3 inertiaLocal )
 {
 	bodySim->invInertiaLocal = invInertiaLocal;
-	bodySim->inertiaLocal = b3InvertMatrix( invInertiaLocal );
+
+	// The gyroscopic solve wants the inertia, and now that the inverse is stored at a
+	// wider scale the two are no longer a shift apart -- so it is handed the tensor the
+	// caller already has rather than recovered by inverting the inverse. That is both
+	// cheaper and more accurate: the round trip used to lose a rounding in each
+	// direction, and for a large body it lost the value entirely.
+	bodySim->inertiaLocal = inertiaLocal;
 }
 
 b3BodyState* b3GetBodyState( b3World* world, b3Body* body )
@@ -247,7 +253,7 @@ b3BodyId b3CreateBody( b3WorldId worldId, const b3BodyDef* def )
 	bodySim->force = b3Vec3_zero;
 	bodySim->torque = b3Vec3_zero;
 	bodySim->invMass = B3_FIX( 0.0f );
-	b3SetLocalInverseInertia( bodySim, b3Mat3_zero );
+	b3SetLocalInverseInertia( bodySim, b3Mat3_zero, b3Mat3_zero );
 	bodySim->minExtent = B3_HUGE;
 	bodySim->maxExtent = b3Vec3_zero;
 	bodySim->linearDamping = def->linearDamping;
@@ -824,7 +830,7 @@ static b3Fixed b3InverseMass( b3Fixed mass )
 		return B3_FIX( 0.0f );
 	}
 
-	return b3FixMax( b3FixDiv( B3_FIX( 1.0f ), mass ), 1 );
+	return b3FixMax( b3InvFromRatio( mass ), B3_INVERSE_EPSILON );
 }
 
 static void b3FloorInertia( b3Matrix3* inertia, b3Fixed mass )
@@ -851,7 +857,7 @@ void b3UpdateBodyMassData( b3World* world, b3Body* body )
 	body->inertia = b3Mat3_zero;
 
 	bodySim->invMass = B3_FIX( 0.0f );
-	b3SetLocalInverseInertia( bodySim, b3Mat3_zero );
+	b3SetLocalInverseInertia( bodySim, b3Mat3_zero, b3Mat3_zero );
 	bodySim->invInertiaWorld = b3Mat3_zero;
 	bodySim->localCenter = b3Vec3_zero;
 	bodySim->minExtent = B3_HUGE;
@@ -941,10 +947,9 @@ void b3UpdateBodyMassData( b3World* world, b3Body* body )
 
 	b3FloorInertia( &body->inertia, body->mass );
 
-	// b3InvertT computes its determinant at full 128-bit precision internally and
-	// returns a zero matrix if the inertia is singular. A Q48.16 determinant would
-	// underflow for small bodies.
-	b3SetLocalInverseInertia( bodySim, b3InvertT( body->inertia ) );
+	// Inverted at the inverse scale, which is the whole reason a large body has a usable
+	// inverse inertia at all. Returns a zero matrix for a singular tensor.
+	b3SetLocalInverseInertia( bodySim, b3InvertInertiaWide( body->inertia ), body->inertia );
 	if ( bodySim->invInertiaLocal.cx.x > 0 || bodySim->invInertiaLocal.cy.y > 0 || bodySim->invInertiaLocal.cz.z > 0 )
 	{
 		b3Matrix3 rotationMatrix = b3MakeMatrixFromQuat( bodySim->transform.q );
@@ -959,7 +964,7 @@ void b3UpdateBodyMassData( b3World* world, b3Body* body )
 		// the refusal lasted exactly until the next step and then undid itself. Zeroing
 		// both is what makes the decision stick. b3Body_SetMassData already did this;
 		// this path was the asymmetric one.
-		b3SetLocalInverseInertia( bodySim, b3Mat3_zero );
+		b3SetLocalInverseInertia( bodySim, b3Mat3_zero, b3Mat3_zero );
 		bodySim->invInertiaWorld = b3Mat3_zero;
 	}
 
@@ -994,7 +999,7 @@ void b3UpdateBodyMassData( b3World* world, b3Body* body )
 	if ( ( bodySim->flags & b3_fixedRotation ) == b3_fixedRotation )
 	{
 		body->inertia = b3Mat3_zero;
-		b3SetLocalInverseInertia( bodySim, b3Mat3_zero );
+		b3SetLocalInverseInertia( bodySim, b3Mat3_zero, b3Mat3_zero );
 		bodySim->invInertiaWorld = b3Mat3_zero;
 	}
 }
@@ -1398,7 +1403,7 @@ void b3Body_ApplyLinearImpulse( b3BodyId bodyId, b3Vec3 impulse, b3Pos point, bo
 		b3BodyState* state = b3Array_Get( set->bodyStates, localIndex );
 		b3BodySim* bodySim = b3Array_Get( set->bodySims, localIndex );
 
-		state->linearVelocity = b3MulAdd( state->linearVelocity, bodySim->invMass, impulse );
+		state->linearVelocity = b3Add( state->linearVelocity, b3InvMulSV( bodySim->invMass, impulse ) );
 
 		b3Fixed maxLinearSpeed = world->maxLinearSpeed;
 		if ( b3LengthSquared( state->linearVelocity ) > b3FixMul( maxLinearSpeed , maxLinearSpeed ) )
@@ -1406,7 +1411,7 @@ void b3Body_ApplyLinearImpulse( b3BodyId bodyId, b3Vec3 impulse, b3Pos point, bo
 			state->linearVelocity = b3MulSV( maxLinearSpeed, b3Normalize( state->linearVelocity ) );
 		}
 
-		b3Vec3 delta = b3MulMV( bodySim->invInertiaWorld, b3Cross( b3SubPos( point, bodySim->center ), impulse ) );
+		b3Vec3 delta = b3InvMulMV( bodySim->invInertiaWorld, b3Cross( b3SubPos( point, bodySim->center ), impulse ) );
 		state->angularVelocity = b3Add( state->angularVelocity, delta );
 	}
 }
@@ -1432,7 +1437,7 @@ void b3Body_ApplyLinearImpulseToCenter( b3BodyId bodyId, b3Vec3 impulse, bool wa
 		b3SolverSet* set = b3Array_Get( world->solverSets, b3_awakeSet );
 		b3BodyState* state = b3Array_Get( set->bodyStates, localIndex );
 		b3BodySim* bodySim = b3Array_Get( set->bodySims, localIndex );
-		state->linearVelocity = b3MulAdd( state->linearVelocity, bodySim->invMass, impulse );
+		state->linearVelocity = b3Add( state->linearVelocity, b3InvMulSV( bodySim->invMass, impulse ) );
 
 		b3Fixed maxLinearSpeed = world->maxLinearSpeed;
 		if ( b3LengthSquared( state->linearVelocity ) > b3FixMul( maxLinearSpeed , maxLinearSpeed ) )
@@ -1777,7 +1782,7 @@ b3Fixed b3Body_GetInverseMass( b3BodyId bodyId )
 	b3World* world = b3GetWorld( bodyId.world0 );
 	b3Body* body = b3GetBodyFullId( world, bodyId );
 	b3BodySim* sim = b3GetBodySim( world, body );
-	return sim->invMass;
+	return b3FixedFromInv( sim->invMass );
 }
 
 b3Matrix3 b3Body_GetWorldInverseRotationalInertia( b3BodyId bodyId )
@@ -1785,7 +1790,7 @@ b3Matrix3 b3Body_GetWorldInverseRotationalInertia( b3BodyId bodyId )
 	b3World* world = b3GetWorld( bodyId.world0 );
 	b3Body* body = b3GetBodyFullId( world, bodyId );
 	b3BodySim* sim = b3GetBodySim( world, body );
-	return sim->invInertiaWorld;
+	return b3FixedFromInvMatrix( sim->invInertiaWorld );
 }
 
 b3Vec3 b3Body_GetLocalCenter( b3BodyId bodyId )
@@ -1845,10 +1850,9 @@ void b3Body_SetMassData( b3BodyId bodyId, b3MassData massData )
 
 	b3FloorInertia( &body->inertia, body->mass );
 
-	// b3InvertT computes its determinant at full 128-bit precision internally and
-	// returns a zero matrix if the inertia is singular. A Q48.16 determinant would
-	// underflow for small bodies.
-	b3SetLocalInverseInertia( bodySim, b3InvertT( body->inertia ) );
+	// Inverted at the inverse scale, which is the whole reason a large body has a usable
+	// inverse inertia at all. Returns a zero matrix for a singular tensor.
+	b3SetLocalInverseInertia( bodySim, b3InvertInertiaWide( body->inertia ), body->inertia );
 	if ( bodySim->invInertiaLocal.cx.x > 0 || bodySim->invInertiaLocal.cy.y > 0 || bodySim->invInertiaLocal.cz.z > 0 )
 	{
 		b3Matrix3 rotationMatrix = b3MakeMatrixFromQuat( bodySim->transform.q );
@@ -1856,7 +1860,7 @@ void b3Body_SetMassData( b3BodyId bodyId, b3MassData massData )
 	}
 	else
 	{
-		b3SetLocalInverseInertia( bodySim, b3Mat3_zero );
+		b3SetLocalInverseInertia( bodySim, b3Mat3_zero, b3Mat3_zero );
 		bodySim->invInertiaWorld = b3Mat3_zero;
 	}
 
@@ -1864,7 +1868,7 @@ void b3Body_SetMassData( b3BodyId bodyId, b3MassData massData )
 	if ( ( bodySim->flags & b3_fixedRotation ) == b3_fixedRotation )
 	{
 		body->inertia = b3Mat3_zero;
-		b3SetLocalInverseInertia( bodySim, b3Mat3_zero );
+		b3SetLocalInverseInertia( bodySim, b3Mat3_zero, b3Mat3_zero );
 		bodySim->invInertiaWorld = b3Mat3_zero;
 	}
 

--- a/src/body.h
+++ b/src/body.h
@@ -7,6 +7,8 @@
 #include "box3d/math_functions.h"
 #include "box3d/types.h"
 
+#include "inverse.h"
+
 typedef struct b3World b3World;
 
 enum b3BodyFlags

--- a/src/contact_solver.c
+++ b/src/contact_solver.c
@@ -157,7 +157,7 @@ void b3PrepareContacts_Mesh( b3SolverBlock block, b3StepContext* context )
 			contactConstraint->invMassB = mB;
 			// The 128-bit matrix inversion is only needed when rolling resistance is active
 			contactConstraint->rollingMass =
-				contact->rollingResistance > B3_FIX( 0.0f ) ? b3InvertMatrix( b3AddMM( iA, iB ) ) : b3Mat3_zero;
+				contact->rollingResistance > B3_FIX( 0.0f ) ? b3InvertAcrossScales( b3AddMM( iA, iB ) ) : b3Mat3_zero;
 			contactConstraint->softness =
 				( contact->flags & b3_contactStaticFlag ) != 0 ? context->staticSoftness : context->contactSoftness;
 			contactConstraint->friction = contact->friction;
@@ -209,7 +209,7 @@ void b3PrepareContacts_Mesh( b3SolverBlock block, b3StepContext* context )
 					b3Vec3 rnA = b3Cross( rA, normal );
 					b3Vec3 rnB = b3Cross( rB, normal );
 					b3Fixed kNormal = mA + mB + b3Dot( rnA, b3MulMV( iA, rnA ) ) + b3Dot( rnB, b3MulMV( iB, rnB ) );
-					cp->normalMass = kNormal > B3_FIX( 0.0f ) ? b3FixDiv( B3_FIX( 1.0f ) , kNormal ) : B3_FIX( 0.0f );
+					cp->normalMass = kNormal > B3_FIX( 0.0f ) ? b3InvReciprocal( kNormal ) : B3_FIX( 0.0f );
 
 					// Save relative velocity for restitution
 					b3Vec3 vrA = b3Add( vA, b3Cross( wA, rA ) );
@@ -251,14 +251,14 @@ void b3PrepareContacts_Mesh( b3SolverBlock block, b3StepContext* context )
 					k.cy.y = mA + mB + b3Dot( rtA2, b3MulMV( iA, rtA2 ) ) + b3Dot( rtB2, b3MulMV( iB, rtB2 ) );
 					k.cx.y = k.cy.x = b3Dot( rtA1, b3MulMV( iA, rtA2 ) ) + b3Dot( rtB1, b3MulMV( iB, rtB2 ) );
 
-					constraint->tangentMass = b3Invert2( k );
+					constraint->tangentMass = b3Invert2AcrossScales( k );
 					constraint->frictionImpulse.x = b3FixMul( warmStartScale , b3Dot( manifold->frictionImpulse, tangent1 ) );
 					constraint->frictionImpulse.y = b3FixMul( warmStartScale , b3Dot( manifold->frictionImpulse, tangent2 ) );
 				}
 
 				{
 					b3Fixed k = b3Dot( normal, b3MulMV( b3AddMM( iA, iB ), normal ) );
-					constraint->twistMass = k > B3_FIX( 0.0f ) ? b3FixDiv( B3_FIX( 1.0f ) , k ) : B3_FIX( 0.0f );
+					constraint->twistMass = k > B3_FIX( 0.0f ) ? b3InvReciprocal( k ) : B3_FIX( 0.0f );
 					constraint->twistImpulse = b3FixMul( warmStartScale , manifold->twistImpulse );
 				}
 
@@ -325,10 +325,10 @@ void b3WarmStartContacts_Mesh( b3SolverBlock block, b3StepContext* context )
 				b3Vec3 rB = cp->rB;
 
 				b3Vec3 impulse = b3MulSV( cp->normalImpulse, normal );
-				wA = b3Sub( wA, b3MulMV( iA, b3Cross( rA, impulse ) ) );
-				vA = b3MulSub( vA, mA, impulse );
-				wB = b3Add( wB, b3MulMV( iB, b3Cross( rB, impulse ) ) );
-				vB = b3MulAdd( vB, mB, impulse );
+				wA = b3Sub( wA, b3InvMulMV( iA, b3Cross( rA, impulse ) ) );
+				vA = b3Sub( vA, b3InvMulSV( mA, impulse ) );
+				wB = b3Add( wB, b3InvMulMV( iB, b3Cross( rB, impulse ) ) );
+				vB = b3Add( vB, b3InvMulSV( mB, impulse ) );
 			}
 
 			// Central friction
@@ -338,24 +338,24 @@ void b3WarmStartContacts_Mesh( b3SolverBlock block, b3StepContext* context )
 				b3Vec3 impulse = b3MulSV( constraint->frictionImpulse.x, constraint->tangent1 );
 				impulse = b3Add( impulse, b3MulSV( constraint->frictionImpulse.y, constraint->tangent2 ) );
 
-				wA = b3Sub( wA, b3MulMV( iA, b3Cross( rA, impulse ) ) );
-				vA = b3MulSub( vA, mA, impulse );
-				wB = b3Add( wB, b3MulMV( iB, b3Cross( rB, impulse ) ) );
-				vB = b3MulAdd( vB, mB, impulse );
+				wA = b3Sub( wA, b3InvMulMV( iA, b3Cross( rA, impulse ) ) );
+				vA = b3Sub( vA, b3InvMulSV( mA, impulse ) );
+				wB = b3Add( wB, b3InvMulMV( iB, b3Cross( rB, impulse ) ) );
+				vB = b3Add( vB, b3InvMulSV( mB, impulse ) );
 			}
 
 			// Central twist friction
 			{
 				b3Vec3 impulse = b3MulSV( constraint->twistImpulse, constraint->normal );
-				wA = b3Sub( wA, b3MulMV( iA, impulse ) );
-				wB = b3Add( wB, b3MulMV( iB, impulse ) );
+				wA = b3Sub( wA, b3InvMulMV( iA, impulse ) );
+				wB = b3Add( wB, b3InvMulMV( iB, impulse ) );
 			}
 
 			// Rolling resistance
 			{
 				b3Vec3 impulse = constraint->rollingImpulse;
-				wA = b3Sub( wA, b3MulMV( iA, impulse ) );
-				wB = b3Add( wB, b3MulMV( iB, impulse ) );
+				wA = b3Sub( wA, b3InvMulMV( iA, impulse ) );
+				wB = b3Add( wB, b3InvMulMV( iB, impulse ) );
 			}
 		}
 
@@ -692,11 +692,11 @@ void b3SolveContacts_Mesh( b3SolverBlock block, b3StepContext* context, bool use
 
 				// apply normal impulse
 				b3Vec3 P = b3MulSV( deltaImpulse, normal );
-				vA = b3MulSub( vA, mA, P );
-				wA = b3Sub( wA, b3MulMV( iA, b3Cross( rA, P ) ) );
+				vA = b3Sub( vA, b3InvMulSV( mA, P ) );
+				wA = b3Sub( wA, b3InvMulMV( iA, b3Cross( rA, P ) ) );
 
-				vB = b3MulAdd( vB, mB, P );
-				wB = b3Add( wB, b3MulMV( iB, b3Cross( rB, P ) ) );
+				vB = b3Add( vB, b3InvMulSV( mB, P ) );
+				wB = b3Add( wB, b3InvMulMV( iB, b3Cross( rB, P ) ) );
 			}
 
 			// No friction when applying bias
@@ -716,8 +716,8 @@ void b3SolveContacts_Mesh( b3SolverBlock block, b3StepContext* context, bool use
 				constraint->twistImpulse = b3FixClamp( oldImpulse + deltaImpulse, -maxImpulse, maxImpulse );
 				deltaImpulse = constraint->twistImpulse - oldImpulse;
 
-				wA = b3Sub( wA, b3MulMV( iA, b3MulSV( deltaImpulse, constraint->normal ) ) );
-				wB = b3Add( wB, b3MulMV( iB, b3MulSV( deltaImpulse, constraint->normal ) ) );
+				wA = b3Sub( wA, b3InvMulMV( iA, b3MulSV( deltaImpulse, constraint->normal ) ) );
+				wB = b3Add( wB, b3InvMulMV( iB, b3MulSV( deltaImpulse, constraint->normal ) ) );
 			}
 
 			// Rolling resistance
@@ -753,8 +753,8 @@ void b3SolveContacts_Mesh( b3SolverBlock block, b3StepContext* context, bool use
 
 				deltaImpulse = b3Sub( constraint->rollingImpulse, oldImpulse );
 
-				wA = b3Sub( wA, b3MulMV( iA, deltaImpulse ) );
-				wB = b3Add( wB, b3MulMV( iB, deltaImpulse ) );
+				wA = b3Sub( wA, b3InvMulMV( iA, deltaImpulse ) );
+				wB = b3Add( wB, b3InvMulMV( iB, deltaImpulse ) );
 			}
 
 			// Central friction
@@ -814,10 +814,10 @@ void b3SolveContacts_Mesh( b3SolverBlock block, b3StepContext* context, bool use
 
 				// Apply delta impulse
 				b3Vec3 P = b3Blend2( deltaImpulse.x, tangent1, deltaImpulse.y, tangent2 );
-				vA = b3MulSub( vA, mA, P );
-				wA = b3Sub( wA, b3MulMV( iA, b3Cross( rA, P ) ) );
-				vB = b3MulAdd( vB, mB, P );
-				wB = b3Add( wB, b3MulMV( iB, b3Cross( rB, P ) ) );
+				vA = b3Sub( vA, b3InvMulSV( mA, P ) );
+				wA = b3Sub( wA, b3InvMulMV( iA, b3Cross( rA, P ) ) );
+				vB = b3Add( vB, b3InvMulSV( mB, P ) );
+				wB = b3Add( wB, b3InvMulMV( iB, b3Cross( rB, P ) ) );
 			}
 		}
 
@@ -917,10 +917,10 @@ void b3ApplyRestitution_Mesh( b3SolverBlock block, b3StepContext* context )
 
 				// apply contact impulse
 				b3Vec3 P = b3MulSV( impulse, normal );
-				vA = b3MulSub( vA, mA, P );
-				wA = b3Sub( wA, b3MulMV( iA, b3Cross( rA, P ) ) );
-				vB = b3MulAdd( vB, mB, P );
-				wB = b3Add( wB, b3MulMV( iB, b3Cross( rB, P ) ) );
+				vA = b3Sub( vA, b3InvMulSV( mA, P ) );
+				wA = b3Sub( wA, b3InvMulMV( iA, b3Cross( rA, P ) ) );
+				vB = b3Add( vB, b3InvMulSV( mB, P ) );
+				wB = b3Add( wB, b3InvMulMV( iB, b3Cross( rB, P ) ) );
 			}
 
 			if ( stateA->flags & b3_dynamicFlag )
@@ -1142,6 +1142,14 @@ static inline b3Vec3W b3WidenVW( b3Vec3WN a )
 
 // Store one lane of a narrow field. Values are bounded by hull extents; the
 // clamp keeps a pathological world deterministic instead of wrapping.
+// Store one lane of a FULL-WIDTH field. The inverse-scaled Jacobian rows live at full
+// width (see the struct comments), so they need this rather than b3StoreNarrow -- which
+// would clamp them to int32 and destroy the precision the wider scale exists to provide.
+static inline void b3StoreWideLane( b3FloatW* target, int lane, b3Fixed value )
+{
+	( (int64_t*)target )[lane] = value;
+}
+
 static inline void b3StoreNarrow( b3FloatWN* target, int lane, b3Fixed value )
 {
 	B3_ASSERT( -INT32_MAX <= value && value <= INT32_MAX );
@@ -1901,6 +1909,75 @@ static inline b3Vec3W b3MulMVFullW( const b3Matrix3FullW* m, b3Vec3W a )
 	};
 }
 
+// ================================================================================
+// CROSSING THE INVERSE SCALE, WIDE.
+//
+// The wide constraint carries inverse quantities and rows built from them -- invMass*n,
+// invI*cross(r,n), invI*n -- all of which stay in the inverse scale, because b3MulW
+// shifts by 16 (see src/inverse.h). These are the operations that take one of those and
+// produce an ORDINARY velocity, so they shift by B3_INVERSE_FRACTION_BITS instead.
+//
+// All of them are PER-PRODUCT, not fused, and that is a requirement rather than a
+// preference: the scalar path uses b3InvMulMV, which rounds per product, and the scalar
+// and wide paths must agree bit for bit or the determinism goldens diverge by worker
+// count. Fusing these would be a real optimization and it is not available here.
+// ================================================================================
+
+static inline b3FloatW b3InvMulW( b3FloatW a, b3FloatW b )
+{
+	return b3MakeW( b3InvMul( a.x, b.x ), b3InvMul( a.y, b.y ), b3InvMul( a.z, b.z ), b3InvMul( a.w, b.w ) );
+}
+
+/// 1 / k per lane, where k is inverse-scaled and the effective mass is ordinary.
+static inline b3FloatW b3InvReciprocalW( b3FloatW a )
+{
+	return b3MakeW( b3InvReciprocal( a.x ), b3InvReciprocal( a.y ), b3InvReciprocal( a.z ), b3InvReciprocal( a.w ) );
+}
+
+// a - s * b, where s or b carries the inverse scale and the result is a velocity.
+static inline b3Vec3W b3InvMulSubSVW( b3Vec3W a, b3FloatW s, b3Vec3W b )
+{
+	return (b3Vec3W){ b3SubW( a.X, b3InvMulW( s, b.X ) ), b3SubW( a.Y, b3InvMulW( s, b.Y ) ),
+					  b3SubW( a.Z, b3InvMulW( s, b.Z ) ) };
+}
+
+// a + s * b, likewise.
+static inline b3Vec3W b3InvMulAddSVW( b3Vec3W a, b3FloatW s, b3Vec3W b )
+{
+	return (b3Vec3W){ b3AddW( a.X, b3InvMulW( s, b.X ) ), b3AddW( a.Y, b3InvMulW( s, b.Y ) ),
+					  b3AddW( a.Z, b3InvMulW( s, b.Z ) ) };
+}
+
+// a - m * b, where m is an inverse inertia and the result is an angular velocity.
+static inline b3Vec3W b3InvMulSubMVW( b3Vec3W a, b3SymMatrix3W m, b3Vec3W b )
+{
+	return (b3Vec3W){
+		b3SubW( a.X, b3AddW( b3AddW( b3InvMulW( m.cxx, b.X ), b3InvMulW( m.cxy, b.Y ) ), b3InvMulW( m.cxz, b.Z ) ) ),
+		b3SubW( a.Y, b3AddW( b3AddW( b3InvMulW( m.cxy, b.X ), b3InvMulW( m.cyy, b.Y ) ), b3InvMulW( m.cyz, b.Z ) ) ),
+		b3SubW( a.Z, b3AddW( b3AddW( b3InvMulW( m.cxz, b.X ), b3InvMulW( m.cyz, b.Y ) ), b3InvMulW( m.czz, b.Z ) ) ),
+	};
+}
+
+// a + m * b, likewise.
+static inline b3Vec3W b3InvMulAddMVW( b3Vec3W a, b3SymMatrix3W m, b3Vec3W b )
+{
+	return (b3Vec3W){
+		b3AddW( a.X, b3AddW( b3AddW( b3InvMulW( m.cxx, b.X ), b3InvMulW( m.cxy, b.Y ) ), b3InvMulW( m.cxz, b.Z ) ) ),
+		b3AddW( a.Y, b3AddW( b3AddW( b3InvMulW( m.cxy, b.X ), b3InvMulW( m.cyy, b.Y ) ), b3InvMulW( m.cyz, b.Z ) ) ),
+		b3AddW( a.Z, b3AddW( b3AddW( b3InvMulW( m.cxz, b.X ), b3InvMulW( m.cyz, b.Y ) ), b3InvMulW( m.czz, b.Z ) ) ),
+	};
+}
+
+// m * a for a full (non-symmetric) inverse tensor, giving an ordinary vector.
+static inline b3Vec3W b3InvMulMVFullW( const b3Matrix3FullW* m, b3Vec3W a )
+{
+	return (b3Vec3W){
+		b3AddW( b3AddW( b3InvMulW( m->cxx, a.X ), b3InvMulW( m->cyx, a.Y ) ), b3InvMulW( m->czx, a.Z ) ),
+		b3AddW( b3AddW( b3InvMulW( m->cxy, a.X ), b3InvMulW( m->cyy, a.Y ) ), b3InvMulW( m->czy, a.Z ) ),
+		b3AddW( b3AddW( b3InvMulW( m->cxz, a.X ), b3InvMulW( m->cyz, a.Y ) ), b3InvMulW( m->czz, a.Z ) ),
+	};
+}
+
 // Symmetric 2x2 times vec2 with the scalar b3MulMV2 rounding: per-product
 // rounding, plain adds. The fused b3MulMV2W does not match b3MulMV2.
 static inline b3Vec2W b3MulMV2UnfusedW( b3SymMatrix2W m, b3Vec2W a )
@@ -1940,7 +2017,13 @@ typedef struct b3ContactConstraintPointWide
 	// Each 128-bit fixed multiply costs several ops, so trading memory for
 	// multiplies pays here (unlike the float SIMD solver).
 	b3Vec3WN rnAs, rnBs;
-	b3Vec3WN iRnAs, iRnBs;
+
+	// FULL WIDTH, unlike their neighbours. These carry the inverse scale (see
+	// src/inverse.h), so a typical value is around 2^40 raw and does not fit the int32
+	// the narrow fields use -- it would clamp, not round. The narrow-storage audit that
+	// justified Q16.16 measured ORDINARY Jacobian terms bounded by hull extents; an
+	// inverse-derived row is a different quantity and is not covered by it.
+	b3Vec3W iRnAs, iRnBs;
 
 	b3FloatW baseSeparations;
 	b3FloatW normalImpulses;
@@ -1965,9 +2048,12 @@ typedef struct b3ContactConstraintWide
 	// invI * normal for the twist impulse, cross(origin, tangent) for central
 	// friction.
 	b3Vec3WN normal;
-	b3Vec3WN mNormalA, mNormalB;
-	b3Vec3WN iNormalA, iNormalB;
 	b3Vec3WN rtA1s, rtA2s, rtB1s, rtB2s;
+
+	// FULL WIDTH for the same reason as iRnAs above: invMass * normal and invI * normal
+	// both carry the inverse scale and overflow int32.
+	b3Vec3W mNormalA, mNormalB;
+	b3Vec3W iNormalA, iNormalB;
 
 	// todo test computing the tangents on the fly, at least tangent2
 	// ^ measured and REJECTED 2026-07-13 (branch tangent2-on-the-fly): bit-identical
@@ -2694,7 +2780,7 @@ void b3PrepareContacts_Convex( b3SolverBlock block, b3StepContext* context )
 				b3Vec3W iRnB = b3MulMVFullW( &iBW, rnB );
 				b3FloatW kNormal = b3AddW( b3AddW( mAW, mBW ), b3AddW( b3DotW( rnA, iRnA ), b3DotW( rnB, iRnB ) ) );
 				__mmask8 kPositive = _mm256_cmpgt_epi64_mask( kNormal.v, _mm256_setzero_si256() );
-				cp->normalMasses = b3MaskKeepW( laneValid & kPositive, b3DivW( oneW, kNormal ) );
+				cp->normalMasses = b3MaskKeepW( laneValid & kPositive, b3InvReciprocalW( kNormal ) );
 
 				B3_AUDIT_V3W( b3_auditAnchor, rA );
 				B3_AUDIT_V3W( b3_auditAnchor, rB );
@@ -2707,8 +2793,8 @@ void b3PrepareContacts_Convex( b3SolverBlock block, b3StepContext* context )
 				// Precomputed normal Jacobian rows for the solve and warm start
 				b3StoreNarrowVW( &cp->rnAs, rnA );
 				b3StoreNarrowVW( &cp->rnBs, rnB );
-				b3StoreNarrowVW( &cp->iRnAs, iRnA );
-				b3StoreNarrowVW( &cp->iRnBs, iRnB );
+				cp->iRnAs = (iRnA );
+				cp->iRnBs = (iRnB );
 
 				// Save relative velocity for restitution
 				b3Vec3W vrA = b3AddVW( vAW, b3CrossUnfusedW( wAW, rA ) );
@@ -2726,8 +2812,8 @@ void b3PrepareContacts_Convex( b3SolverBlock block, b3StepContext* context )
 				b3StoreNarrowVW( &cp->anchorBs, b3ZeroVW() );
 				b3StoreNarrowVW( &cp->rnAs, b3ZeroVW() );
 				b3StoreNarrowVW( &cp->rnBs, b3ZeroVW() );
-				b3StoreNarrowVW( &cp->iRnAs, b3ZeroVW() );
-				b3StoreNarrowVW( &cp->iRnBs, b3ZeroVW() );
+				cp->iRnAs = (b3ZeroVW() );
+				cp->iRnBs = (b3ZeroVW() );
 				cp->baseSeparations = b3ZeroW();
 				cp->normalImpulses = b3ZeroW();
 				cp->totalNormalImpulses = b3ZeroW();
@@ -2771,8 +2857,8 @@ void b3PrepareContacts_Convex( b3SolverBlock block, b3StepContext* context )
 			// Precomputed linear normal Jacobian
 			b3Vec3W mNormalAW = b3MulSVW( mAW, normalW );
 			b3Vec3W mNormalBW = b3MulSVW( mBW, normalW );
-			b3StoreNarrowVW( &constraint->mNormalA, mNormalAW );
-			b3StoreNarrowVW( &constraint->mNormalB, mNormalBW );
+			constraint->mNormalA = (mNormalAW );
+			constraint->mNormalB = (mNormalBW );
 
 			B3_AUDIT_V3W( b3_auditMNormal, mNormalAW );
 			B3_AUDIT_V3W( b3_auditMNormal, mNormalBW );
@@ -2797,7 +2883,7 @@ void b3PrepareContacts_Convex( b3SolverBlock block, b3StepContext* context )
 					k.cx.x = ( (b3Fixed*)&kxx )[lane];
 					k.cy.y = ( (b3Fixed*)&kyy )[lane];
 					k.cx.y = k.cy.x = ( (b3Fixed*)&kxy )[lane];
-					b3Matrix2 tangentMass = b3Invert2( k );
+					b3Matrix2 tangentMass = b3Invert2AcrossScales( k );
 
 					( (b3Fixed*)&constraint->tangentMass.cxx )[lane] = tangentMass.cx.x;
 					( (b3Fixed*)&constraint->tangentMass.cxy )[lane] = tangentMass.cx.y;
@@ -2812,12 +2898,12 @@ void b3PrepareContacts_Convex( b3SolverBlock block, b3StepContext* context )
 				// Precomputed angular normal Jacobian, also used for the twist mass
 				b3Vec3W iNormalAW = b3MulMVFullW( &iAW, normalW );
 				b3Vec3W iNormalBW = b3MulMVFullW( &iBW, normalW );
-				b3StoreNarrowVW( &constraint->iNormalA, iNormalAW );
-				b3StoreNarrowVW( &constraint->iNormalB, iNormalBW );
+				constraint->iNormalA = (iNormalAW );
+				constraint->iNormalB = (iNormalBW );
 
 				b3FloatW kTwist = b3AddW( b3DotW( normalW, iNormalAW ), b3DotW( normalW, iNormalBW ) );
 				__mmask8 kPositive = _mm256_cmpgt_epi64_mask( kTwist.v, _mm256_setzero_si256() );
-				constraint->twistMass = b3MaskKeepW( kPositive, b3DivW( oneW, kTwist ) );
+				constraint->twistMass = b3MaskKeepW( kPositive, b3InvReciprocalW( kTwist ) );
 				constraint->twistImpulse = b3MulW( warmStartScaleW, twistImpulseW );
 
 				B3_AUDIT_V3W( b3_auditINormal, iNormalAW );
@@ -2830,7 +2916,7 @@ void b3PrepareContacts_Convex( b3SolverBlock block, b3StepContext* context )
 				for ( int lane = 0; lane < laneCount; ++lane )
 				{
 					b3Matrix3 rollingMass = laneRollingResistance[lane] > B3_FIX( 0.0f )
-												? b3InvertMatrix( b3AddMM( iAFull[lane], iBFull[lane] ) )
+												? b3InvertAcrossScales( b3AddMM( iAFull[lane], iBFull[lane] ) )
 												: b3Mat3_zero;
 
 					( (b3Fixed*)&constraint->rollingMass.cxx )[lane] = rollingMass.cx.x;
@@ -3069,7 +3155,7 @@ void b3PrepareContacts_Convex( b3SolverBlock block, b3StepContext* context )
 					b3Vec3 iRnA = b3MulMV( iA, rnA );
 					b3Vec3 iRnB = b3MulMV( iB, rnB );
 					b3Fixed kNormal = mA + mB + b3Dot( rnA, iRnA ) + b3Dot( rnB, iRnB );
-					( (b3Fixed*)&cp->normalMasses )[lane] = kNormal > B3_FIX( 0.0f ) ? b3FixDiv( B3_FIX( 1.0f ) , kNormal ) : B3_FIX( 0.0f );
+					( (b3Fixed*)&cp->normalMasses )[lane] = kNormal > B3_FIX( 0.0f ) ? b3InvReciprocal( kNormal ) : B3_FIX( 0.0f );
 
 					B3_AUDIT_V3( b3_auditAnchor, rA );
 					B3_AUDIT_V3( b3_auditAnchor, rB );
@@ -3090,12 +3176,12 @@ void b3PrepareContacts_Convex( b3SolverBlock block, b3StepContext* context )
 					b3StoreNarrow( &cp->rnBs.X, lane, rnB.x );
 					b3StoreNarrow( &cp->rnBs.Y, lane, rnB.y );
 					b3StoreNarrow( &cp->rnBs.Z, lane, rnB.z );
-					b3StoreNarrow( &cp->iRnAs.X, lane, iRnA.x );
-					b3StoreNarrow( &cp->iRnAs.Y, lane, iRnA.y );
-					b3StoreNarrow( &cp->iRnAs.Z, lane, iRnA.z );
-					b3StoreNarrow( &cp->iRnBs.X, lane, iRnB.x );
-					b3StoreNarrow( &cp->iRnBs.Y, lane, iRnB.y );
-					b3StoreNarrow( &cp->iRnBs.Z, lane, iRnB.z );
+					b3StoreWideLane( &cp->iRnAs.X, lane, iRnA.x );
+					b3StoreWideLane( &cp->iRnAs.Y, lane, iRnA.y );
+					b3StoreWideLane( &cp->iRnAs.Z, lane, iRnA.z );
+					b3StoreWideLane( &cp->iRnBs.X, lane, iRnB.x );
+					b3StoreWideLane( &cp->iRnBs.Y, lane, iRnB.y );
+					b3StoreWideLane( &cp->iRnBs.Z, lane, iRnB.z );
 
 					// Save relative velocity for restitution
 					b3Vec3 vrA = b3Add( vA, b3Cross( wA, rA ) );
@@ -3137,12 +3223,12 @@ void b3PrepareContacts_Convex( b3SolverBlock block, b3StepContext* context )
 				// Precomputed linear normal Jacobian
 				b3Vec3 mNormalA = b3MulSV( mA, normal );
 				b3Vec3 mNormalB = b3MulSV( mB, normal );
-				b3StoreNarrow( &constraint->mNormalA.X, lane, mNormalA.x );
-				b3StoreNarrow( &constraint->mNormalA.Y, lane, mNormalA.y );
-				b3StoreNarrow( &constraint->mNormalA.Z, lane, mNormalA.z );
-				b3StoreNarrow( &constraint->mNormalB.X, lane, mNormalB.x );
-				b3StoreNarrow( &constraint->mNormalB.Y, lane, mNormalB.y );
-				b3StoreNarrow( &constraint->mNormalB.Z, lane, mNormalB.z );
+				b3StoreWideLane( &constraint->mNormalA.X, lane, mNormalA.x );
+				b3StoreWideLane( &constraint->mNormalA.Y, lane, mNormalA.y );
+				b3StoreWideLane( &constraint->mNormalA.Z, lane, mNormalA.z );
+				b3StoreWideLane( &constraint->mNormalB.X, lane, mNormalB.x );
+				b3StoreWideLane( &constraint->mNormalB.Y, lane, mNormalB.y );
+				b3StoreWideLane( &constraint->mNormalB.Z, lane, mNormalB.z );
 
 				B3_AUDIT_V3( b3_auditMNormal, mNormalA );
 				B3_AUDIT_V3( b3_auditMNormal, mNormalB );
@@ -3156,7 +3242,7 @@ void b3PrepareContacts_Convex( b3SolverBlock block, b3StepContext* context )
 					k.cx.x = mA + mB + b3Dot( rtA1, b3MulMV( iA, rtA1 ) ) + b3Dot( rtB1, b3MulMV( iB, rtB1 ) );
 					k.cy.y = mA + mB + b3Dot( rtA2, b3MulMV( iA, rtA2 ) ) + b3Dot( rtB2, b3MulMV( iB, rtB2 ) );
 					k.cx.y = k.cy.x = b3Dot( rtA1, b3MulMV( iA, rtA2 ) ) + b3Dot( rtB1, b3MulMV( iB, rtB2 ) );
-					b3Matrix2 tangentMass = b3Invert2( k );
+					b3Matrix2 tangentMass = b3Invert2AcrossScales( k );
 
 					( (b3Fixed*)&constraint->tangentMass.cxx )[lane] = tangentMass.cx.x;
 					( (b3Fixed*)&constraint->tangentMass.cxy )[lane] = tangentMass.cx.y;
@@ -3172,15 +3258,15 @@ void b3PrepareContacts_Convex( b3SolverBlock block, b3StepContext* context )
 					// Precomputed angular normal Jacobian, also used for the twist mass
 					b3Vec3 iNormalA = b3MulMV( iA, normal );
 					b3Vec3 iNormalB = b3MulMV( iB, normal );
-					b3StoreNarrow( &constraint->iNormalA.X, lane, iNormalA.x );
-					b3StoreNarrow( &constraint->iNormalA.Y, lane, iNormalA.y );
-					b3StoreNarrow( &constraint->iNormalA.Z, lane, iNormalA.z );
-					b3StoreNarrow( &constraint->iNormalB.X, lane, iNormalB.x );
-					b3StoreNarrow( &constraint->iNormalB.Y, lane, iNormalB.y );
-					b3StoreNarrow( &constraint->iNormalB.Z, lane, iNormalB.z );
+					b3StoreWideLane( &constraint->iNormalA.X, lane, iNormalA.x );
+					b3StoreWideLane( &constraint->iNormalA.Y, lane, iNormalA.y );
+					b3StoreWideLane( &constraint->iNormalA.Z, lane, iNormalA.z );
+					b3StoreWideLane( &constraint->iNormalB.X, lane, iNormalB.x );
+					b3StoreWideLane( &constraint->iNormalB.Y, lane, iNormalB.y );
+					b3StoreWideLane( &constraint->iNormalB.Z, lane, iNormalB.z );
 
 					b3Fixed k = b3Dot( normal, iNormalA ) + b3Dot( normal, iNormalB );
-					( (b3Fixed*)&constraint->twistMass )[lane] = k > B3_FIX( 0.0f ) ? b3FixDiv( B3_FIX( 1.0f ) , k ) : B3_FIX( 0.0f );
+					( (b3Fixed*)&constraint->twistMass )[lane] = k > B3_FIX( 0.0f ) ? b3InvReciprocal( k ) : B3_FIX( 0.0f );
 					( (b3Fixed*)&constraint->twistImpulse )[lane] = b3FixMul( warmStartScale , manifold->twistImpulse );
 
 					B3_AUDIT_V3( b3_auditINormal, iNormalA );
@@ -3191,7 +3277,7 @@ void b3PrepareContacts_Convex( b3SolverBlock block, b3StepContext* context )
 				{
 					// The 128-bit matrix inversion is only needed when rolling resistance is active
 					b3Matrix3 rollingMass =
-						contact->rollingResistance > B3_FIX( 0.0f ) ? b3InvertMatrix( b3AddMM( iA, iB ) ) : b3Mat3_zero;
+						contact->rollingResistance > B3_FIX( 0.0f ) ? b3InvertAcrossScales( b3AddMM( iA, iB ) ) : b3Mat3_zero;
 
 					( (b3Fixed*)&constraint->rollingMass.cxx )[lane] = rollingMass.cx.x;
 					( (b3Fixed*)&constraint->rollingMass.cxy )[lane] = rollingMass.cx.y;
@@ -3221,12 +3307,12 @@ void b3PrepareContacts_Convex( b3SolverBlock block, b3StepContext* context )
 					b3StoreNarrow( &cp->rnBs.X, lane, B3_FIX( 0.0f ) );
 					b3StoreNarrow( &cp->rnBs.Y, lane, B3_FIX( 0.0f ) );
 					b3StoreNarrow( &cp->rnBs.Z, lane, B3_FIX( 0.0f ) );
-					b3StoreNarrow( &cp->iRnAs.X, lane, B3_FIX( 0.0f ) );
-					b3StoreNarrow( &cp->iRnAs.Y, lane, B3_FIX( 0.0f ) );
-					b3StoreNarrow( &cp->iRnAs.Z, lane, B3_FIX( 0.0f ) );
-					b3StoreNarrow( &cp->iRnBs.X, lane, B3_FIX( 0.0f ) );
-					b3StoreNarrow( &cp->iRnBs.Y, lane, B3_FIX( 0.0f ) );
-					b3StoreNarrow( &cp->iRnBs.Z, lane, B3_FIX( 0.0f ) );
+					b3StoreWideLane( &cp->iRnAs.X, lane, B3_FIX( 0.0f ) );
+					b3StoreWideLane( &cp->iRnAs.Y, lane, B3_FIX( 0.0f ) );
+					b3StoreWideLane( &cp->iRnAs.Z, lane, B3_FIX( 0.0f ) );
+					b3StoreWideLane( &cp->iRnBs.X, lane, B3_FIX( 0.0f ) );
+					b3StoreWideLane( &cp->iRnBs.Y, lane, B3_FIX( 0.0f ) );
+					b3StoreWideLane( &cp->iRnBs.Z, lane, B3_FIX( 0.0f ) );
 					( (b3Fixed*)&cp->baseSeparations )[lane] = B3_FIX( 0.0f );
 					( (b3Fixed*)&cp->normalImpulses )[lane] = B3_FIX( 0.0f );
 					( (b3Fixed*)&cp->totalNormalImpulses )[lane] = B3_FIX( 0.0f );
@@ -3268,10 +3354,10 @@ void b3WarmStartContacts_Convex( b3SolverBlock block, b3StepContext* context )
 		{
 			b3ContactConstraintPointWide* cp = c->points + j;
 
-			bA.v = b3MulSubSVW( bA.v, cp->normalImpulses, b3WidenVW( c->mNormalA ) );
-			bA.w = b3MulSubSVW( bA.w, cp->normalImpulses, b3WidenVW( cp->iRnAs ) );
-			bB.v = b3MulAddSVW( bB.v, cp->normalImpulses, b3WidenVW( c->mNormalB ) );
-			bB.w = b3MulAddSVW( bB.w, cp->normalImpulses, b3WidenVW( cp->iRnBs ) );
+			bA.v = b3InvMulSubSVW( bA.v, cp->normalImpulses, c->mNormalA );
+			bA.w = b3InvMulSubSVW( bA.w, cp->normalImpulses, cp->iRnAs );
+			bB.v = b3InvMulAddSVW( bB.v, cp->normalImpulses, c->mNormalB );
+			bB.w = b3InvMulAddSVW( bB.w, cp->normalImpulses, cp->iRnBs );
 		}
 
 		// Central friction
@@ -3285,23 +3371,23 @@ void b3WarmStartContacts_Convex( b3SolverBlock block, b3StepContext* context )
 			b3Vec3W LB = b3MulSVW( c->frictionImpulse.x, b3WidenVW( c->rtB1s ) );
 			LB = b3MulAddSVW( LB, c->frictionImpulse.y, b3WidenVW( c->rtB2s ) );
 
-			bA.w = b3MulSubMVW( bA.w, c->invIA, LA );
-			bA.v = b3MulSubSVW( bA.v, c->invMassA, impulse );
-			bB.w = b3MulAddMVW( bB.w, c->invIB, LB );
-			bB.v = b3MulAddSVW( bB.v, c->invMassB, impulse );
+			bA.w = b3InvMulSubMVW( bA.w, c->invIA, LA );
+			bA.v = b3InvMulSubSVW( bA.v, c->invMassA, impulse );
+			bB.w = b3InvMulAddMVW( bB.w, c->invIB, LB );
+			bB.v = b3InvMulAddSVW( bB.v, c->invMassB, impulse );
 		}
 
 		// Central twist friction
 		{
-			bA.w = b3MulSubSVW( bA.w, c->twistImpulse, b3WidenVW( c->iNormalA ) );
-			bB.w = b3MulAddSVW( bB.w, c->twistImpulse, b3WidenVW( c->iNormalB ) );
+			bA.w = b3InvMulSubSVW( bA.w, c->twistImpulse, c->iNormalA );
+			bB.w = b3InvMulAddSVW( bB.w, c->twistImpulse, c->iNormalB );
 		}
 
 		// Rolling resistance
 		{
 			b3Vec3W impulse = c->rollingImpulse;
-			bA.w = b3MulSubMVW( bA.w, c->invIA, impulse );
-			bB.w = b3MulAddMVW( bB.w, c->invIB, impulse );
+			bA.w = b3InvMulSubMVW( bA.w, c->invIA, impulse );
+			bB.w = b3InvMulAddMVW( bB.w, c->invIB, impulse );
 		}
 
 		b3ScatterBodies( states, c->indexA, &bA );
@@ -3409,10 +3495,10 @@ void b3SolveContacts_Convex( b3SolverBlock block, b3StepContext* context, bool u
 			B3_AUDIT_W( b3_auditTotalNormalImpulse, cp->totalNormalImpulses );
 
 			// Apply contact impulse through the precomputed Jacobian rows
-			bA.v = b3MulSubSVW( bA.v, deltaImpulse, b3WidenVW( c->mNormalA ) );
-			bA.w = b3MulSubSVW( bA.w, deltaImpulse, b3WidenVW( cp->iRnAs ) );
-			bB.v = b3MulAddSVW( bB.v, deltaImpulse, b3WidenVW( c->mNormalB ) );
-			bB.w = b3MulAddSVW( bB.w, deltaImpulse, b3WidenVW( cp->iRnBs ) );
+			bA.v = b3InvMulSubSVW( bA.v, deltaImpulse, c->mNormalA );
+			bA.w = b3InvMulSubSVW( bA.w, deltaImpulse, cp->iRnAs );
+			bB.v = b3InvMulAddSVW( bB.v, deltaImpulse, c->mNormalB );
+			bB.w = b3InvMulAddSVW( bB.w, deltaImpulse, cp->iRnBs );
 		}
 
 		// No friction when applying bias
@@ -3459,8 +3545,8 @@ void b3SolveContacts_Convex( b3SolverBlock block, b3StepContext* context, bool u
 
 				deltaImpulse = b3SubVW( c->rollingImpulse, oldImpulse );
 
-				bA.w = b3MulSubMVW( bA.w, c->invIA, deltaImpulse );
-				bB.w = b3MulAddMVW( bB.w, c->invIB, deltaImpulse );
+				bA.w = b3InvMulSubMVW( bA.w, c->invIA, deltaImpulse );
+				bB.w = b3InvMulAddMVW( bB.w, c->invIB, deltaImpulse );
 			}
 
 			// Central twist friction
@@ -3473,8 +3559,8 @@ void b3SolveContacts_Convex( b3SolverBlock block, b3StepContext* context, bool u
 				c->twistImpulse = b3SymClampW( b3AddW( oldImpulse, deltaImpulse ), maxLambda );
 				deltaImpulse = b3SubW( c->twistImpulse, oldImpulse );
 
-				bA.w = b3MulSubSVW( bA.w, deltaImpulse, b3WidenVW( c->iNormalA ) );
-				bB.w = b3MulAddSVW( bB.w, deltaImpulse, b3WidenVW( c->iNormalB ) );
+				bA.w = b3InvMulSubSVW( bA.w, deltaImpulse, c->iNormalA );
+				bB.w = b3InvMulAddSVW( bB.w, deltaImpulse, c->iNormalB );
 			}
 
 			// Central friction
@@ -3546,10 +3632,10 @@ void b3SolveContacts_Convex( b3SolverBlock block, b3StepContext* context, bool u
 									  b3MulSVW( deltaImpulse.y, b3WidenVW( c->rtA2s ) ) );
 				b3Vec3W LB = b3AddVW( b3MulSVW( deltaImpulse.x, b3WidenVW( c->rtB1s ) ),
 									  b3MulSVW( deltaImpulse.y, b3WidenVW( c->rtB2s ) ) );
-				bA.w = b3MulSubMVW( bA.w, c->invIA, LA );
-				bA.v = b3MulSubSVW( bA.v, c->invMassA, P );
-				bB.w = b3MulAddMVW( bB.w, c->invIB, LB );
-				bB.v = b3MulAddSVW( bB.v, c->invMassB, P );
+				bA.w = b3InvMulSubMVW( bA.w, c->invIA, LA );
+				bA.v = b3InvMulSubSVW( bA.v, c->invMassA, P );
+				bB.w = b3InvMulAddMVW( bB.w, c->invIB, LB );
+				bB.v = b3InvMulAddSVW( bB.v, c->invMassB, P );
 			}
 		}
 
@@ -3613,10 +3699,10 @@ void b3ApplyRestitution_Convex( b3SolverBlock block, b3StepContext* context )
 			cp->totalNormalImpulses = b3AddW( cp->totalNormalImpulses, deltaImpulse );
 
 			// Apply contact impulse through the precomputed Jacobian rows
-			bA.v = b3MulSubSVW( bA.v, deltaImpulse, b3WidenVW( c->mNormalA ) );
-			bA.w = b3MulSubSVW( bA.w, deltaImpulse, b3WidenVW( cp->iRnAs ) );
-			bB.v = b3MulAddSVW( bB.v, deltaImpulse, b3WidenVW( c->mNormalB ) );
-			bB.w = b3MulAddSVW( bB.w, deltaImpulse, b3WidenVW( cp->iRnBs ) );
+			bA.v = b3InvMulSubSVW( bA.v, deltaImpulse, c->mNormalA );
+			bA.w = b3InvMulSubSVW( bA.w, deltaImpulse, cp->iRnAs );
+			bB.v = b3InvMulAddSVW( bB.v, deltaImpulse, c->mNormalB );
+			bB.w = b3InvMulAddSVW( bB.w, deltaImpulse, cp->iRnBs );
 		}
 
 		b3ScatterBodies( states, c->indexA, &bA );
@@ -3922,7 +4008,7 @@ void b3PrepareContacts_MeshWide( b3SolverBlock block, b3StepContext* context )
 
 				// The 128-bit matrix inversion is only needed when rolling resistance is active
 				b3Matrix3 rollingMass =
-					contact->rollingResistance > B3_FIX( 0.0f ) ? b3InvertMatrix( b3AddMM( iA, iB ) ) : b3Mat3_zero;
+					contact->rollingResistance > B3_FIX( 0.0f ) ? b3InvertAcrossScales( b3AddMM( iA, iB ) ) : b3Mat3_zero;
 				( (b3Fixed*)&constraint->rollingMass.cxx )[lane] = rollingMass.cx.x;
 				( (b3Fixed*)&constraint->rollingMass.cxy )[lane] = rollingMass.cx.y;
 				( (b3Fixed*)&constraint->rollingMass.cxz )[lane] = rollingMass.cx.z;
@@ -3998,7 +4084,7 @@ void b3PrepareContacts_MeshWide( b3SolverBlock block, b3StepContext* context )
 						b3Vec3 rnB = b3Cross( rB, normal );
 						b3Fixed kNormal = mA + mB + b3Dot( rnA, b3MulMV( iA, rnA ) ) + b3Dot( rnB, b3MulMV( iB, rnB ) );
 						( (b3Fixed*)&cp->normalMass )[lane] =
-							kNormal > B3_FIX( 0.0f ) ? b3FixDiv( B3_FIX( 1.0f ), kNormal ) : B3_FIX( 0.0f );
+							kNormal > B3_FIX( 0.0f ) ? b3InvReciprocal( kNormal ) : B3_FIX( 0.0f );
 
 						// Save relative velocity for restitution
 						b3Vec3 vrA = b3Add( vA, b3Cross( wA, rA ) );
@@ -4040,7 +4126,7 @@ void b3PrepareContacts_MeshWide( b3SolverBlock block, b3StepContext* context )
 						k.cy.y = mA + mB + b3Dot( rtA2, b3MulMV( iA, rtA2 ) ) + b3Dot( rtB2, b3MulMV( iB, rtB2 ) );
 						k.cx.y = k.cy.x = b3Dot( rtA1, b3MulMV( iA, rtA2 ) ) + b3Dot( rtB1, b3MulMV( iB, rtB2 ) );
 
-						b3Matrix2 tangentMass = b3Invert2( k );
+						b3Matrix2 tangentMass = b3Invert2AcrossScales( k );
 						B3_ASSERT( tangentMass.cx.y == tangentMass.cy.x );
 						( (b3Fixed*)&slot->tangentMass.cxx )[lane] = tangentMass.cx.x;
 						( (b3Fixed*)&slot->tangentMass.cxy )[lane] = tangentMass.cx.y;
@@ -4055,7 +4141,7 @@ void b3PrepareContacts_MeshWide( b3SolverBlock block, b3StepContext* context )
 					{
 						b3Fixed k = b3Dot( normal, b3MulMV( b3AddMM( iA, iB ), normal ) );
 						( (b3Fixed*)&slot->twistMass )[lane] =
-							k > B3_FIX( 0.0f ) ? b3FixDiv( B3_FIX( 1.0f ), k ) : B3_FIX( 0.0f );
+							k > B3_FIX( 0.0f ) ? b3InvReciprocal( k ) : B3_FIX( 0.0f );
 						( (b3Fixed*)&slot->twistImpulse )[lane] = b3FixMul( warmStartScale, manifold->twistImpulse );
 					}
 
@@ -4101,10 +4187,10 @@ void b3WarmStartContacts_MeshWide( b3SolverBlock block, b3StepContext* context )
 				b3ManifoldConstraintPointMeshWide* cp = m->points + j;
 
 				b3Vec3W impulse = b3MulSVW( cp->normalImpulse, normal );
-				bA.w = b3SubVW( bA.w, b3MulMVFullW( &c->invIA, b3CrossUnfusedW( cp->rA, impulse ) ) );
-				bA.v = b3MulSubSVW( bA.v, c->invMassA, impulse );
-				bB.w = b3AddVW( bB.w, b3MulMVFullW( &c->invIB, b3CrossUnfusedW( cp->rB, impulse ) ) );
-				bB.v = b3MulAddSVW( bB.v, c->invMassB, impulse );
+				bA.w = b3SubVW( bA.w, b3InvMulMVFullW( &c->invIA, b3CrossUnfusedW( cp->rA, impulse ) ) );
+				bA.v = b3InvMulSubSVW( bA.v, c->invMassA, impulse );
+				bB.w = b3AddVW( bB.w, b3InvMulMVFullW( &c->invIB, b3CrossUnfusedW( cp->rB, impulse ) ) );
+				bB.v = b3InvMulAddSVW( bB.v, c->invMassB, impulse );
 			}
 
 			// Central friction
@@ -4112,24 +4198,24 @@ void b3WarmStartContacts_MeshWide( b3SolverBlock block, b3StepContext* context )
 				b3Vec3W impulse = b3MulSVW( m->frictionImpulse.x, m->tangent1 );
 				impulse = b3AddVW( impulse, b3MulSVW( m->frictionImpulse.y, m->tangent2 ) );
 
-				bA.w = b3SubVW( bA.w, b3MulMVFullW( &c->invIA, b3CrossUnfusedW( m->centerA, impulse ) ) );
-				bA.v = b3MulSubSVW( bA.v, c->invMassA, impulse );
-				bB.w = b3AddVW( bB.w, b3MulMVFullW( &c->invIB, b3CrossUnfusedW( m->centerB, impulse ) ) );
-				bB.v = b3MulAddSVW( bB.v, c->invMassB, impulse );
+				bA.w = b3SubVW( bA.w, b3InvMulMVFullW( &c->invIA, b3CrossUnfusedW( m->centerA, impulse ) ) );
+				bA.v = b3InvMulSubSVW( bA.v, c->invMassA, impulse );
+				bB.w = b3AddVW( bB.w, b3InvMulMVFullW( &c->invIB, b3CrossUnfusedW( m->centerB, impulse ) ) );
+				bB.v = b3InvMulAddSVW( bB.v, c->invMassB, impulse );
 			}
 
 			// Central twist friction
 			{
 				b3Vec3W impulse = b3MulSVW( m->twistImpulse, normal );
-				bA.w = b3SubVW( bA.w, b3MulMVFullW( &c->invIA, impulse ) );
-				bB.w = b3AddVW( bB.w, b3MulMVFullW( &c->invIB, impulse ) );
+				bA.w = b3SubVW( bA.w, b3InvMulMVFullW( &c->invIA, impulse ) );
+				bB.w = b3AddVW( bB.w, b3InvMulMVFullW( &c->invIB, impulse ) );
 			}
 
 			// Rolling resistance
 			{
 				b3Vec3W impulse = m->rollingImpulse;
-				bA.w = b3SubVW( bA.w, b3MulMVFullW( &c->invIA, impulse ) );
-				bB.w = b3AddVW( bB.w, b3MulMVFullW( &c->invIB, impulse ) );
+				bA.w = b3SubVW( bA.w, b3InvMulMVFullW( &c->invIA, impulse ) );
+				bB.w = b3AddVW( bB.w, b3InvMulMVFullW( &c->invIB, impulse ) );
 			}
 		}
 
@@ -4232,10 +4318,10 @@ void b3SolveContacts_MeshWide( b3SolverBlock block, b3StepContext* context, bool
 
 				// apply normal impulse
 				b3Vec3W P = b3MulSVW( deltaImpulse, normal );
-				bA.v = b3MulSubSVW( bA.v, c->invMassA, P );
-				bA.w = b3SubVW( bA.w, b3MulMVFullW( &c->invIA, b3CrossUnfusedW( rA, P ) ) );
-				bB.v = b3MulAddSVW( bB.v, c->invMassB, P );
-				bB.w = b3AddVW( bB.w, b3MulMVFullW( &c->invIB, b3CrossUnfusedW( rB, P ) ) );
+				bA.v = b3InvMulSubSVW( bA.v, c->invMassA, P );
+				bA.w = b3SubVW( bA.w, b3InvMulMVFullW( &c->invIA, b3CrossUnfusedW( rA, P ) ) );
+				bB.v = b3InvMulAddSVW( bB.v, c->invMassB, P );
+				bB.w = b3AddVW( bB.w, b3InvMulMVFullW( &c->invIB, b3CrossUnfusedW( rB, P ) ) );
 			}
 
 			// No friction when applying bias
@@ -4256,8 +4342,8 @@ void b3SolveContacts_MeshWide( b3SolverBlock block, b3StepContext* context, bool
 				deltaImpulse = b3SubW( m->twistImpulse, oldImpulse );
 
 				b3Vec3W P = b3MulSVW( deltaImpulse, normal );
-				bA.w = b3SubVW( bA.w, b3MulMVFullW( &c->invIA, P ) );
-				bB.w = b3AddVW( bB.w, b3MulMVFullW( &c->invIB, P ) );
+				bA.w = b3SubVW( bA.w, b3InvMulMVFullW( &c->invIA, P ) );
+				bB.w = b3AddVW( bB.w, b3InvMulMVFullW( &c->invIB, P ) );
 			}
 
 			// Rolling resistance. The rolling mass and resistance are per-contact,
@@ -4297,8 +4383,8 @@ void b3SolveContacts_MeshWide( b3SolverBlock block, b3StepContext* context, bool
 
 				deltaImpulse = b3SubVW( rollingImpulse, oldImpulse );
 
-				bA.w = b3SubVW( bA.w, b3MulMVFullW( &c->invIA, deltaImpulse ) );
-				bB.w = b3AddVW( bB.w, b3MulMVFullW( &c->invIB, deltaImpulse ) );
+				bA.w = b3SubVW( bA.w, b3InvMulMVFullW( &c->invIA, deltaImpulse ) );
+				bB.w = b3AddVW( bB.w, b3InvMulMVFullW( &c->invIB, deltaImpulse ) );
 			}
 
 			// Central friction
@@ -4351,10 +4437,10 @@ void b3SolveContacts_MeshWide( b3SolverBlock block, b3StepContext* context, bool
 
 				// Apply delta impulse
 				b3Vec3W P = b3AddVW( b3MulSVW( deltaImpulse.x, tangent1 ), b3MulSVW( deltaImpulse.y, tangent2 ) );
-				bA.v = b3MulSubSVW( bA.v, c->invMassA, P );
-				bA.w = b3SubVW( bA.w, b3MulMVFullW( &c->invIA, b3CrossUnfusedW( rA, P ) ) );
-				bB.v = b3MulAddSVW( bB.v, c->invMassB, P );
-				bB.w = b3AddVW( bB.w, b3MulMVFullW( &c->invIB, b3CrossUnfusedW( rB, P ) ) );
+				bA.v = b3InvMulSubSVW( bA.v, c->invMassA, P );
+				bA.w = b3SubVW( bA.w, b3InvMulMVFullW( &c->invIA, b3CrossUnfusedW( rA, P ) ) );
+				bB.v = b3InvMulAddSVW( bB.v, c->invMassB, P );
+				bB.w = b3AddVW( bB.w, b3InvMulMVFullW( &c->invIB, b3CrossUnfusedW( rB, P ) ) );
 			}
 		}
 
@@ -4422,10 +4508,10 @@ void b3ApplyRestitution_MeshWide( b3SolverBlock block, b3StepContext* context )
 
 				// apply contact impulse
 				b3Vec3W P = b3MulSVW( impulse, normal );
-				bA.v = b3MulSubSVW( bA.v, c->invMassA, P );
-				bA.w = b3SubVW( bA.w, b3MulMVFullW( &c->invIA, b3CrossUnfusedW( cp->rA, P ) ) );
-				bB.v = b3MulAddSVW( bB.v, c->invMassB, P );
-				bB.w = b3AddVW( bB.w, b3MulMVFullW( &c->invIB, b3CrossUnfusedW( cp->rB, P ) ) );
+				bA.v = b3InvMulSubSVW( bA.v, c->invMassA, P );
+				bA.w = b3SubVW( bA.w, b3InvMulMVFullW( &c->invIA, b3CrossUnfusedW( cp->rA, P ) ) );
+				bB.v = b3InvMulAddSVW( bB.v, c->invMassB, P );
+				bB.w = b3AddVW( bB.w, b3InvMulMVFullW( &c->invIB, b3CrossUnfusedW( cp->rB, P ) ) );
 			}
 		}
 

--- a/src/contact_solver.c
+++ b/src/contact_solver.c
@@ -1145,10 +1145,16 @@ static inline b3Vec3W b3WidenVW( b3Vec3WN a )
 // Store one lane of a FULL-WIDTH field. The inverse-scaled Jacobian rows live at full
 // width (see the struct comments), so they need this rather than b3StoreNarrow -- which
 // would clamp them to int32 and destroy the precision the wider scale exists to provide.
+//
+// Only the lane-at-a-time prepare needs it. The AVX-512 prepare builds those rows as
+// whole vectors and assigns them in one go, so the helper is dead there and the guard
+// says so rather than leaving -Wunused-function to say it.
+#if !defined( B3_SIMD_AVX512 )
 static inline void b3StoreWideLane( b3FloatW* target, int lane, b3Fixed value )
 {
 	( (int64_t*)target )[lane] = value;
 }
+#endif
 
 static inline void b3StoreNarrow( b3FloatWN* target, int lane, b3Fixed value )
 {

--- a/src/contact_solver.c
+++ b/src/contact_solver.c
@@ -1609,43 +1609,6 @@ static inline b3FloatW b3Dot3W( b3FloatW a, b3FloatW b, b3FloatW c, b3FloatW d, 
 #endif
 }
 
-// acc + a*b + c*d + e*f
-static inline b3FloatW b3AddDot3W( b3FloatW acc, b3FloatW a, b3FloatW b, b3FloatW c, b3FloatW d, b3FloatW e, b3FloatW f )
-{
-#if defined( B3_SIMD_AVX512 )
-	// (acc << 16) is a multiple of 2^16, so the single rounded shift splits
-	// exactly: b3FixFromDotRaw((acc << 16) + S) == acc + b3FixFromDotRaw(S)
-	return b3AddW( acc, b3Dot3W( a, b, c, d, e, f ) );
-#else
-	return (b3FloatW){
-		b3FixFromDotRaw( b3Int128ShiftLeft( (b3Int128)acc.x, B3_FIXED_FRACTION_BITS ) + (b3Int128)a.x * b.x + (b3Int128)c.x * d.x + (b3Int128)e.x * f.x ),
-		b3FixFromDotRaw( b3Int128ShiftLeft( (b3Int128)acc.y, B3_FIXED_FRACTION_BITS ) + (b3Int128)a.y * b.y + (b3Int128)c.y * d.y + (b3Int128)e.y * f.y ),
-		b3FixFromDotRaw( b3Int128ShiftLeft( (b3Int128)acc.z, B3_FIXED_FRACTION_BITS ) + (b3Int128)a.z * b.z + (b3Int128)c.z * d.z + (b3Int128)e.z * f.z ),
-		b3FixFromDotRaw( b3Int128ShiftLeft( (b3Int128)acc.w, B3_FIXED_FRACTION_BITS ) + (b3Int128)a.w * b.w + (b3Int128)c.w * d.w + (b3Int128)e.w * f.w ),
-	};
-#endif
-}
-
-// acc - (a*b + c*d + e*f)
-static inline b3FloatW b3SubDot3W( b3FloatW acc, b3FloatW a, b3FloatW b, b3FloatW c, b3FloatW d, b3FloatW e, b3FloatW f )
-{
-#if defined( B3_SIMD_AVX512 )
-	// Round-half-up is not odd-symmetric, so accumulate the negated sum and
-	// round that, exactly like the scalar (acc << 16) - ab - cd - ef.
-	b3DotAccAVX sum = b3DotBeginAVX( a.v, b.v );
-	sum = b3DotAddAVX( sum, c.v, d.v );
-	sum = b3DotAddAVX( sum, e.v, f.v );
-	return b3AddW( acc, (b3FloatW){ .v = b3DotFinishAVX( b3DotNegAVX( sum ) ) } );
-#else
-	return (b3FloatW){
-		b3FixFromDotRaw( b3Int128ShiftLeft( (b3Int128)acc.x, B3_FIXED_FRACTION_BITS ) - (b3Int128)a.x * b.x - (b3Int128)c.x * d.x - (b3Int128)e.x * f.x ),
-		b3FixFromDotRaw( b3Int128ShiftLeft( (b3Int128)acc.y, B3_FIXED_FRACTION_BITS ) - (b3Int128)a.y * b.y - (b3Int128)c.y * d.y - (b3Int128)e.y * f.y ),
-		b3FixFromDotRaw( b3Int128ShiftLeft( (b3Int128)acc.z, B3_FIXED_FRACTION_BITS ) - (b3Int128)a.z * b.z - (b3Int128)c.z * d.z - (b3Int128)e.z * f.z ),
-		b3FixFromDotRaw( b3Int128ShiftLeft( (b3Int128)acc.w, B3_FIXED_FRACTION_BITS ) - (b3Int128)a.w * b.w - (b3Int128)c.w * d.w - (b3Int128)e.w * f.w ),
-	};
-#endif
-}
-
 // Relative velocity along an axis using precomputed cross(r, axis) rows:
 // dot(dv, axis) + dot(wB, rbxa) - dot(wA, raxa), nine products accumulated
 // at 128 bits with a single rounding.
@@ -1684,12 +1647,6 @@ static inline b3FloatW b3RelVelocityW( b3Vec3W dv, b3Vec3W axis, b3Vec3W wB, b3V
 static inline b3Vec3W b3MulSVW( b3FloatW s, b3Vec3W a )
 {
 	return (b3Vec3W){ b3MulW( s, a.X ), b3MulW( s, a.Y ), b3MulW( s, a.Z ) };
-}
-
-// a - s * b
-static inline b3Vec3W b3MulSubSVW( b3Vec3W a, b3FloatW s, b3Vec3W b )
-{
-	return (b3Vec3W){ b3SubW( a.X, b3MulW( s, b.X ) ), b3SubW( a.Y, b3MulW( s, b.Y ) ), b3SubW( a.Z, b3MulW( s, b.Z ) ) };
 }
 
 // a + s * b
@@ -1748,26 +1705,6 @@ static inline b3Vec3W b3MulMVW( b3SymMatrix3W m, b3Vec3W a )
 	};
 
 	return b;
-}
-
-// a - m * b
-static inline b3Vec3W b3MulSubMVW( b3Vec3W a, b3SymMatrix3W m, b3Vec3W b )
-{
-	return (b3Vec3W){
-		b3SubDot3W( a.X, m.cxx, b.X, m.cxy, b.Y, m.cxz, b.Z ),
-		b3SubDot3W( a.Y, m.cxy, b.X, m.cyy, b.Y, m.cyz, b.Z ),
-		b3SubDot3W( a.Z, m.cxz, b.X, m.cyz, b.Y, m.czz, b.Z ),
-	};
-}
-
-// a + m * b
-static inline b3Vec3W b3MulAddMVW( b3Vec3W a, b3SymMatrix3W m, b3Vec3W b )
-{
-	return (b3Vec3W){
-		b3AddDot3W( a.X, m.cxx, b.X, m.cxy, b.Y, m.cxz, b.Z ),
-		b3AddDot3W( a.Y, m.cxy, b.X, m.cyy, b.Y, m.cyz, b.Z ),
-		b3AddDot3W( a.Z, m.cxz, b.X, m.cyz, b.Y, m.czz, b.Z ),
-	};
 }
 
 static inline b3FloatW b3DotW( b3Vec3W a, b3Vec3W b )
@@ -1928,11 +1865,15 @@ static inline b3FloatW b3InvMulW( b3FloatW a, b3FloatW b )
 	return b3MakeW( b3InvMul( a.x, b.x ), b3InvMul( a.y, b.y ), b3InvMul( a.z, b.z ), b3InvMul( a.w, b.w ) );
 }
 
-/// 1 / k per lane, where k is inverse-scaled and the effective mass is ordinary.
+/// 1 / k per lane, where k is inverse-scaled and the effective mass is ordinary. Guarded
+/// because its only callers are in the AVX-512 constraint prepare -- every other build
+/// reaches the same arithmetic through the scalar b3InvReciprocal, lane by lane.
+#if defined( B3_SIMD_AVX512 )
 static inline b3FloatW b3InvReciprocalW( b3FloatW a )
 {
 	return b3MakeW( b3InvReciprocal( a.x ), b3InvReciprocal( a.y ), b3InvReciprocal( a.z ), b3InvReciprocal( a.w ) );
 }
+#endif
 
 // a - s * b, where s or b carries the inverse scale and the result is a velocity.
 static inline b3Vec3W b3InvMulSubSVW( b3Vec3W a, b3FloatW s, b3Vec3W b )

--- a/src/distance_joint.c
+++ b/src/distance_joint.c
@@ -294,7 +294,7 @@ void b3PrepareDistanceJoint( b3JointSim* base, b3StepContext* context )
 	b3Vec3 crA = b3Cross( rA, axis );
 	b3Vec3 crB = b3Cross( rB, axis );
 	b3Fixed k = mA + mB + b3Dot( crA, b3MulMV( iA, crA ) ) + b3Dot( crB, b3MulMV( iB, crB ) );
-	joint->axialMass = k > B3_FIX( 0.0f ) ? b3FixDiv( B3_FIX( 1.0f ) , k ) : B3_FIX( 0.0f );
+	joint->axialMass = k > B3_FIX( 0.0f ) ? b3InvReciprocal( k ) : B3_FIX( 0.0f );
 
 	joint->distanceSoftness = b3MakeSoft( joint->hertz, joint->dampingRatio, context->h );
 
@@ -335,14 +335,14 @@ void b3WarmStartDistanceJoint( b3JointSim* base, b3StepContext* context )
 
 	if ( stateA->flags & b3_dynamicFlag )
 	{
-		stateA->linearVelocity = b3MulSub( stateA->linearVelocity, mA, P );
-		stateA->angularVelocity = b3Sub( stateA->angularVelocity, b3MulMV( iA, b3Cross( rA, P ) ) );
+		stateA->linearVelocity = b3Sub( stateA->linearVelocity, b3InvMulSV( mA, P ) );
+		stateA->angularVelocity = b3Sub( stateA->angularVelocity, b3InvMulMV( iA, b3Cross( rA, P ) ) );
 	}
 
 	if ( stateB->flags & b3_dynamicFlag )
 	{
-		stateB->linearVelocity = b3MulAdd( stateB->linearVelocity, mB, P );
-		stateB->angularVelocity = b3Add( stateB->angularVelocity, b3MulMV( iB, b3Cross( rB, P ) ) );
+		stateB->linearVelocity = b3Add( stateB->linearVelocity, b3InvMulSV( mB, P ) );
+		stateB->angularVelocity = b3Add( stateB->angularVelocity, b3InvMulMV( iB, b3Cross( rB, P ) ) );
 	}
 }
 
@@ -400,10 +400,10 @@ void b3SolveDistanceJoint( b3JointSim* base, b3StepContext* context, bool useBia
 			impulse = joint->impulse - oldImpulse;
 
 			b3Vec3 P = b3MulSV( impulse, axis );
-			vA = b3MulSub( vA, mA, P );
-			wA = b3Sub( wA, b3MulMV( iA, b3Cross( rA, P ) ) );
-			vB = b3MulAdd( vB, mB, P );
-			wB = b3Add( wB, b3MulMV( iB, b3Cross( rB, P ) ) );
+			vA = b3Sub( vA, b3InvMulSV( mA, P ) );
+			wA = b3Sub( wA, b3InvMulMV( iA, b3Cross( rA, P ) ) );
+			vB = b3Add( vB, b3InvMulSV( mB, P ) );
+			wB = b3Add( wB, b3InvMulMV( iB, b3Cross( rB, P ) ) );
 		}
 
 		if ( joint->enableLimit )
@@ -436,10 +436,10 @@ void b3SolveDistanceJoint( b3JointSim* base, b3StepContext* context, bool useBia
 				joint->lowerImpulse = newImpulse;
 
 				b3Vec3 P = b3MulSV( impulse, axis );
-				vA = b3MulSub( vA, mA, P );
-				wA = b3Sub( wA, b3MulMV( iA, b3Cross( rA, P ) ) );
-				vB = b3MulAdd( vB, mB, P );
-				wB = b3Add( wB, b3MulMV( iB, b3Cross( rB, P ) ) );
+				vA = b3Sub( vA, b3InvMulSV( mA, P ) );
+				wA = b3Sub( wA, b3InvMulMV( iA, b3Cross( rA, P ) ) );
+				vB = b3Add( vB, b3InvMulSV( mB, P ) );
+				wB = b3Add( wB, b3InvMulMV( iB, b3Cross( rB, P ) ) );
 			}
 
 			// upper
@@ -470,10 +470,10 @@ void b3SolveDistanceJoint( b3JointSim* base, b3StepContext* context, bool useBia
 				joint->upperImpulse = newImpulse;
 
 				b3Vec3 P = b3MulSV( -impulse, axis );
-				vA = b3MulSub( vA, mA, P );
-				wA = b3Sub( wA, b3MulMV( iA, b3Cross( rA, P ) ) );
-				vB = b3MulAdd( vB, mB, P );
-				wB = b3Add( wB, b3MulMV( iB, b3Cross( rB, P ) ) );
+				vA = b3Sub( vA, b3InvMulSV( mA, P ) );
+				wA = b3Sub( wA, b3InvMulMV( iA, b3Cross( rA, P ) ) );
+				vB = b3Add( vB, b3InvMulSV( mB, P ) );
+				wB = b3Add( wB, b3InvMulMV( iB, b3Cross( rB, P ) ) );
 			}
 		}
 
@@ -488,10 +488,10 @@ void b3SolveDistanceJoint( b3JointSim* base, b3StepContext* context, bool useBia
 			impulse = joint->motorImpulse - oldImpulse;
 
 			b3Vec3 P = b3MulSV( impulse, axis );
-			vA = b3MulSub( vA, mA, P );
-			wA = b3Sub( wA, b3MulMV( iA, b3Cross( rA, P ) ) );
-			vB = b3MulAdd( vB, mB, P );
-			wB = b3Add( wB, b3MulMV( iB, b3Cross( rB, P ) ) );
+			vA = b3Sub( vA, b3InvMulSV( mA, P ) );
+			wA = b3Sub( wA, b3InvMulMV( iA, b3Cross( rA, P ) ) );
+			vB = b3Add( vB, b3InvMulSV( mB, P ) );
+			wB = b3Add( wB, b3InvMulMV( iB, b3Cross( rB, P ) ) );
 		}
 	}
 	else
@@ -516,10 +516,10 @@ void b3SolveDistanceJoint( b3JointSim* base, b3StepContext* context, bool useBia
 		joint->impulse += impulse;
 
 		b3Vec3 P = b3MulSV( impulse, axis );
-		vA = b3MulSub( vA, mA, P );
-		wA = b3Sub( wA, b3MulMV( iA, b3Cross( rA, P ) ) );
-		vB = b3MulAdd( vB, mB, P );
-		wB = b3Add( wB, b3MulMV( iB, b3Cross( rB, P ) ) );
+		vA = b3Sub( vA, b3InvMulSV( mA, P ) );
+		wA = b3Sub( wA, b3InvMulMV( iA, b3Cross( rA, P ) ) );
+		vB = b3Add( vB, b3InvMulSV( mB, P ) );
+		wB = b3Add( wB, b3InvMulMV( iB, b3Cross( rB, P ) ) );
 	}
 
 	if ( stateA->flags & b3_dynamicFlag )

--- a/src/inverse.h
+++ b/src/inverse.h
@@ -1,0 +1,245 @@
+// SPDX-FileCopyrightText: 2026 Más Bandwidth LLC
+// SPDX-License-Identifier: MIT
+//
+// WIDER STORAGE FOR INVERSE QUANTITIES.
+//
+// The solver never uses a body's mass or its inertia tensor. It uses their INVERSES, and
+// an inverse is small exactly where the thing it inverts is large. Q48.16 holds no
+// positive value below 1/65536, so a body past 65,536 units of mass or inertia has no
+// representable inverse at all -- its inverse mass reads zero, which this engine spells
+// STATIC, and its inverse inertia reads zero, which is a body that will not rotate. A
+// uniform solid cube of density 1 crosses that line at about 13.1 units on a side.
+//
+// So inverse quantities carry MORE FRACTION BITS than everything else. They are still
+// b3Fixed and still b3Matrix3 -- what changes is the scale they are interpreted at, and
+// this header is where that scale is named and where every crossing between the two
+// scales happens.
+//
+// ================================================================================
+// THE ONE THING TO UNDERSTAND: MOST ARITHMETIC NEEDS NO CHANGE
+// ================================================================================
+//
+// b3FixMul(a, b) is (a * b) >> 16. Feed it an inverse (scaled 2^40) and an ordinary value
+// (scaled 2^16) and the result is scaled 2^40 -- an inverse again. That is exactly what
+// the effective-mass machinery wants, so it keeps working verbatim:
+//
+//     kNormal = invMassA + invMassB + dot( rnA, invIA * rnA ) + dot( rnB, invIB * rnB )
+//
+// Every term there is a per-mass quantity, every operation is b3FixMul or a sum of them,
+// and the whole expression stays in the inverse scale without a single edit. The same is
+// true of b3AddMM on two inverse tensors, b3MulMV of an inverse tensor by an ordinary
+// vector, b3Dot of an ordinary vector with one of those results, and the similarity
+// transform R * invI * R^T -- because a rotation matrix is dimensionless.
+//
+// WHAT DOES NEED AN EDIT is every place an inverse turns back into an ordinary quantity,
+// and there are only two shapes of those:
+//
+//   1. Applying an inverse to get a velocity:  dv = invMass * J,  dw = invI * torque.
+//      The result is an ordinary Q48.16 value, so the shift is 40, not 16. Use b3InvMul
+//      or b3InvMulMV. Using b3FixMul here is a silent factor of 2^24.
+//
+//   2. Inverting an inverse:  effectiveMass = 1 / kNormal. Use b3InvReciprocal.
+//
+// Getting one of those wrong is a factor of 16,777,216, which is loud in any test that
+// looks at a velocity, and invisible in one that does not.
+//
+// ================================================================================
+// WHY 40 AND NOT 48
+// ================================================================================
+//
+// Widening the fraction buys range at the small end and SPENDS it at the large end, and
+// the large end is real: a small body has a large inverse. Inverse mass and inverse
+// inertia have to share one format, because the contact solver adds them together in the
+// kNormal expression above.
+//
+// The four constraints, measured rather than assumed. The large-body target is space's
+// shipping asteroid, a 250-unit cube of mass 15,625,000 and inertia 8.1e10. The
+// small-body limits are what this engine can actually produce: b3FloorInertia floors the
+// inertia diagonal at 4 ULP, so the largest inverse inertia is 1/(4/65536) = 16,384;
+// mass has no floor, and a 0.01-radius sphere at density 1 gives an inverse mass of
+// about 2.4e5.
+//
+//     inverse mass:    asteroid 6.4e-08  needs f >= 24 ;  2.4e5 must fit -> f <= 45
+//     inverse inertia: asteroid 1.23e-11 needs f >= 37 ;  16384 must fit -> f <= 49
+//
+// The intersection is f in [37, 45]:
+//
+//     format    invI asteroid    invM asteroid    max value    headroom on a 1cm sphere
+//     Q26.37              1.7             8796     6.71e+07                      280x
+//     Q23.40             13.5            70369     8.39e+06                       35x
+//     Q19.44            216.4          1125900     5.24e+05                      2.2x
+//     Q15.48           3462.1         18014399     3.28e+04            0.1x -- OVERFLOWS
+//
+// Q16.48 IS EXCLUDED BY MEASUREMENT, and it was the assumption this work started from.
+// Its ceiling is 32,768 and a one-centimetre sphere needs 240,000, so it would have
+// traded a large-body bug for a small-body bug -- a worse trade, because small bodies are
+// common and large ones are not. 40 is chosen for headroom at both ends rather than for
+// resolution at one: 13.5 quanta of inverse inertia for the asteroid is coarse, but it is
+// more graded response than the hand-tuned constant it replaces, and it keeps 35x of room
+// before a small body overflows.
+//
+// THE FLOOR AND THE FORMAT ARE COUPLED. The f <= 49 bound is b3FloorInertia's 4-ULP
+// constant and nothing else. Lowering that floor raises the largest inverse inertia and
+// eats this headroom, so the two must be changed together. That sentence is the reason
+// this comment exists.
+#pragma once
+
+#include "box3d/math_functions.h"
+#include "box3d/types.h"
+
+/// Fraction bits for stored inverse quantities. See the analysis above before changing
+/// it: it is one constant precisely so the choice can be revisited cheaply, but it is
+/// bounded on both sides and neither bound is arbitrary.
+#define B3_INVERSE_FRACTION_BITS 40
+
+/// How much wider an inverse is than an ordinary value. Every conversion below shifts by
+/// either this or B3_INVERSE_FRACTION_BITS.
+#define B3_INVERSE_EXTRA_BITS ( B3_INVERSE_FRACTION_BITS - B3_FIXED_FRACTION_BITS )
+
+/// One quantum of an inverse quantity: the smallest value this format tells apart from
+/// zero, and therefore the floor a finite dynamic mass clamps to.
+#define B3_INVERSE_EPSILON ( (b3Fixed)1 )
+
+/// The largest inverse quantity that fits. Named so the small-body bound is testable
+/// rather than only described.
+#define B3_INVERSE_MAX_VALUE ( B3_FIXED_MAX >> B3_INVERSE_FRACTION_BITS )
+
+/// An ordinary Q48.16 value seen as an inverse quantity. Exact, and overflows above
+/// B3_INVERSE_MAX_VALUE -- only for literals and configured values, never for a computed
+/// inverse, which b3InvFromRatio produces already scaled.
+B3_INLINE b3Fixed b3InvFromFixed( b3Fixed a )
+{
+	return a << B3_INVERSE_EXTRA_BITS;
+}
+
+/// An inverse quantity seen as an ordinary Q48.16 value, truncating toward zero. Lossy by
+/// construction: this is the conversion that used to be the storage, and it is what the
+/// public API returns to callers who ask for an inverse mass.
+B3_INLINE b3Fixed b3FixedFromInv( b3Fixed a )
+{
+	return a >> B3_INVERSE_EXTRA_BITS;
+}
+
+/// 1/a, exactly, in the inverse scale. This is the whole point of the format.
+///
+/// The numerator is 2^(16+40) = 2^56, which fits in an int64 with room to spare, so one
+/// hardware divide gives the exact truncated reciprocal and no 128-bit arithmetic is
+/// involved. A zero denominator returns zero: zero mass is the degenerate body, not
+/// infinity, and every caller here already treats it that way.
+B3_INLINE b3Fixed b3InvFromRatio( b3Fixed a )
+{
+	if ( a == 0 )
+	{
+		return 0;
+	}
+
+	return ( (int64_t)1 << ( B3_FIXED_FRACTION_BITS + B3_INVERSE_FRACTION_BITS ) ) / a;
+}
+
+/// 1 / k, where k is an inverse quantity and the answer is an ordinary one: the effective
+/// mass of a constraint. Same single divide, same zero convention.
+B3_INLINE b3Fixed b3InvReciprocal( b3Fixed k )
+{
+	if ( k == 0 )
+	{
+		return B3_FIX( 0.0f );
+	}
+
+	return ( (int64_t)1 << ( B3_FIXED_FRACTION_BITS + B3_INVERSE_FRACTION_BITS ) ) / k;
+}
+
+/// An inverse quantity applied to an ordinary one, giving an ORDINARY one: dv = invMass*J.
+///
+/// Shift by the inverse's fraction bits, not by 16. Round half up, matching b3FixMul, and
+/// at 128 bits because a large inverse against a large impulse leaves 64.
+B3_INLINE b3Fixed b3InvMul( b3Fixed a, b3Fixed b )
+{
+	fixInt128 product = fixInt128MulI64( a, b );
+	fixInt128 rounded = fixInt128Add( product, fixInt128FromI64( (int64_t)1 << ( B3_INVERSE_FRACTION_BITS - 1 ) ) );
+	return (b3Fixed)fixInt128ToI64( fixInt128Shr( rounded, B3_INVERSE_FRACTION_BITS ) );
+}
+
+/// An inverse scalar applied to an ordinary vector, giving an ORDINARY vector:
+/// dv = invMass * impulse.
+B3_INLINE b3Vec3 b3InvMulSV( b3Fixed a, b3Vec3 v )
+{
+	b3Vec3 out = { b3InvMul( a, v.x ), b3InvMul( a, v.y ), b3InvMul( a, v.z ) };
+	return out;
+}
+
+/// A whole inverse tensor seen as ordinary Q48.16, for the public getters. Lossy in
+/// exactly the way the old storage was: a large body's inverse inertia reads zero here,
+/// which is now a property of the reporting rather than of the simulation.
+B3_INLINE b3Matrix3 b3FixedFromInvMatrix( b3Matrix3 m )
+{
+	b3Matrix3 out;
+	out.cx = B3_LITERAL( b3Vec3 ){ b3FixedFromInv( m.cx.x ), b3FixedFromInv( m.cx.y ), b3FixedFromInv( m.cx.z ) };
+	out.cy = B3_LITERAL( b3Vec3 ){ b3FixedFromInv( m.cy.x ), b3FixedFromInv( m.cy.y ), b3FixedFromInv( m.cy.z ) };
+	out.cz = B3_LITERAL( b3Vec3 ){ b3FixedFromInv( m.cz.x ), b3FixedFromInv( m.cz.y ), b3FixedFromInv( m.cz.z ) };
+	return out;
+}
+
+/// The inverse of an inertia tensor, computed DIRECTLY at the inverse scale.
+///
+/// The obvious implementation -- invert to Q48.16 and shift left by 24 -- is exactly the
+/// thing this format exists to avoid: the Q48.16 inverse of a large tensor is already
+/// zero, and shifting zero gains nothing. So the scale is applied inside the division,
+/// where the precision still exists.
+///
+/// An inverse entry is cofactor/determinant with the cofactor at Q32.32 and the
+/// determinant at Q**.48, so an answer scaled by 2^40 is ( cofactor << 56 ) / determinant.
+/// A cofactor reaches 126 bits and shifting it up 56 leaves 128, so the whole calculation
+/// runs at 256 bits -- unconditionally, rather than picking an arm by magnitude. This
+/// runs when mass data is set and never in the solver, so the only thing that matters
+/// about its cost is that it is finite.
+///
+/// A singular tensor gives the zero matrix, as everywhere else in this engine.
+B3_INLINE b3Matrix3 b3InvertInertiaWide( b3Matrix3 m )
+{
+	fixInt128 c00 = fixCofactor128( m.cy.y, m.cz.z, m.cy.z, m.cz.y );
+	fixInt128 c01 = fixCofactor128( m.cy.z, m.cz.x, m.cy.x, m.cz.z );
+	fixInt128 c02 = fixCofactor128( m.cy.x, m.cz.y, m.cy.y, m.cz.x );
+	fixInt128 c10 = fixCofactor128( m.cz.y, m.cx.z, m.cz.z, m.cx.y );
+	fixInt128 c11 = fixCofactor128( m.cz.z, m.cx.x, m.cz.x, m.cx.z );
+	fixInt128 c12 = fixCofactor128( m.cz.x, m.cx.y, m.cz.y, m.cx.x );
+	fixInt128 c20 = fixCofactor128( m.cx.y, m.cy.z, m.cx.z, m.cy.y );
+	fixInt128 c21 = fixCofactor128( m.cx.z, m.cy.x, m.cx.x, m.cy.z );
+	fixInt128 c22 = fixCofactor128( m.cx.x, m.cy.y, m.cx.y, m.cy.x );
+
+	fixUInt256 det = fixUInt256Add( fixUInt256Add( fixInt256MulI128ByI64( c00, m.cx.x ), fixInt256MulI128ByI64( c10, m.cy.x ) ),
+									fixInt256MulI128ByI64( c20, m.cz.x ) );
+	if ( fixUInt256IsZero( det ) )
+	{
+		return b3Mat3_zero;
+	}
+
+	bool negative = fixInt256IsNegative( det );
+	fixUInt256 absDet = fixInt256Abs( det );
+
+	const int shift = B3_FIXED_FRACTION_BITS + B3_INVERSE_FRACTION_BITS;
+
+	b3Matrix3 out;
+	out.cx = B3_LITERAL( b3Vec3 ){ fixDivShiftedWide( c00, shift, absDet, negative ),
+								   fixDivShiftedWide( c10, shift, absDet, negative ),
+								   fixDivShiftedWide( c20, shift, absDet, negative ) };
+	out.cy = B3_LITERAL( b3Vec3 ){ fixDivShiftedWide( c01, shift, absDet, negative ),
+								   fixDivShiftedWide( c11, shift, absDet, negative ),
+								   fixDivShiftedWide( c21, shift, absDet, negative ) };
+	out.cz = B3_LITERAL( b3Vec3 ){ fixDivShiftedWide( c02, shift, absDet, negative ),
+								   fixDivShiftedWide( c12, shift, absDet, negative ),
+								   fixDivShiftedWide( c22, shift, absDet, negative ) };
+	return out;
+}
+
+/// An inverse tensor applied to an ordinary vector, giving an ORDINARY vector:
+/// dw = invInertiaWorld * angularImpulse. The matrix-vector form of b3InvMul, with the
+/// same per-product rounding b3MulMV uses.
+B3_INLINE b3Vec3 b3InvMulMV( b3Matrix3 m, b3Vec3 v )
+{
+	b3Vec3 out = {
+		b3InvMul( m.cx.x, v.x ) + b3InvMul( m.cy.x, v.y ) + b3InvMul( m.cz.x, v.z ),
+		b3InvMul( m.cx.y, v.x ) + b3InvMul( m.cy.y, v.y ) + b3InvMul( m.cz.y, v.z ),
+		b3InvMul( m.cx.z, v.x ) + b3InvMul( m.cy.z, v.y ) + b3InvMul( m.cz.z, v.z ),
+	};
+	return out;
+}

--- a/src/inverse.h
+++ b/src/inverse.h
@@ -126,6 +126,16 @@ B3_INLINE b3Fixed b3FixedFromInv( b3Fixed a )
 /// hardware divide gives the exact truncated reciprocal and no 128-bit arithmetic is
 /// involved. A zero denominator returns zero: zero mass is the degenerate body, not
 /// infinity, and every caller here already treats it that way.
+///
+/// SATURATES at the top of the format. The small-body bound in the analysis above is the
+/// one input this engine does not enforce for itself -- inertia has b3FloorInertia, but
+/// mass has no floor at all, so a caller may hand over a mass whose inverse does not fit.
+/// Q24.40 holds inverse quantities up to 8.39e6, which is a body of mass 1.19e-7 -- a
+/// sphere of about 3mm at density 1, far below the 4cm scale where this engine's inertia
+/// already needs flooring. Below that the answer clamps to the largest inverse there is,
+/// so such a body is VERY LIGHT rather than wrapped to something of arbitrary sign. That
+/// turns the one assumption in the format choice into an enforced invariant, which is the
+/// same move b3InverseMass makes at the other end of the range.
 B3_INLINE b3Fixed b3InvFromRatio( b3Fixed a )
 {
 	if ( a == 0 )
@@ -133,7 +143,18 @@ B3_INLINE b3Fixed b3InvFromRatio( b3Fixed a )
 		return 0;
 	}
 
-	return ( (int64_t)1 << ( B3_FIXED_FRACTION_BITS + B3_INVERSE_FRACTION_BITS ) ) / a;
+	b3Int128 ratio = fixInt128Div( fixInt128ShiftLeft( fixInt128FromI64( 1 ), B3_FIXED_FRACTION_BITS + B3_INVERSE_FRACTION_BITS ),
+								  fixInt128FromI64( a ) );
+	if ( fixInt128Gt( ratio, fixInt128FromI64( B3_FIXED_MAX ) ) )
+	{
+		return B3_FIXED_MAX;
+	}
+	if ( fixInt128Lt( ratio, fixInt128FromI64( -B3_FIXED_MAX ) ) )
+	{
+		return -B3_FIXED_MAX;
+	}
+
+	return (b3Fixed)fixInt128ToI64( ratio );
 }
 
 /// 1 / k, where k is an inverse quantity and the answer is an ordinary one: the effective
@@ -179,7 +200,11 @@ B3_INLINE b3Matrix3 b3FixedFromInvMatrix( b3Matrix3 m )
 	return out;
 }
 
-/// The inverse of an inertia tensor, computed DIRECTLY at the inverse scale.
+/// A 3x3 inverse that CROSSES THE TWO SCALES, in either direction: an ordinary tensor in
+/// gives an inverse-scaled one out, and an inverse-scaled one in gives an ordinary one
+/// out. The same routine serves both, and that is not a coincidence -- inverting a
+/// 2^40-scaled matrix down to 2^16 needs the same shift as inverting a 2^16 matrix up to
+/// 2^40, because the shift is the SUM of the two scales either way.
 ///
 /// The obvious implementation -- invert to Q48.16 and shift left by 24 -- is exactly the
 /// thing this format exists to avoid: the Q48.16 inverse of a large tensor is already
@@ -194,7 +219,7 @@ B3_INLINE b3Matrix3 b3FixedFromInvMatrix( b3Matrix3 m )
 /// about its cost is that it is finite.
 ///
 /// A singular tensor gives the zero matrix, as everywhere else in this engine.
-B3_INLINE b3Matrix3 b3InvertInertiaWide( b3Matrix3 m )
+B3_INLINE b3Matrix3 b3InvertAcrossScales( b3Matrix3 m )
 {
 	fixInt128 c00 = fixCofactor128( m.cy.y, m.cz.z, m.cy.z, m.cz.y );
 	fixInt128 c01 = fixCofactor128( m.cy.z, m.cz.x, m.cy.x, m.cz.z );
@@ -240,6 +265,51 @@ B3_INLINE b3Vec3 b3InvMulMV( b3Matrix3 m, b3Vec3 v )
 		b3InvMul( m.cx.x, v.x ) + b3InvMul( m.cy.x, v.y ) + b3InvMul( m.cz.x, v.z ),
 		b3InvMul( m.cx.y, v.x ) + b3InvMul( m.cy.y, v.y ) + b3InvMul( m.cz.y, v.z ),
 		b3InvMul( m.cx.z, v.x ) + b3InvMul( m.cy.z, v.y ) + b3InvMul( m.cz.z, v.z ),
+	};
+	return out;
+}
+
+
+/// Solve an inverse-scaled system for an ORDINARY result: the joints' impulse solves,
+/// where k is a per-mass matrix and the right-hand side is a velocity.
+///
+/// The shift here is 40 and not 56, which is the one place the two scales do not simply
+/// add: the right-hand side is already an ordinary value, so it contributes 16 of the
+/// scale itself. Carried at 256 bits because a cofactor of inverse-scaled entries reaches
+/// 2^107 for the smallest body this format admits, and the shift takes it past 128.
+B3_INLINE b3Vec3 b3Solve3AcrossScales( b3Matrix3 m, b3Vec3 a )
+{
+	fixInt128 c00 = fixCofactor128( m.cy.y, m.cz.z, m.cy.z, m.cz.y );
+	fixInt128 c01 = fixCofactor128( m.cy.z, m.cz.x, m.cy.x, m.cz.z );
+	fixInt128 c02 = fixCofactor128( m.cy.x, m.cz.y, m.cy.y, m.cz.x );
+	fixInt128 c10 = fixCofactor128( m.cz.y, m.cx.z, m.cz.z, m.cx.y );
+	fixInt128 c11 = fixCofactor128( m.cz.z, m.cx.x, m.cz.x, m.cx.z );
+	fixInt128 c12 = fixCofactor128( m.cz.x, m.cx.y, m.cz.y, m.cx.x );
+	fixInt128 c20 = fixCofactor128( m.cx.y, m.cy.z, m.cx.z, m.cy.y );
+	fixInt128 c21 = fixCofactor128( m.cx.z, m.cy.x, m.cx.x, m.cy.z );
+	fixInt128 c22 = fixCofactor128( m.cx.x, m.cy.y, m.cx.y, m.cy.x );
+
+	fixUInt256 det = fixUInt256Add( fixUInt256Add( fixInt256MulI128ByI64( c00, m.cx.x ), fixInt256MulI128ByI64( c10, m.cy.x ) ),
+									fixInt256MulI128ByI64( c20, m.cz.x ) );
+	if ( fixUInt256IsZero( det ) )
+	{
+		return b3Vec3_zero;
+	}
+
+	bool negative = fixInt256IsNegative( det );
+	fixUInt256 absDet = fixInt256Abs( det );
+
+	fixUInt256 nx = fixUInt256Add( fixUInt256Add( fixInt256MulI128ByI64( c00, a.x ), fixInt256MulI128ByI64( c01, a.y ) ),
+								   fixInt256MulI128ByI64( c02, a.z ) );
+	fixUInt256 ny = fixUInt256Add( fixUInt256Add( fixInt256MulI128ByI64( c10, a.x ), fixInt256MulI128ByI64( c11, a.y ) ),
+								   fixInt256MulI128ByI64( c12, a.z ) );
+	fixUInt256 nz = fixUInt256Add( fixUInt256Add( fixInt256MulI128ByI64( c20, a.x ), fixInt256MulI128ByI64( c21, a.y ) ),
+								   fixInt256MulI128ByI64( c22, a.z ) );
+
+	b3Vec3 out = {
+		fixDivShifted256( nx, B3_INVERSE_FRACTION_BITS, absDet, negative ),
+		fixDivShifted256( ny, B3_INVERSE_FRACTION_BITS, absDet, negative ),
+		fixDivShifted256( nz, B3_INVERSE_FRACTION_BITS, absDet, negative ),
 	};
 	return out;
 }

--- a/src/math_internal.h
+++ b/src/math_internal.h
@@ -8,6 +8,8 @@
 #include "box3d/collision.h"
 #include "box3d/math_functions.h"
 
+#include "inverse.h"
+
 struct b3Sweep;
 struct b3Plane;
 
@@ -363,6 +365,26 @@ static inline b3Matrix2 b3Invert2( b3Matrix2 m )
 	}
 
 	return B3_LITERAL( b3Matrix2 ){ { B3_FIX( 0.0f ), B3_FIX( 0.0f ) }, { B3_FIX( 0.0f ), B3_FIX( 0.0f ) } };
+}
+
+/// A 2x2 inverse across the two scales: the tangent (friction) mass, built from an
+/// inverse-scaled k and used as an ordinary mass. Same shift as the 3x3 for the same
+/// reason, and 128 bits is enough here because a 2x2 determinant is two products rather
+/// than a cofactor against a third entry.
+static inline b3Matrix2 b3Invert2AcrossScales( b3Matrix2 m )
+{
+	b3Int128 det = fixInt128Sub( fixInt128MulI64( m.cx.x, m.cy.y ), fixInt128MulI64( m.cx.y, m.cy.x ) );
+	if ( fixInt128Eq( det, FIX_INT128_ZERO ) )
+	{
+		return B3_LITERAL( b3Matrix2 ){ { B3_FIX( 0.0f ), B3_FIX( 0.0f ) }, { B3_FIX( 0.0f ), B3_FIX( 0.0f ) } };
+	}
+
+	const int shift = B3_FIXED_FRACTION_BITS + B3_INVERSE_FRACTION_BITS;
+
+	return B3_LITERAL( b3Matrix2 ){
+		{ fixDivShifted( fixInt128FromI64( m.cy.y ), shift, det ), fixDivShifted( fixInt128FromI64( -m.cx.y ), shift, det ) },
+		{ fixDivShifted( fixInt128FromI64( -m.cy.x ), shift, det ), fixDivShifted( fixInt128FromI64( m.cx.x ), shift, det ) },
+	};
 }
 
 // Assumes positive semi-definite

--- a/src/motor_joint.c
+++ b/src/motor_joint.c
@@ -226,7 +226,7 @@ void b3PrepareMotorJoint( b3JointSim* base, b3StepContext* context )
 	joint->linearSpring = b3MakeSoft( joint->linearHertz, joint->linearDampingRatio, context->h );
 	joint->angularSpring = b3MakeSoft( joint->angularHertz, joint->angularDampingRatio, context->h );
 
-	joint->angularMass = b3InvertMatrix( invInertiaSum );
+	joint->angularMass = b3InvertAcrossScales( invInertiaSum );
 
 	if ( context->enableWarmStarting == false )
 	{
@@ -260,10 +260,10 @@ void b3WarmStartMotorJoint( b3JointSim* base, b3StepContext* context )
 	b3Vec3 linearImpulse = b3Add( joint->linearVelocityImpulse, joint->linearSpringImpulse );
 	b3Vec3 angularImpulse = b3Add( joint->angularVelocityImpulse, joint->angularSpringImpulse );
 
-	stateA->linearVelocity = b3MulSub( stateA->linearVelocity, mA, linearImpulse );
-	stateA->angularVelocity = b3Sub( stateA->angularVelocity, b3MulMV( iA, b3Add( b3Cross( rA, linearImpulse ), angularImpulse ) ) );
-	stateB->linearVelocity = b3MulAdd( stateB->linearVelocity, mB, linearImpulse );
-	stateB->angularVelocity = b3Add( stateB->angularVelocity, b3MulMV( iB, b3Add( b3Cross( rB, linearImpulse ), angularImpulse ) ) );
+	stateA->linearVelocity = b3Sub( stateA->linearVelocity, b3InvMulSV( mA, linearImpulse ) );
+	stateA->angularVelocity = b3Sub( stateA->angularVelocity, b3InvMulMV( iA, b3Add( b3Cross( rA, linearImpulse ), angularImpulse ) ) );
+	stateB->linearVelocity = b3Add( stateB->linearVelocity, b3InvMulSV( mB, linearImpulse ) );
+	stateB->angularVelocity = b3Add( stateB->angularVelocity, b3InvMulMV( iB, b3Add( b3Cross( rB, linearImpulse ), angularImpulse ) ) );
 }
 
 void b3SolveMotorJoint( b3JointSim* base, b3StepContext* context )
@@ -321,8 +321,8 @@ void b3SolveMotorJoint( b3JointSim* base, b3StepContext* context )
 		}
 		impulse = b3Sub( joint->angularSpringImpulse, oldImpulse );
 
-		wA = b3Sub( wA, b3MulMV( iA, impulse ) );
-		wB = b3Add( wB, b3MulMV( iB, impulse ) );
+		wA = b3Sub( wA, b3InvMulMV( iA, impulse ) );
+		wB = b3Add( wB, b3InvMulMV( iB, impulse ) );
 	}
 
 	// angular velocity
@@ -340,8 +340,8 @@ void b3SolveMotorJoint( b3JointSim* base, b3StepContext* context )
 		}
 		impulse = b3Sub( joint->angularVelocityImpulse, oldImpulse );
 
-		wA = b3Sub( wA, b3MulMV( iA, impulse ) );
-		wB = b3Add( wB, b3MulMV( iB, impulse ) );
+		wA = b3Sub( wA, b3InvMulMV( iA, impulse ) );
+		wB = b3Add( wB, b3InvMulMV( iB, impulse ) );
 	}
 
 	b3Vec3 rA = b3RotateVector( stateA->deltaRotation, joint->frameA.p );
@@ -370,7 +370,7 @@ void b3SolveMotorJoint( b3JointSim* base, b3StepContext* context )
 		k.cy.y += mA + mB;
 		k.cz.z += mA + mB;
 
-		b3Vec3 b = b3Solve3( k, b3Add( cdot, bias ) );
+		b3Vec3 b = b3Solve3AcrossScales( k, b3Add( cdot, bias ) );
 
 		b3Vec3 oldImpulse = joint->linearSpringImpulse;
 		b3Vec3 impulse = b3MulSub( b3MulSV( -massScale, b ), impulseScale, oldImpulse );
@@ -384,10 +384,10 @@ void b3SolveMotorJoint( b3JointSim* base, b3StepContext* context )
 
 		impulse = b3Sub( joint->linearSpringImpulse, oldImpulse );
 
-		vA = b3MulSub( vA, mA, impulse );
-		wA = b3Sub( wA, b3MulMV( iA, b3Cross( rA, impulse ) ) );
-		vB = b3MulAdd( vB, mB, impulse );
-		wB = b3Add( wB, b3MulMV( iB, b3Cross( rB, impulse ) ) );
+		vA = b3Sub( vA, b3InvMulSV( mA, impulse ) );
+		wA = b3Sub( wA, b3InvMulMV( iA, b3Cross( rA, impulse ) ) );
+		vB = b3Add( vB, b3InvMulSV( mB, impulse ) );
+		wB = b3Add( wB, b3InvMulMV( iB, b3Cross( rB, impulse ) ) );
 	}
 
 	// linear velocity
@@ -405,7 +405,7 @@ void b3SolveMotorJoint( b3JointSim* base, b3StepContext* context )
 		k.cy.y += mA + mB;
 		k.cz.z += mA + mB;
 
-		b3Vec3 b = b3Solve3( k, cdot );
+		b3Vec3 b = b3Solve3AcrossScales( k, cdot );
 		b3Vec3 impulse = b3Neg( b );
 
 		b3Vec3 oldImpulse = joint->linearVelocityImpulse;
@@ -419,10 +419,10 @@ void b3SolveMotorJoint( b3JointSim* base, b3StepContext* context )
 
 		impulse = b3Sub( joint->linearVelocityImpulse, oldImpulse );
 
-		vA = b3MulSub( vA, mA, impulse );
-		wA = b3Sub( wA, b3MulMV( iA, b3Cross( rA, impulse ) ) );
-		vB = b3MulAdd( vB, mB, impulse );
-		wB = b3Add( wB, b3MulMV( iB, b3Cross( rB, impulse ) ) );
+		vA = b3Sub( vA, b3InvMulSV( mA, impulse ) );
+		wA = b3Sub( wA, b3InvMulMV( iA, b3Cross( rA, impulse ) ) );
+		vB = b3Add( vB, b3InvMulSV( mB, impulse ) );
+		wB = b3Add( wB, b3InvMulMV( iB, b3Cross( rB, impulse ) ) );
 	}
 
 	if ( stateA->flags & b3_dynamicFlag )

--- a/src/parallel_joint.c
+++ b/src/parallel_joint.c
@@ -142,8 +142,8 @@ void b3WarmStartParallelJoint( b3JointSim* base, b3StepContext* context )
 
 	b3Vec3 angularImpulse = b3Blend2( joint->perpImpulse.x, joint->perpAxisX, joint->perpImpulse.y, joint->perpAxisY );
 
-	wA = b3Sub( wA, b3MulMV( iA, angularImpulse ) );
-	wB = b3Add( wB, b3MulMV( iB, angularImpulse ) );
+	wA = b3Sub( wA, b3InvMulMV( iA, angularImpulse ) );
+	wB = b3Add( wB, b3InvMulMV( iB, angularImpulse ) );
 
 	if ( stateA->flags & b3_dynamicFlag )
 	{
@@ -224,8 +224,8 @@ void b3SolveParallelJoint( b3JointSim* base, b3StepContext* context )
 		deltaImpulse = b3Sub2( joint->perpImpulse, oldImpulse );
 
 		b3Vec3 angularImpulse = b3Blend2( deltaImpulse.x, perpAxisX, deltaImpulse.y, perpAxisY );
-		wA = b3Sub( wA, b3MulMV( iA, angularImpulse ) );
-		wB = b3Add( wB, b3MulMV( iB, angularImpulse ) );
+		wA = b3Sub( wA, b3InvMulMV( iA, angularImpulse ) );
+		wB = b3Add( wB, b3InvMulMV( iB, angularImpulse ) );
 	}
 
 	if ( stateA->flags & b3_dynamicFlag )

--- a/src/physics_world.c
+++ b/src/physics_world.c
@@ -3429,11 +3429,11 @@ static bool ExplosionCallback( int proxyId, uint64_t userData, void* context )
 	b3SolverSet* set = b3Array_Get( world->solverSets, b3_awakeSet );
 	b3BodyState* state = b3Array_Get( set->bodyStates, localIndex );
 	b3BodySim* bodySim = b3Array_Get( set->bodySims, localIndex );
-	state->linearVelocity = b3MulAdd( state->linearVelocity, bodySim->invMass, impulse );
+	state->linearVelocity = b3Add( state->linearVelocity, b3InvMulSV( bodySim->invMass, impulse ) );
 
 	// Lever arm from the center of mass to the closest point, rotated to world
 	b3Vec3 r = b3RotateVector( xf.q, b3Sub( closestPoint, bodySim->localCenter ) );
-	state->angularVelocity = b3Add( state->angularVelocity, b3MulMV( bodySim->invInertiaWorld, b3Cross( r, impulse ) ) );
+	state->angularVelocity = b3Add( state->angularVelocity, b3InvMulMV( bodySim->invInertiaWorld, b3Cross( r, impulse ) ) );
 
 	return true;
 }

--- a/src/prismatic_joint.c
+++ b/src/prismatic_joint.c
@@ -336,7 +336,7 @@ void b3PreparePrismaticJoint( b3JointSim* base, b3StepContext* context )
 	joint->frameB.p = b3RotateVector( bodySimB->transform.q, b3Sub( base->localFrameB.p, bodySimB->localCenter ) );
 
 	joint->deltaCenter = b3SubPos( bodySimB->center, bodySimA->center );
-	joint->rotationMass = b3InvertMatrix( invInertiaSum );
+	joint->rotationMass = b3InvertAcrossScales( invInertiaSum );
 
 	// Initial joint axes in world space
 	b3Matrix3 matrixA = b3MakeMatrixFromQuat( joint->frameA.q );
@@ -401,10 +401,10 @@ void b3WarmStartPrismaticJoint( b3JointSim* base, b3StepContext* context )
 	b3Vec3 wA = stateA->angularVelocity;
 	b3Vec3 vB = stateB->linearVelocity;
 	b3Vec3 wB = stateB->angularVelocity;
-	vA = b3MulSub( vA, mA, P );
-	wA = b3Sub( wA, b3MulMV( iA, LA ) );
-	vB = b3MulAdd( vB, mB, P );
-	wB = b3Add( wB, b3MulMV( iB, LB ) );
+	vA = b3Sub( vA, b3InvMulSV( mA, P ) );
+	wA = b3Sub( wA, b3InvMulMV( iA, LA ) );
+	vB = b3Add( vB, b3InvMulSV( mB, P ) );
+	wB = b3Add( wB, b3InvMulMV( iB, LB ) );
 
 	if ( stateA->flags & b3_dynamicFlag )
 	{
@@ -454,7 +454,7 @@ void b3SolvePrismaticJoint( b3JointSim* base, b3StepContext* context, bool useBi
 
 	// The axial effective mass must be fresh to avoid divergence when the joint is stressed
 	b3Fixed ka = mA + mB + b3Dot( sAx, b3MulMV( iA, sAx ) ) + b3Dot( sBx, b3MulMV( iB, sBx ) );
-	b3Fixed axialMass = ka > B3_FIX( 0.0f ) ? b3FixDiv( B3_FIX( 1.0f ) , ka ) : B3_FIX( 0.0f );
+	b3Fixed axialMass = ka > B3_FIX( 0.0f ) ? b3InvReciprocal( ka ) : B3_FIX( 0.0f );
 
 	// Solve spring
 	if ( joint->enableSpring && fixedRotation == false )
@@ -475,10 +475,10 @@ void b3SolvePrismaticJoint( b3JointSim* base, b3StepContext* context, bool useBi
 		b3Vec3 LA = b3MulSV( deltaImpulse, sAx );
 		b3Vec3 LB = b3MulSV( deltaImpulse, sBx );
 
-		vA = b3MulSub( vA, mA, P );
-		wA = b3Sub( wA, b3MulMV( iA, LA ) );
-		vB = b3MulAdd( vB, mB, P );
-		wB = b3Add( wB, b3MulMV( iB, LB ) );
+		vA = b3Sub( vA, b3InvMulSV( mA, P ) );
+		wA = b3Sub( wA, b3InvMulMV( iA, LA ) );
+		vB = b3Add( vB, b3InvMulSV( mB, P ) );
+		wB = b3Add( wB, b3InvMulMV( iB, LB ) );
 	}
 
 	if ( joint->enableMotor && fixedRotation == false )
@@ -497,10 +497,10 @@ void b3SolvePrismaticJoint( b3JointSim* base, b3StepContext* context, bool useBi
 		b3Vec3 LA = b3MulSV( deltaImpulse, sAx );
 		b3Vec3 LB = b3MulSV( deltaImpulse, sBx );
 
-		vA = b3MulSub( vA, mA, P );
-		wA = b3Sub( wA, b3MulMV( iA, LA ) );
-		vB = b3MulAdd( vB, mB, P );
-		wB = b3Add( wB, b3MulMV( iB, LB ) );
+		vA = b3Sub( vA, b3InvMulSV( mA, P ) );
+		wA = b3Sub( wA, b3InvMulMV( iA, LA ) );
+		vB = b3Add( vB, b3InvMulSV( mB, P ) );
+		wB = b3Add( wB, b3InvMulMV( iB, LB ) );
 	}
 
 	if ( joint->enableLimit && fixedRotation == false )
@@ -539,10 +539,10 @@ void b3SolvePrismaticJoint( b3JointSim* base, b3StepContext* context, bool useBi
 				b3Vec3 LA = b3MulSV( deltaImpulse, sAx );
 				b3Vec3 LB = b3MulSV( deltaImpulse, sBx );
 
-				vA = b3MulSub( vA, mA, P );
-				wA = b3Sub( wA, b3MulMV( iA, LA ) );
-				vB = b3MulAdd( vB, mB, P );
-				wB = b3Add( wB, b3MulMV( iB, LB ) );
+				vA = b3Sub( vA, b3InvMulSV( mA, P ) );
+				wA = b3Sub( wA, b3InvMulMV( iA, LA ) );
+				vB = b3Add( vB, b3InvMulSV( mB, P ) );
+				wB = b3Add( wB, b3InvMulMV( iB, LB ) );
 			}
 			else
 			{
@@ -584,10 +584,10 @@ void b3SolvePrismaticJoint( b3JointSim* base, b3StepContext* context, bool useBi
 				b3Vec3 LA = b3MulSV( negDeltaImpulse, sAx );
 				b3Vec3 LB = b3MulSV( negDeltaImpulse, sBx );
 
-				vA = b3MulSub( vA, mA, P );
-				wA = b3Sub( wA, b3MulMV( iA, LA ) );
-				vB = b3MulAdd( vB, mB, P );
-				wB = b3Add( wB, b3MulMV( iB, LB ) );
+				vA = b3Sub( vA, b3InvMulSV( mA, P ) );
+				wA = b3Sub( wA, b3InvMulMV( iA, LA ) );
+				vB = b3Add( vB, b3InvMulSV( mB, P ) );
+				wB = b3Add( wB, b3InvMulMV( iB, LB ) );
 			}
 			else
 			{
@@ -624,8 +624,8 @@ void b3SolvePrismaticJoint( b3JointSim* base, b3StepContext* context, bool useBi
 			b3MulSV( impulseScale, joint->angularImpulse ) );
 		joint->angularImpulse = b3Add( joint->angularImpulse, impulse );
 
-		wA = b3Sub( wA, b3MulMV( iA, impulse ) );
-		wB = b3Add( wB, b3MulMV( iB, impulse ) );
+		wA = b3Sub( wA, b3InvMulMV( iA, impulse ) );
+		wB = b3Add( wB, b3InvMulMV( iB, impulse ) );
 	}
 
 	// Solve point-to-line constraint
@@ -667,10 +667,10 @@ void b3SolvePrismaticJoint( b3JointSim* base, b3StepContext* context, bool useBi
 
 		b3Vec3 P = b3Blend2( deltaImpulse.x, perpY, deltaImpulse.y, perpZ );
 
-		vA = b3MulSub( vA, mA, P );
-		wA = b3Sub( wA, b3MulMV( iA, b3Blend2( deltaImpulse.x, sAy, deltaImpulse.y, sAz ) ) );
-		vB = b3MulAdd( vB, mB, P );
-		wB = b3Add( wB, b3MulMV( iB, b3Blend2( deltaImpulse.x, sBy, deltaImpulse.y, sBz ) ) );
+		vA = b3Sub( vA, b3InvMulSV( mA, P ) );
+		wA = b3Sub( wA, b3InvMulMV( iA, b3Blend2( deltaImpulse.x, sAy, deltaImpulse.y, sAz ) ) );
+		vB = b3Add( vB, b3InvMulSV( mB, P ) );
+		wB = b3Add( wB, b3InvMulMV( iB, b3Blend2( deltaImpulse.x, sBy, deltaImpulse.y, sBz ) ) );
 	}
 
 	B3_ASSERT( b3IsValidVec3( vA ) );

--- a/src/revolute_joint.c
+++ b/src/revolute_joint.c
@@ -304,7 +304,7 @@ void b3PrepareRevoluteJoint( b3JointSim* base, b3StepContext* context )
 		// Rotation axis is the z-axis of body A.
 		b3Vec3 rotationAxisZ = b3RotateVector( joint->frameA.q, b3Vec3_axisZ );
 		b3Fixed k = b3Dot( rotationAxisZ, b3MulMV( invInertiaSum, rotationAxisZ ) );
-		joint->axialMass = k > B3_FIX( 0.0f ) ? b3FixDiv( B3_FIX( 1.0f ) , k ) : B3_FIX( 0.0f );
+		joint->axialMass = k > B3_FIX( 0.0f ) ? b3InvReciprocal( k ) : B3_FIX( 0.0f );
 		joint->rotationAxisZ = rotationAxisZ;
 	}
 
@@ -361,11 +361,11 @@ void b3WarmStartRevoluteJoint( b3JointSim* base, b3StepContext* context )
 		b3Add( b3MulSV( joint->perpImpulse.x, joint->perpAxisX ), b3MulSV( joint->perpImpulse.y, joint->perpAxisY ) );
 	angularImpulse = b3MulAdd( angularImpulse, axialImpulse, joint->rotationAxisZ );
 
-	vA = b3MulSub( vA, mA, joint->linearImpulse );
-	wA = b3Sub( wA, b3MulMV( iA, b3Add( b3Cross( rA, joint->linearImpulse ), angularImpulse ) ) );
+	vA = b3Sub( vA, b3InvMulSV( mA, joint->linearImpulse ) );
+	wA = b3Sub( wA, b3InvMulMV( iA, b3Add( b3Cross( rA, joint->linearImpulse ), angularImpulse ) ) );
 
-	vB = b3MulAdd( vB, mB, joint->linearImpulse );
-	wB = b3Add( wB, b3MulMV( iB, b3Add( b3Cross( rB, joint->linearImpulse ), angularImpulse ) ) );
+	vB = b3Add( vB, b3InvMulSV( mB, joint->linearImpulse ) );
+	wB = b3Add( wB, b3InvMulMV( iB, b3Add( b3Cross( rB, joint->linearImpulse ), angularImpulse ) ) );
 
 	if ( stateA->flags & b3_dynamicFlag )
 	{
@@ -551,8 +551,8 @@ void b3SolveRevoluteJoint( b3JointSim* base, b3StepContext* context, bool useBia
 		joint->perpImpulse = b3Add2( joint->perpImpulse, deltaImpulse );
 
 		b3Vec3 angularImpulse = b3Add( b3MulSV( deltaImpulse.x, perpAxisX ), b3MulSV( deltaImpulse.y, perpAxisY ) );
-		wA = b3Sub( wA, b3MulMV( iA, angularImpulse ) );
-		wB = b3Add( wB, b3MulMV( iB, angularImpulse ) );
+		wA = b3Sub( wA, b3InvMulMV( iA, angularImpulse ) );
+		wB = b3Add( wB, b3InvMulMV( iB, angularImpulse ) );
 	}
 
 	// Solve point-to-point constraint
@@ -587,15 +587,15 @@ void b3SolveRevoluteJoint( b3JointSim* base, b3StepContext* context, bool useBia
 		k.cy.y += mA + mB;
 		k.cz.z += mA + mB;
 
-		b3Vec3 b = b3Solve3( k, b3Add( cdot, bias ) );
+		b3Vec3 b = b3Solve3AcrossScales( k, b3Add( cdot, bias ) );
 
 		b3Vec3 impulse = b3Sub( b3MulSV( -massScale, b ), b3MulSV( impulseScale, joint->linearImpulse ) );
 		joint->linearImpulse = b3Add( joint->linearImpulse, impulse );
 
-		vA = b3MulSub( vA, mA, impulse );
-		wA = b3Sub( wA, b3MulMV( iA, b3Cross( rA, impulse ) ) );
-		vB = b3MulAdd( vB, mB, impulse );
-		wB = b3Add( wB, b3MulMV( iB, b3Cross( rB, impulse ) ) );
+		vA = b3Sub( vA, b3InvMulSV( mA, impulse ) );
+		wA = b3Sub( wA, b3InvMulMV( iA, b3Cross( rA, impulse ) ) );
+		vB = b3Add( vB, b3InvMulSV( mB, impulse ) );
+		wB = b3Add( wB, b3InvMulMV( iB, b3Cross( rB, impulse ) ) );
 	}
 
 	if ( stateA->flags & b3_dynamicFlag )

--- a/src/revolute_joint.c
+++ b/src/revolute_joint.c
@@ -427,8 +427,8 @@ void b3SolveRevoluteJoint( b3JointSim* base, b3StepContext* context, bool useBia
 		b3Fixed deltaImpulse = b3FixMul( b3FixMul( -massScale , joint->axialMass ) , ( cdot + bias ) ) - b3FixMul( impulseScale , joint->springImpulse );
 		joint->springImpulse += deltaImpulse;
 
-		wA = b3MulSub( wA, deltaImpulse, b3MulMV( iA, joint->rotationAxisZ ) );
-		wB = b3MulAdd( wB, deltaImpulse, b3MulMV( iB, joint->rotationAxisZ ) );
+		wA = b3Sub( wA, b3InvMulSV( deltaImpulse, b3MulMV( iA, joint->rotationAxisZ ) ) );
+		wB = b3Add( wB, b3InvMulSV( deltaImpulse, b3MulMV( iB, joint->rotationAxisZ ) ) );
 	}
 
 	if ( joint->enableMotor && fixedRotation == false )
@@ -442,8 +442,8 @@ void b3SolveRevoluteJoint( b3JointSim* base, b3StepContext* context, bool useBia
 		deltaImpulse = newImpulse - joint->motorImpulse;
 		joint->motorImpulse = newImpulse;
 
-		wA = b3MulSub( wA, deltaImpulse, b3MulMV( iA, joint->rotationAxisZ ) );
-		wB = b3MulAdd( wB, deltaImpulse, b3MulMV( iB, joint->rotationAxisZ ) );
+		wA = b3Sub( wA, b3InvMulSV( deltaImpulse, b3MulMV( iA, joint->rotationAxisZ ) ) );
+		wB = b3Add( wB, b3InvMulSV( deltaImpulse, b3MulMV( iB, joint->rotationAxisZ ) ) );
 	}
 
 	if ( joint->enableLimit && fixedRotation == false )
@@ -478,8 +478,8 @@ void b3SolveRevoluteJoint( b3JointSim* base, b3StepContext* context, bool useBia
 			joint->lowerImpulse = b3FixMax( oldImpulse + deltaImpulse, B3_FIX( 0.0f ) );
 			deltaImpulse = joint->lowerImpulse - oldImpulse;
 
-			wA = b3MulSub( wA, deltaImpulse, b3MulMV( iA, axis ) );
-			wB = b3MulAdd( wB, deltaImpulse, b3MulMV( iB, axis ) );
+			wA = b3Sub( wA, b3InvMulSV( deltaImpulse, b3MulMV( iA, axis ) ) );
+			wB = b3Add( wB, b3InvMulSV( deltaImpulse, b3MulMV( iB, axis ) ) );
 		}
 
 		// Upper limit
@@ -508,8 +508,8 @@ void b3SolveRevoluteJoint( b3JointSim* base, b3StepContext* context, bool useBia
 			deltaImpulse = joint->upperImpulse - oldImpulse;
 
 			// sign flipped on applied impulse
-			wA = b3MulAdd( wA, deltaImpulse, b3MulMV( iA, axis ) );
-			wB = b3MulSub( wB, deltaImpulse, b3MulMV( iB, axis ) );
+			wA = b3Add( wA, b3InvMulSV( deltaImpulse, b3MulMV( iA, axis ) ) );
+			wB = b3Sub( wB, b3InvMulSV( deltaImpulse, b3MulMV( iB, axis ) ) );
 		}
 	}
 

--- a/src/solver.c
+++ b/src/solver.c
@@ -97,10 +97,14 @@ static void b3IntegrateVelocitiesTask( b3SolverBlock block, b3StepContext* conte
 		// Gravity scale will be zero for kinematic bodies
 		b3Fixed gravityScale = sim->invMass > B3_FIX( 0.0f ) ? sim->gravityScale : B3_FIX( 0.0f );
 
-		b3Vec3 linearVelocityDelta = b3Blend2( b3FixMul( h , sim->invMass ), sim->force, b3FixMul( h , gravityScale ), gravity );
+		// The force term crosses out of the inverse scale (invMass * force is a velocity);
+		// the gravity term never entered it. So they are formed separately rather than
+		// through b3Blend2, which would have to apply one shift to both.
+		b3Vec3 linearVelocityDelta =
+			b3Add( b3InvMulSV( b3FixMul( h, sim->invMass ), sim->force ), b3MulSV( b3FixMul( h, gravityScale ), gravity ) );
 		v = b3MulAdd( linearVelocityDelta, linearDamping, v );
 
-		b3Vec3 angularVelocityDelta = b3MulSV( h, b3MulMV( sim->invInertiaWorld, sim->torque ) );
+		b3Vec3 angularVelocityDelta = b3MulSV( h, b3InvMulMV( sim->invInertiaWorld, sim->torque ) );
 		w = b3MulAdd( angularVelocityDelta, angularDamping, w );
 
 		// Gyroscopic torque by solving this nonlinear equation using Newton-Raphson.

--- a/src/spherical_joint.c
+++ b/src/spherical_joint.c
@@ -341,7 +341,7 @@ void b3PrepareSphericalJoint( b3JointSim* base, b3StepContext* context )
 		// Swing axis may be zero
 		b3Vec3 swingAxis = b3Normalize( b3Cross( coneAxis, twistAxis ) );
 		b3Fixed k = b3Dot( swingAxis, b3MulMV( invInertiaSum, swingAxis ) );
-		joint->swingMass = k > B3_FIX( 0.0f ) ? b3FixDiv( B3_FIX( 1.0f ) , k ) : B3_FIX( 0.0f );
+		joint->swingMass = k > B3_FIX( 0.0f ) ? b3InvReciprocal( k ) : B3_FIX( 0.0f );
 		joint->swingAxis = swingAxis;
 	}
 
@@ -355,13 +355,13 @@ void b3PrepareSphericalJoint( b3JointSim* base, b3StepContext* context )
 		b3Vec3 perpAxis = b3Cross( swingAxis, coneAxis );
 		b3Vec3 twistJacobian = b3MulAdd( coneAxis, tanThetaOver2, perpAxis );
 		b3Fixed k = b3Dot( twistJacobian, b3MulMV( invInertiaSum, twistJacobian ) );
-		joint->twistMass = k > B3_FIX( 0.0f ) ? b3FixDiv( B3_FIX( 1.0f ) , k ) : B3_FIX( 0.0f );
+		joint->twistMass = k > B3_FIX( 0.0f ) ? b3InvReciprocal( k ) : B3_FIX( 0.0f );
 		joint->twistJacobian = twistJacobian;
 	}
 
 	if ( base->fixedRotation == false )
 	{
-		joint->rotationMass = b3InvertMatrix( invInertiaSum );
+		joint->rotationMass = b3InvertAcrossScales( invInertiaSum );
 	}
 	else
 	{
@@ -410,11 +410,11 @@ void b3WarmStartSphericalJoint( b3JointSim* base, b3StepContext* context )
 	angularImpulse = b3MulSub( angularImpulse, joint->swingImpulse, joint->swingAxis );
 	angularImpulse = b3MulAdd( angularImpulse, joint->lowerTwistImpulse - joint->upperTwistImpulse, joint->twistJacobian );
 
-	vA = b3MulSub( vA, mA, joint->linearImpulse );
-	wA = b3Sub( wA, b3MulMV( iA, b3Add( b3Cross( rA, joint->linearImpulse ), angularImpulse ) ) );
+	vA = b3Sub( vA, b3InvMulSV( mA, joint->linearImpulse ) );
+	wA = b3Sub( wA, b3InvMulMV( iA, b3Add( b3Cross( rA, joint->linearImpulse ), angularImpulse ) ) );
 
-	vB = b3MulAdd( vB, mB, joint->linearImpulse );
-	wB = b3Add( wB, b3MulMV( iB, b3Add( b3Cross( rB, joint->linearImpulse ), angularImpulse ) ) );
+	vB = b3Add( vB, b3InvMulSV( mB, joint->linearImpulse ) );
+	wB = b3Add( wB, b3InvMulMV( iB, b3Add( b3Cross( rB, joint->linearImpulse ), angularImpulse ) ) );
 
 	if ( stateA->flags & b3_dynamicFlag )
 	{
@@ -470,8 +470,8 @@ void b3SolveSphericalJoint( b3JointSim* base, b3StepContext* context, bool useBi
 								   impulseScale, joint->springImpulse );
 		joint->springImpulse = b3Add( joint->springImpulse, impulse );
 
-		wA = b3Sub( wA, b3MulMV( iA, impulse ) );
-		wB = b3Add( wB, b3MulMV( iB, impulse ) );
+		wA = b3Sub( wA, b3InvMulMV( iA, impulse ) );
+		wB = b3Add( wB, b3InvMulMV( iB, impulse ) );
 	}
 
 	if ( joint->enableMotor && fixedRotation == false )
@@ -490,8 +490,8 @@ void b3SolveSphericalJoint( b3JointSim* base, b3StepContext* context, bool useBi
 		lambda = b3Sub( newImpulse, joint->motorImpulse );
 		joint->motorImpulse = newImpulse;
 
-		wA = b3Sub( wA, b3MulMV( iA, lambda ) );
-		wB = b3Add( wB, b3MulMV( iB, lambda ) );
+		wA = b3Sub( wA, b3InvMulMV( iA, lambda ) );
+		wB = b3Add( wB, b3InvMulMV( iB, lambda ) );
 	}
 
 	if ( joint->enableTwistLimit && fixedRotation == false )
@@ -634,15 +634,15 @@ void b3SolveSphericalJoint( b3JointSim* base, b3StepContext* context, bool useBi
 		k.cy.y += mA + mB;
 		k.cz.z += mA + mB;
 
-		b3Vec3 b = b3Solve3( k, b3Add( cdot, bias ) );
+		b3Vec3 b = b3Solve3AcrossScales( k, b3Add( cdot, bias ) );
 
 		b3Vec3 impulse = b3MulSub( b3MulSV( -massScale, b ), impulseScale, joint->linearImpulse );
 		joint->linearImpulse = b3Add( joint->linearImpulse, impulse );
 
-		vA = b3MulSub( vA, mA, impulse );
-		wA = b3Sub( wA, b3MulMV( iA, b3Cross( rA, impulse ) ) );
-		vB = b3MulAdd( vB, mB, impulse );
-		wB = b3Add( wB, b3MulMV( iB, b3Cross( rB, impulse ) ) );
+		vA = b3Sub( vA, b3InvMulSV( mA, impulse ) );
+		wA = b3Sub( wA, b3InvMulMV( iA, b3Cross( rA, impulse ) ) );
+		vB = b3Add( vB, b3InvMulSV( mB, impulse ) );
+		wB = b3Add( wB, b3InvMulMV( iB, b3Cross( rB, impulse ) ) );
 	}
 
 	if ( stateA->flags & b3_dynamicFlag )

--- a/src/spherical_joint.c
+++ b/src/spherical_joint.c
@@ -526,8 +526,8 @@ void b3SolveSphericalJoint( b3JointSim* base, b3StepContext* context, bool useBi
 			joint->lowerTwistImpulse = b3FixMax( oldImpulse + deltaImpulse, B3_FIX( 0.0f ) );
 			deltaImpulse = joint->lowerTwistImpulse - oldImpulse;
 
-			wA = b3MulSub( wA, deltaImpulse, b3MulMV( iA, twistJacobian ) );
-			wB = b3MulAdd( wB, deltaImpulse, b3MulMV( iB, twistJacobian ) );
+			wA = b3Sub( wA, b3InvMulSV( deltaImpulse, b3MulMV( iA, twistJacobian ) ) );
+			wB = b3Add( wB, b3InvMulSV( deltaImpulse, b3MulMV( iB, twistJacobian ) ) );
 		}
 
 		// Upper limit
@@ -556,8 +556,8 @@ void b3SolveSphericalJoint( b3JointSim* base, b3StepContext* context, bool useBi
 			deltaImpulse = joint->upperTwistImpulse - oldImpulse;
 
 			// sign flipped on applied impulse
-			wA = b3MulAdd( wA, deltaImpulse, b3MulMV( iA, twistJacobian ) );
-			wB = b3MulSub( wB, deltaImpulse, b3MulMV( iB, twistJacobian ) );
+			wA = b3Add( wA, b3InvMulSV( deltaImpulse, b3MulMV( iA, twistJacobian ) ) );
+			wB = b3Sub( wB, b3InvMulSV( deltaImpulse, b3MulMV( iB, twistJacobian ) ) );
 		}
 	}
 
@@ -597,8 +597,8 @@ void b3SolveSphericalJoint( b3JointSim* base, b3StepContext* context, bool useBi
 		deltaImpulse = joint->swingImpulse - oldImpulse;
 
 		// sign flipped on applied impulse
-		wA = b3MulAdd( wA, deltaImpulse, b3MulMV( iA, swingAxis ) );
-		wB = b3MulSub( wB, deltaImpulse, b3MulMV( iB, swingAxis ) );
+		wA = b3Add( wA, b3InvMulSV( deltaImpulse, b3MulMV( iA, swingAxis ) ) );
+		wB = b3Sub( wB, b3InvMulSV( deltaImpulse, b3MulMV( iB, swingAxis ) ) );
 	}
 
 	// Solve point-to-point constraint

--- a/src/triangle_manifold.c
+++ b/src/triangle_manifold.c
@@ -228,8 +228,21 @@ static b3SeparatingAxis b3QueryTriangleAndCapsuleEdges( const b3Vec3* vertices, 
 		}
 
 		// Similar to hull vs hull (b3QueryEdgeDirections)
+		//
+		// THE SIGN TEST IS A SIGN TEST, not a product. This asked whether a and b have
+		// opposite signs by computing a*b and comparing to zero -- and b3FixMul quantizes,
+		// so a product below one ULP reads as exactly zero no matter what its true sign
+		// was. Measured here with a = -3751 and b = -4 raw: both negative, true product
+		// +0.229, and b3FixMul returns 0, which satisfies "<= 0" and sends a same-sign
+		// pair down the opposite-sign branch. That branch then computes t = b/(b - a),
+		// which is only in [0, 1] when the signs really do differ, and it came out at
+		// -0.001053 -- an out-of-range interpolation parameter.
+		//
+		// This is hard-won rule 7 in CLAUDE.md ("squared-tolerance guards collapse; use
+		// d > 0 directly") applied to a product of two different values rather than a
+		// square. Comparing the signs directly is exact for every input and cheaper.
 		b3Vec3 axis;
-		if ( b3FixMul( a , b ) <= B3_FIX( 0.0f ) )
+		if ( ( a > B3_FIX( 0.0f ) && b > B3_FIX( 0.0f ) ) == false && ( a < B3_FIX( 0.0f ) && b < B3_FIX( 0.0f ) ) == false )
 		{
 			b3Fixed t = b3FixDiv( b , ( b - a ) );
 			axis = b3Lerp( sideNormal, plane.normal, t );

--- a/src/weld_joint.c
+++ b/src/weld_joint.c
@@ -120,7 +120,7 @@ void b3PrepareWeldJoint( b3JointSim* base, b3StepContext* context )
 	joint->frameB.p = b3RotateVector( bodySimB->transform.q, b3Sub( base->localFrameB.p, bodySimB->localCenter ) );
 
 	joint->deltaCenter = b3SubPos( bodySimB->center, bodySimA->center );
-	joint->angularMass = b3InvertMatrix( invInertiaSum );
+	joint->angularMass = b3InvertAcrossScales( invInertiaSum );
 
 	if ( joint->linearHertz == B3_FIX( 0.0f ) )
 	{
@@ -172,11 +172,11 @@ void b3WarmStartWeldJoint( b3JointSim* base, b3StepContext* context )
 	b3Vec3 rA = b3RotateVector( stateA->deltaRotation, joint->frameA.p );
 	b3Vec3 rB = b3RotateVector( stateB->deltaRotation, joint->frameB.p );
 
-	vA = b3MulSub( vA, mA, joint->linearImpulse );
-	wA = b3Sub( wA, b3MulMV( iA, b3Add( b3Cross( rA, joint->linearImpulse ), joint->angularImpulse ) ) );
+	vA = b3Sub( vA, b3InvMulSV( mA, joint->linearImpulse ) );
+	wA = b3Sub( wA, b3InvMulMV( iA, b3Add( b3Cross( rA, joint->linearImpulse ), joint->angularImpulse ) ) );
 
-	vB = b3MulAdd( vB, mB, joint->linearImpulse );
-	wB = b3Add( wB, b3MulMV( iB, b3Add( b3Cross( rB, joint->linearImpulse ), joint->angularImpulse ) ) );
+	vB = b3Add( vB, b3InvMulSV( mB, joint->linearImpulse ) );
+	wB = b3Add( wB, b3InvMulMV( iB, b3Add( b3Cross( rB, joint->linearImpulse ), joint->angularImpulse ) ) );
 
 	if ( stateA->flags & b3_dynamicFlag )
 	{
@@ -243,8 +243,8 @@ void b3SolveWeldJoint( b3JointSim* base, b3StepContext* context, bool useBias )
 		b3Vec3 impulse = b3MulSub( b3MulSV( -massScale, b3MulMV( joint->angularMass, b3Add( cdot, bias ) ) ), impulseScale, joint->angularImpulse );
 		joint->angularImpulse = b3Add( joint->angularImpulse, impulse );
 
-		wA = b3Sub( wA, b3MulMV( iA, impulse ) );
-		wB = b3Add( wB, b3MulMV( iB, impulse ) );
+		wA = b3Sub( wA, b3InvMulMV( iA, impulse ) );
+		wB = b3Add( wB, b3InvMulMV( iB, impulse ) );
 	}
 
 	// linear constraint
@@ -279,15 +279,15 @@ void b3SolveWeldJoint( b3JointSim* base, b3StepContext* context, bool useBias )
 		k.cy.y += mA + mB;
 		k.cz.z += mA + mB;
 
-		b3Vec3 b = b3Solve3( k, b3Add( cdot, bias ) );
+		b3Vec3 b = b3Solve3AcrossScales( k, b3Add( cdot, bias ) );
 
 		b3Vec3 impulse = b3MulSub( b3MulSV( -massScale, b ), impulseScale, joint->linearImpulse );
 		joint->linearImpulse = b3Add( joint->linearImpulse, impulse );
 
-		vA = b3MulSub( vA, mA, impulse );
-		wA = b3Sub( wA, b3MulMV( iA, b3Cross( rA, impulse ) ) );
-		vB = b3MulAdd( vB, mB, impulse );
-		wB = b3Add( wB, b3MulMV( iB, b3Cross( rB, impulse ) ) );
+		vA = b3Sub( vA, b3InvMulSV( mA, impulse ) );
+		wA = b3Sub( wA, b3InvMulMV( iA, b3Cross( rA, impulse ) ) );
+		vB = b3Add( vB, b3InvMulSV( mB, impulse ) );
+		wB = b3Add( wB, b3InvMulMV( iB, b3Cross( rB, impulse ) ) );
 	}
 
 	if ( stateA->flags & b3_dynamicFlag )

--- a/src/wheel_joint.c
+++ b/src/wheel_joint.c
@@ -462,7 +462,7 @@ void b3PrepareWheelJoint( b3JointSim* base, b3StepContext* context )
 
 		b3Fixed k = base->invMassA + base->invMassB + b3Dot( rAn, b3MulMV( base->invIA, rAn ) ) +
 				  b3Dot( rBn, b3MulMV( base->invIB, rBn ) );
-		joint->suspensionMass = k > B3_FIX( 0.0f ) ? b3FixDiv( B3_FIX( 1.0f ) , k ) : B3_FIX( 0.0f );
+		joint->suspensionMass = k > B3_FIX( 0.0f ) ? b3InvReciprocal( k ) : B3_FIX( 0.0f );
 	}
 
 	joint->suspensionSoftness = b3MakeSoft( joint->suspensionHertz, joint->suspensionDampingRatio, context->h );
@@ -472,7 +472,7 @@ void b3PrepareWheelJoint( b3JointSim* base, b3StepContext* context )
 		// Rotation axis is the z-axis of body A.
 		b3Vec3 spinAxis = matrixB.cz;
 		b3Fixed k = b3Dot( spinAxis, b3MulMV( invInertiaSum, spinAxis ) );
-		joint->spinMass = k > B3_FIX( 0.0f ) ? b3FixDiv( B3_FIX( 1.0f ) , k ) : B3_FIX( 0.0f );
+		joint->spinMass = k > B3_FIX( 0.0f ) ? b3InvReciprocal( k ) : B3_FIX( 0.0f );
 	}
 
 	{
@@ -485,7 +485,7 @@ void b3PrepareWheelJoint( b3JointSim* base, b3StepContext* context )
 			b3MulSV( den, b3Cross( matrixB.cz, b3Sub( b3MulSV( -cs, matrixA.cy ), b3MulSV( ss, matrixA.cz ) ) ) );
 
 		b3Fixed k = b3Dot( steeringAxis, b3MulMV( invInertiaSum, steeringAxis ) );
-		joint->steeringMass = k > B3_FIX( 0.0f ) ? b3FixDiv( B3_FIX( 1.0f ) , k ) : B3_FIX( 0.0f );
+		joint->steeringMass = k > B3_FIX( 0.0f ) ? b3InvReciprocal( k ) : B3_FIX( 0.0f );
 	}
 
 	if ( context->enableWarmStarting == false )
@@ -584,14 +584,14 @@ void b3WarmStartWheelJoint( b3JointSim* base, b3StepContext* context )
 
 	if ( stateA->flags & b3_dynamicFlag )
 	{
-		stateA->linearVelocity = b3MulSub( stateA->linearVelocity, mA, linearImpulse );
-		stateA->angularVelocity = b3Sub( stateA->angularVelocity, b3MulMV( iA, b3Add( angularImpulseA, angularImpulse ) ) );
+		stateA->linearVelocity = b3Sub( stateA->linearVelocity, b3InvMulSV( mA, linearImpulse ) );
+		stateA->angularVelocity = b3Sub( stateA->angularVelocity, b3InvMulMV( iA, b3Add( angularImpulseA, angularImpulse ) ) );
 	}
 
 	if ( stateB->flags & b3_dynamicFlag )
 	{
-		stateB->linearVelocity = b3MulAdd( stateB->linearVelocity, mB, linearImpulse );
-		stateB->angularVelocity = b3Add( stateB->angularVelocity, b3MulMV( iB, b3Add( angularImpulseB, angularImpulse ) ) );
+		stateB->linearVelocity = b3Add( stateB->linearVelocity, b3InvMulSV( mB, linearImpulse ) );
+		stateB->angularVelocity = b3Add( stateB->angularVelocity, b3InvMulMV( iB, b3Add( angularImpulseB, angularImpulse ) ) );
 	}
 }
 
@@ -667,8 +667,8 @@ void b3SolveWheelJoint( b3JointSim* base, b3StepContext* context, bool useBias )
 		joint->spinImpulse = b3FixClamp( joint->spinImpulse + impulse, -maxImpulse, maxImpulse );
 		impulse = joint->spinImpulse - oldImpulse;
 
-		wA = b3Sub( wA, b3MulMV( iA, b3MulSV( impulse, spinAxis ) ) );
-		wB = b3Add( wB, b3MulMV( iB, b3MulSV( impulse, spinAxis ) ) );
+		wA = b3Sub( wA, b3InvMulMV( iA, b3MulSV( impulse, spinAxis ) ) );
+		wB = b3Add( wB, b3InvMulMV( iB, b3MulSV( impulse, spinAxis ) ) );
 	}
 
 	// suspension
@@ -688,10 +688,10 @@ void b3SolveWheelJoint( b3JointSim* base, b3StepContext* context, bool useBias )
 		b3Vec3 angularImpulseA = b3MulSV( impulse, sAx );
 		b3Vec3 angularImpulseB = b3MulSV( impulse, sBx );
 
-		vA = b3MulSub( vA, mA, linearImpulse );
-		wA = b3Sub( wA, b3MulMV( iA, angularImpulseA ) );
-		vB = b3MulAdd( vB, mB, linearImpulse );
-		wB = b3Add( wB, b3MulMV( iB, angularImpulseB ) );
+		vA = b3Sub( vA, b3InvMulSV( mA, linearImpulse ) );
+		wA = b3Sub( wA, b3InvMulMV( iA, angularImpulseA ) );
+		vB = b3Add( vB, b3InvMulSV( mB, linearImpulse ) );
+		wB = b3Add( wB, b3InvMulMV( iB, angularImpulseB ) );
 	}
 
 	// steering
@@ -713,8 +713,8 @@ void b3SolveWheelJoint( b3JointSim* base, b3StepContext* context, bool useBias )
 			joint->steeringSpringImpulse = b3FixClamp( oldImpulse + impulse, -maxImpulse, maxImpulse );
 			impulse = joint->steeringSpringImpulse - oldImpulse;
 
-			wA = b3Sub( wA, b3MulMV( iA, b3MulSV( impulse, steeringAxis ) ) );
-			wB = b3Add( wB, b3MulMV( iB, b3MulSV( impulse, steeringAxis ) ) );
+			wA = b3Sub( wA, b3InvMulMV( iA, b3MulSV( impulse, steeringAxis ) ) );
+			wB = b3Add( wB, b3InvMulMV( iB, b3MulSV( impulse, steeringAxis ) ) );
 		}
 
 		if ( joint->enableSteeringLimit )
@@ -744,8 +744,8 @@ void b3SolveWheelJoint( b3JointSim* base, b3StepContext* context, bool useBias )
 				joint->lowerSteeringImpulse = b3FixMax( oldImpulse + impulse, B3_FIX( 0.0f ) );
 				impulse = joint->lowerSteeringImpulse - oldImpulse;
 
-				wA = b3Sub( wA, b3MulMV( iA, b3MulSV( impulse, steeringAxis ) ) );
-				wB = b3Add( wB, b3MulMV( iB, b3MulSV( impulse, steeringAxis ) ) );
+				wA = b3Sub( wA, b3InvMulMV( iA, b3MulSV( impulse, steeringAxis ) ) );
+				wB = b3Add( wB, b3InvMulMV( iB, b3MulSV( impulse, steeringAxis ) ) );
 			}
 
 			// Upper limit
@@ -778,8 +778,8 @@ void b3SolveWheelJoint( b3JointSim* base, b3StepContext* context, bool useBias )
 				impulse = joint->upperSteeringImpulse - oldImpulse;
 
 				// sign flipped on applied impulse
-				wA = b3Add( wA, b3MulMV( iA, b3MulSV( impulse, steeringAxis ) ) );
-				wB = b3Sub( wB, b3MulMV( iB, b3MulSV( impulse, steeringAxis ) ) );
+				wA = b3Add( wA, b3InvMulMV( iA, b3MulSV( impulse, steeringAxis ) ) );
+				wB = b3Sub( wB, b3InvMulMV( iB, b3MulSV( impulse, steeringAxis ) ) );
 			}
 		}
 	}
@@ -815,10 +815,10 @@ void b3SolveWheelJoint( b3JointSim* base, b3StepContext* context, bool useBias )
 			b3Vec3 angularImpulseA = b3MulSV( impulse, sAx );
 			b3Vec3 angularImpulseB = b3MulSV( impulse, sBx );
 
-			vA = b3MulSub( vA, mA, linearImpulse );
-			wA = b3Sub( wA, b3MulMV( iA, angularImpulseA ) );
-			vB = b3MulAdd( vB, mB, linearImpulse );
-			wB = b3Add( wB, b3MulMV( iB, angularImpulseB ) );
+			vA = b3Sub( vA, b3InvMulSV( mA, linearImpulse ) );
+			wA = b3Sub( wA, b3InvMulMV( iA, angularImpulseA ) );
+			vB = b3Add( vB, b3InvMulSV( mB, linearImpulse ) );
+			wB = b3Add( wB, b3InvMulMV( iB, angularImpulseB ) );
 		}
 
 		// Upper limit
@@ -855,10 +855,10 @@ void b3SolveWheelJoint( b3JointSim* base, b3StepContext* context, bool useBias )
 			b3Vec3 angularImpulseB = b3MulSV( impulse, sBx );
 
 			// sign flipped on applied impulse
-			vA = b3MulAdd( vA, mA, linearImpulse );
-			wA = b3Add( wA, b3MulMV( iA, angularImpulseA ) );
-			vB = b3MulSub( vB, mB, linearImpulse );
-			wB = b3Sub( wB, b3MulMV( iB, angularImpulseB ) );
+			vA = b3Add( vA, b3InvMulSV( mA, linearImpulse ) );
+			wA = b3Add( wA, b3InvMulMV( iA, angularImpulseA ) );
+			vB = b3Sub( vB, b3InvMulSV( mB, linearImpulse ) );
+			wB = b3Sub( wB, b3InvMulMV( iB, angularImpulseB ) );
 		}
 	}
 
@@ -884,7 +884,7 @@ void b3SolveWheelJoint( b3JointSim* base, b3StepContext* context, bool useBias )
 
 			b3Matrix3 invInertiaSum = b3AddMM( iA, iB );
 			b3Fixed k = b3Dot( u, b3MulMV( invInertiaSum, u ) );
-			b3Fixed perpMass = k > B3_FIX( 0.0f ) ? b3FixDiv( B3_FIX( 1.0f ) , k ) : B3_FIX( 0.0f );
+			b3Fixed perpMass = k > B3_FIX( 0.0f ) ? b3InvReciprocal( k ) : B3_FIX( 0.0f );
 
 			b3Fixed deltaImpulse = b3FixMul( b3FixMul( -massScale , perpMass ) , ( cdot + bias ) ) - b3FixMul( impulseScale , joint->angularImpulse.x );
 			joint->angularImpulse.x += deltaImpulse;
@@ -931,8 +931,8 @@ void b3SolveWheelJoint( b3JointSim* base, b3StepContext* context, bool useBias )
 			joint->angularImpulse = (b3Vec2){ oldImpulse.x + deltaImpulse.x, oldImpulse.y + deltaImpulse.y };
 
 			b3Vec3 angularImpulse = b3Blend2( deltaImpulse.x, perpAxisX, deltaImpulse.y, perpAxisY );
-			wA = b3Sub( wA, b3MulMV( iA, angularImpulse ) );
-			wB = b3Add( wB, b3MulMV( iB, angularImpulse ) );
+			wA = b3Sub( wA, b3InvMulMV( iA, angularImpulse ) );
+			wB = b3Add( wB, b3InvMulMV( iB, angularImpulse ) );
 		}
 	}
 
@@ -975,10 +975,10 @@ void b3SolveWheelJoint( b3JointSim* base, b3StepContext* context, bool useBias )
 
 		b3Vec3 linearImpulse = b3Blend2( deltaImpulse.x, perpY, deltaImpulse.y, perpZ );
 
-		vA = b3MulSub( vA, mA, linearImpulse );
-		wA = b3Sub( wA, b3MulMV( iA, b3Blend2( deltaImpulse.x, sAy, deltaImpulse.y, sAz ) ) );
-		vB = b3MulAdd( vB, mB, linearImpulse );
-		wB = b3Add( wB, b3MulMV( iB, b3Blend2( deltaImpulse.x, sBy, deltaImpulse.y, sBz ) ) );
+		vA = b3Sub( vA, b3InvMulSV( mA, linearImpulse ) );
+		wA = b3Sub( wA, b3InvMulMV( iA, b3Blend2( deltaImpulse.x, sAy, deltaImpulse.y, sAz ) ) );
+		vB = b3Add( vB, b3InvMulSV( mB, linearImpulse ) );
+		wB = b3Add( wB, b3InvMulMV( iB, b3Blend2( deltaImpulse.x, sBy, deltaImpulse.y, sBz ) ) );
 	}
 
 	if ( stateA->flags & b3_dynamicFlag )

--- a/src/wheel_joint.c
+++ b/src/wheel_joint.c
@@ -889,8 +889,8 @@ void b3SolveWheelJoint( b3JointSim* base, b3StepContext* context, bool useBias )
 			b3Fixed deltaImpulse = b3FixMul( b3FixMul( -massScale , perpMass ) , ( cdot + bias ) ) - b3FixMul( impulseScale , joint->angularImpulse.x );
 			joint->angularImpulse.x += deltaImpulse;
 
-			wA = b3MulSub( wA, deltaImpulse, b3MulMV( iA, u ) );
-			wB = b3MulAdd( wB, deltaImpulse, b3MulMV( iB, u ) );
+			wA = b3Sub( wA, b3InvMulSV( deltaImpulse, b3MulMV( iA, u ) ) );
+			wB = b3Add( wB, b3InvMulSV( deltaImpulse, b3MulMV( iB, u ) ) );
 		}
 		else
 		{

--- a/test/test_body.c
+++ b/test/test_body.c
@@ -416,7 +416,7 @@ static int InverseMassQuantumFloor( void )
 		b3MassData massData = { B3_FIX( 65536.0f ), b3Vec3_zero, kDiagInertia };
 		b3Body_SetMassData( bodyId, massData );
 		ENSURE( b3Body_GetInverseMassPrecise( bodyId ) == ( (int64_t)1 << 24 ) );
-		ENSURE( b3Body_GetInverseMass( bodyId ) == 1 );
+		ENSURE( b3Body_GetInverseMass( bodyId ) == B3_FIXED_EPSILON );
 	}
 
 	// One unit past it. The stored inverse is a real, graded value -- the whole point of

--- a/test/test_body.c
+++ b/test/test_body.c
@@ -408,21 +408,27 @@ static int InverseMassQuantumFloor( void )
 	b3BodyDef bodyDef = b3DefaultBodyDef();
 	bodyDef.type = b3_dynamicBody;
 
-	// At the line: 1 / 65,536 is exactly one quantum, with no clamping involved.
+	// 65,536 was the old cliff -- the largest mass whose inverse was representable at all.
+	// It is now unremarkable, and the point of these two cases is that it no longer marks
+	// anything: the inverse is exact on both sides of it.
 	{
 		b3BodyId bodyId = b3CreateBody( worldId, &bodyDef );
 		b3MassData massData = { B3_FIX( 65536.0f ), b3Vec3_zero, kDiagInertia };
 		b3Body_SetMassData( bodyId, massData );
+		ENSURE( b3Body_GetInverseMassPrecise( bodyId ) == ( (int64_t)1 << 24 ) );
 		ENSURE( b3Body_GetInverseMass( bodyId ) == 1 );
 	}
 
-	// One unit past it, where the true inverse is 0.99998 of a quantum. Truncation gives
-	// zero; the floor gives the smallest inverse mass this format has.
+	// One unit past it. The stored inverse is a real, graded value -- the whole point of
+	// the wider format -- while the legacy getter truncates it to zero, which is the
+	// documented lossiness rather than a body that stopped moving.
 	{
 		b3BodyId bodyId = b3CreateBody( worldId, &bodyDef );
 		b3MassData massData = { B3_FIX( 65537.0f ), b3Vec3_zero, kDiagInertia };
 		b3Body_SetMassData( bodyId, massData );
-		ENSURE( b3Body_GetInverseMass( bodyId ) == 1 );
+		ENSURE( b3Body_GetInverseMassPrecise( bodyId ) > 0 );
+		ENSURE( b3Body_GetInverseMassPrecise( bodyId ) < ( (int64_t)1 << 24 ) );
+		ENSURE( b3Body_GetInverseMass( bodyId ) == 0 );
 	}
 
 	// Far past it, the case space actually contains. Still dynamic, still movable.
@@ -430,7 +436,7 @@ static int InverseMassQuantumFloor( void )
 		b3BodyId bodyId = b3CreateBody( worldId, &bodyDef );
 		b3MassData massData = { B3_FIX( 1.0e7f ), b3Vec3_zero, kDiagInertia };
 		b3Body_SetMassData( bodyId, massData );
-		ENSURE( b3Body_GetInverseMass( bodyId ) > 0 );
+		ENSURE( b3Body_GetInverseMassPrecise( bodyId ) > 0 );
 	}
 
 	// And the floor is a floor, not a rewrite: an ordinary mass is unaffected.
@@ -447,7 +453,7 @@ static int InverseMassQuantumFloor( void )
 		b3BodyDef staticDef = b3DefaultBodyDef();
 		staticDef.type = b3_staticBody;
 		b3BodyId bodyId = b3CreateBody( worldId, &staticDef );
-		ENSURE( b3Body_GetInverseMass( bodyId ) == 0 );
+		ENSURE( b3Body_GetInverseMassPrecise( bodyId ) == 0 );
 	}
 
 	// Zero mass on a dynamic body is not a large mass and must not be floored -- the
@@ -456,7 +462,7 @@ static int InverseMassQuantumFloor( void )
 		b3BodyId bodyId = b3CreateBody( worldId, &bodyDef );
 		b3MassData massData = { B3_FIX( 0.0f ), b3Vec3_zero, b3Mat3_zero };
 		b3Body_SetMassData( bodyId, massData );
-		ENSURE( b3Body_GetInverseMass( bodyId ) == 0 );
+		ENSURE( b3Body_GetInverseMassPrecise( bodyId ) == 0 );
 	}
 
 	b3DestroyWorld( worldId );
@@ -482,7 +488,7 @@ static int InverseMassQuantumFloorFromShapes( void )
 	b3CreateHullShape( bodyId, &shapeDef, &hull.base );
 
 	ENSURE( b3Body_GetMass( bodyId ) > B3_FIX( 65536.0f ) );
-	ENSURE( b3Body_GetInverseMass( bodyId ) > 0 );
+	ENSURE( b3Body_GetInverseMassPrecise( bodyId ) > 0 );
 
 	b3DestroyWorld( worldId );
 	return 0;
@@ -517,8 +523,8 @@ static int InverseInertiaScaleEnvelope( void )
 	b3WorldDef worldDef = b3DefaultWorldDef();
 	b3WorldId worldId = b3CreateWorld( &worldDef );
 
-	// Cube sides spanning both cliffs, in half units so the arithmetic below is exact.
-	static const int halfSides[] = { 2, 10, 22, 26, 27, 40, 75, 88, 160, 240, 500, 1000 };
+	// Cube sides spanning the whole useful range, in half units so the arithmetic is exact.
+	static const int halfSides[] = { 2, 10, 22, 26, 27, 40, 75, 88, 160, 240, 500, 734, 1000 };
 
 	b3Fixed previousDiagonal = B3_FIXED_MAX;
 
@@ -542,11 +548,22 @@ static int InverseInertiaScaleEnvelope( void )
 		b3MassData massData = { (b3Fixed)massRaw, b3Vec3_zero, inertia };
 		b3Body_SetMassData( bodyId, massData );
 
-		// The body is created at identity rotation, so the world inverse tensor IS the
-		// local one here -- the similarity transform is by the identity matrix.
-		b3Matrix3 invLocal = b3Body_GetWorldInverseRotationalInertia( bodyId );
+		// Created at identity rotation, so the world tensor IS the local one here.
+		b3Matrix3 invLocal = b3Body_GetWorldInverseRotationalInertiaPrecise( bodyId );
 
-		// Never negative, on any entry of a diagonal tensor's inverse.
+		// THE ORACLE, and it shares no arithmetic with the implementation: for a diagonal
+		// tensor the inverse entry is exactly 2^(16 + fractionBits) / inertiaRaw,
+		// truncated toward zero. An equality at every size, including the sizes where the
+		// right answer is zero.
+		// 2^(16 + fraction bits) is 2^56 at the current format and fits an int64 with room
+		// to spare, so the oracle needs no wide arithmetic of its own -- which is the
+		// point of it.
+		b3Fixed expected = (b3Fixed)( ( (int64_t)1 << ( 16 + b3GetInverseFractionBits() ) ) / inertiaRaw );
+		ENSURE( invLocal.cx.x == expected );
+		ENSURE( invLocal.cy.y == expected );
+		ENSURE( invLocal.cz.z == expected );
+
+		// Never negative, and a diagonal tensor inverts to a diagonal one.
 		ENSURE( invLocal.cx.x >= 0 && invLocal.cy.y >= 0 && invLocal.cz.z >= 0 );
 		ENSURE( invLocal.cx.y == 0 && invLocal.cx.z == 0 );
 		ENSURE( invLocal.cy.x == 0 && invLocal.cy.z == 0 );
@@ -556,32 +573,40 @@ static int InverseInertiaScaleEnvelope( void )
 		ENSURE( invLocal.cx.x <= previousDiagonal );
 		previousDiagonal = invLocal.cx.x;
 
+		// THE UNLOCK. Everything from side 13.5 to side 250 used to be zero -- rotation
+		// locked, spin never damping -- and is now a real graded value. This is the
+		// acceptance criterion for the whole widening, so it is asserted per size rather
+		// than described.
+		if ( s2 <= 500 )
+		{
+			ENSURE( invLocal.cx.x > 0 );
+		}
+
 		// The world tensor is a similarity transform of the local one, so it inherits the
-		// same contract. Rotating the body must not manufacture a negative entry or
-		// resurrect a refused tensor.
+		// contract. Rotating must not manufacture a negative entry.
 		b3Body_SetTransform( bodyId, (b3Pos){ B3_FIX( 0.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) },
 							 b3MakeQuatFromAxisAngle( b3Normalize( (b3Vec3){ B3_FIX( 1.0f ), B3_FIX( 2.0f ), B3_FIX( 3.0f ) } ),
 													  B3_FIX( 0.7f ) ) );
 
-		b3Matrix3 invWorld = b3Body_GetWorldInverseRotationalInertia( bodyId );
+		b3Matrix3 invWorld = b3Body_GetWorldInverseRotationalInertiaPrecise( bodyId );
 		ENSURE( invWorld.cx.x >= 0 && invWorld.cy.y >= 0 && invWorld.cz.z >= 0 );
 
 		if ( invLocal.cx.x == 0 )
 		{
-			// A refused tensor stays refused -- through the transform change above, and
-			// through a step of the world, which recomputes the world tensor from the
-			// local one without a guard of its own.
+			// Past the line the refusal still has to stick, through a transform change and
+			// through a step of the world.
 			ENSURE( invWorld.cx.x == 0 && invWorld.cy.y == 0 && invWorld.cz.z == 0 );
 
 			b3World_Step( worldId, B3_FIX( 1.0f ) / 60, 4 );
 
-			invWorld = b3Body_GetWorldInverseRotationalInertia( bodyId );
+			invWorld = b3Body_GetWorldInverseRotationalInertiaPrecise( bodyId );
 			ENSURE( invWorld.cx.x == 0 && invWorld.cy.y == 0 && invWorld.cz.z == 0 );
 		}
 	}
 
-	// The walk has to have arrived at zero rather than merely stayed small, or the
-	// monotonicity above would be satisfied by a constant.
+	// The walk still has to arrive at zero, or the monotonicity above would be satisfied
+	// by a constant. The line has moved from about side 13 to about side 367 -- a factor
+	// of 28 in length, and of 17 million in inertia.
 	ENSURE( previousDiagonal == 0 );
 
 	b3DestroyWorld( worldId );

--- a/test/test_determinism.c
+++ b/test/test_determinism.c
@@ -36,7 +36,7 @@
 #if defined( BOX3D_LUDICROUS_MODE )
 #define RAGDOLL_HASH 0xAD895018
 #else
-#define RAGDOLL_HASH 0xC9322058
+#define RAGDOLL_HASH 0x09699541
 #endif
 
 // Goldens for the c37cfe4-ported scenarios (wave pile, query spawn, mesh drop).
@@ -47,19 +47,19 @@
 // dfa5e6a triangle-vs-hull admission change (hulls resting on mesh terrain take
 // slightly different manifolds); their sleep steps and everything about query
 // spawn carried over unchanged.
-#define WAVE_PILE_SLEEP_STEP 279
+#define WAVE_PILE_SLEEP_STEP 277
 #define QUERY_SPAWN_SLEEP_STEP 243
 #define QUERY_SPAWN_HIT_COUNT 59
 #define QUERY_SPAWN_QUERY_HASH 0xE583B246
-#define MESH_DROP_SLEEP_STEP 250
+#define MESH_DROP_SLEEP_STEP 215
 #if defined( BOX3D_LUDICROUS_MODE )
 #define WAVE_PILE_HASH 0xCD74B232
 #define QUERY_SPAWN_HASH 0x72EDD20C
 #define MESH_DROP_HASH 0xEE4D0F7A
 #else
-#define WAVE_PILE_HASH 0x6FA2F3B2
-#define QUERY_SPAWN_HASH 0x28042A4C
-#define MESH_DROP_HASH 0x777F3CB6
+#define WAVE_PILE_HASH 0x33AFFF2D
+#define QUERY_SPAWN_HASH 0x17EC3891
+#define MESH_DROP_HASH 0x2045D332
 #endif
 
 static int SingleMultithreadingTest( int workerCount )

--- a/test/test_determinism.c
+++ b/test/test_determinism.c
@@ -27,12 +27,15 @@
 // bit-exact rigid translation of the trajectory. The hash differs only because it covers
 // the absolute transform bytes, and the wide build stores 128-bit positions (80-byte
 // b3WorldTransform vs 56-byte), so it carries its own golden. Full 128 bits are hashed.
-// Both hashes moved 2026-08-22 with the f42be21 triangle-face clip fix: the crossing test is a
-// sign comparison now, so a capsule core straddling a triangle edge with both separations under
-// ~0.004 gets its second clip point instead of losing it to a b3FixMul that quantized to zero.
-// Ragdolls rest on the mesh floor, so this is the only scene that moves. Previously 0x886BE415
-// (ludicrous) and 0xB222C195 (narrow). Every sleep step and every other scene carried over
-// unchanged, verified identical for worker counts 1-5 in both builds.
+// RE-CAPTURED 2026-08-24 for the wider storage of inverse quantities (Q24.40): every body's
+// inverse mass and inverse inertia now carry 24 more fraction bits, so every trajectory in
+// every scene moves in its last bits. Previously 0xC9322058 (narrow). Before that, both
+// hashes moved 2026-08-22 with the f42be21 triangle-face clip fix.
+//
+// THE SLEEP STEP IS UNCHANGED AT 287, and that is the reassuring part: the ragdolls settle
+// on exactly the same step they always did, so the widening moved the arithmetic without
+// moving the physics. An early version of the change had this at 0 -- never sleeping --
+// which is what a missed scale crossing looks like, and is how one was found.
 #if defined( BOX3D_LUDICROUS_MODE )
 #define RAGDOLL_HASH 0xAD895018
 #else

--- a/tools/revendor-fixed.sh
+++ b/tools/revendor-fixed.sh
@@ -18,10 +18,10 @@
 set -euo pipefail
 
 FIXED_REPO="https://github.com/mas-bandwidth/fixed.git"
-# v1.3.0. Pinned as a SHA rather than the tag name on purpose: a tag can be moved,
-# a commit cannot, and "vendored at v1.3.0" should mean one specific tree forever.
-FIXED_PIN="db2e4809f62a031e994b336cbada2d012f9c99df"
-FIXED_VERSION="v1.3.0"
+# v1.3.1. Pinned as a SHA rather than the tag name on purpose: a tag can be moved,
+# a commit cannot, and "vendored at v1.3.1" should mean one specific tree forever.
+FIXED_PIN="cb48d9db245745292ec946b409a91bec07eb9d34"
+FIXED_VERSION="v1.3.1"
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DEST="$ROOT/extern/fixed"


### PR DESCRIPTION
**Draft, and held deliberately.** The change is correct and every suite is green; it is not proposed for merge because the performance cost is far more than slight, and the gate says that trade is Glenn's. Addresses #35.

## What it does

A body's inverse inertia is now exact and nonzero from cube side 1 to about **366**, where it was **13.1**. That is a factor of 28 in length and 17 million in inertia. Space's 250-unit asteroid — whose inverse inertia *and* inverse mass were both exactly zero, so it could neither spin nor be pushed — now has real graded values.

| cube side | before | after |
|---|---|---|
| 11 | 2.4 quanta | 40,962,613 quanta |
| 13.5 | **0 — rotation locked** | 14,712,356 |
| 37.5 | **0** | 88,960 |
| 44 | **0** | 40,003 |
| 120 | **0** | 265 |
| 250 | **0** | 6.8 |
| 500 | 0 | 0 (the new line is ~366) |

## DEVIATION: Q24.40, not the Q16.48 that was asked for

Derived, not preferred. **Inverse mass and inverse inertia must share one format**, because the contact solver adds them together:

```c
kNormal = invMassA + invMassB + dot( rnA, invIA * rnA ) + dot( rnB, invIB * rnB );
```

That gives four bounds. The large end is space's asteroid; the small end is what this engine can actually produce — `b3FloorInertia` floors the inertia diagonal at 4 ULP, giving a largest inverse inertia of 16,384, and a 0.01-radius sphere at density 1 gives an inverse mass of ~2.4e5.

```
inverse mass:    asteroid 6.4e-08  needs f >= 24 ;  2.4e5 must fit -> f <= 45
inverse inertia: asteroid 1.23e-11 needs f >= 37 ;  16384 must fit -> f <= 49
                                          intersection: f in [37, 45]
```

**f = 48 is outside it.** Its ceiling is 32,768 and a one-centimetre sphere needs 240,000, so Q16.48 would have converted a large-body bug into a small-body bug — a worse trade, since small bodies are common and large ones are not. `src/inverse.h` carries the table beside the constant. Mass has no floor of its own, so `b3InvFromRatio` **saturates** rather than assuming one: a body too light to represent reads as very light, never wrapped.

## Why this is smaller than the ~150 sites first estimated

`b3FixMul` shifts by 16, so an inverse (2^40) times an ordinary value (2^16) comes out at 2^40 — an inverse again. The entire effective-mass machinery, `b3AddMM` on two inverse tensors, and the similarity transform `R·invI·Rᵀ` all work **verbatim**. Only two shapes change: applying an inverse to get a velocity (shift 40, not 16), and inverting an inverse.

The ~40 reciprocal sites were classified **one at a time**, because some denominators in the very same expressions are ordinary quantities:

| site | verdict | why |
|---|---|---|
| `kNormal`, `kTwist`, joint `k`/`ka` | **widened** | sums of inverse mass and `invI`-derived terms |
| `totalFrictionWeight` (×3) | stays ordinary | a weight, not an inverse |
| `wheel_joint` `den = cs² + ss²` (×3) | stays ordinary | trigonometry, dimensionless |
| tangent mass `b3Invert2` | **widened** | inverse-scaled `k` → ordinary mass |
| joint `rotationMass` | **widened** | inverse-scaled sum → ordinary mass |
| impulse-normalisation divides | stay ordinary | impulses, not inverses |

Inverting a 2^40 matrix down to 2^16 needs the **same shift** as inverting 2^16 up to 2^40, so one routine serves both directions.

**Narrow storage had to be partly undone.** `iRnAs`, `iRnBs`, `mNormalA/B`, `iNormalA/B` carry the inverse scale, so a typical value is ~2^40 raw and does **not** fit the int32 the narrow fields use — it would clamp, not round. The audit that justified Q16.16 measured *ordinary* Jacobian terms bounded by hull extents; an inverse-derived row is a different quantity and was never covered by it.

## Verification

- All 22 suites green. All four determinism goldens re-captured.
- **`MultithreadingTest` passes**, which is the check that matters: it holds the scalar and wide paths to bit-identity across worker counts 1–5.
- The ragdolls still sleep on **step 287**, exactly as before. An early version had that at 0 — which is what a missed scale crossing looks like, and is how one was found.
- The envelope test's oracle is the exact integer `2^(16+f) / inertiaRaw`, sharing no arithmetic with the implementation, asserted as an equality at every size.

## The cost, after the prerequisite landed

The first measurement of this branch was **joint_grid +503%, rain +275%**. The cause was structural rather than a missed optimization: the exact arm of `fixInvertMatrix` and `fixSolve3` admits cofactors below 2^62, a cofactor of 2^40-scaled entries is 2^80, so **every** solve or inverse of an inverse-scaled matrix is forced onto the 256-bit arm — whose division was bit-serial, ~200 iterations. Profiling put 426 of 455 samples inside that loop. Lowering the format does not escape it: the 128-bit arm needs f ≤ 31 and the asteroid needs f ≥ 37.

So the prerequisite was built and landed upstream: **mas-bandwidth/fixed#19**, Knuth Algorithm D over 64-bit limbs, released as **v1.3.1** and pinned here. Every frozen hash upstream is unchanged, so it is speed and nothing else.

That removed most of it:

| benchmark | before the divider | **after** |
|---|---|---|
| joint_grid | +503.0% | **+15.2%** |
| rain | +275.3% | **+17.1%** |
| trees50 | +30.4% | **+11.3%** |
| trees100 | +20.9% | +0.6% |
| trees25 | +16.1% | +5.6% |

Full interleaved A/B (both binaries alternating in one window, min per side), Apple M2, RelWithDebInfo + LTO, 5 pairs; the three double-digit scenes re-measured at 7 pairs and unchanged:

| benchmark | base ms | head ms | delta |
|---|---|---|---|
| convex_pile | 16722.1 | 7714.6 | **-53.9%** |
| junkyard | 9876.4 | 9211.8 | -6.7% |
| many_pyramids | 2051.9 | 1946.6 | -5.1% |
| washer | 14424.9 | 14205.1 | -1.5% |
| trees100 | 156.1 | 157.1 | +0.6% |
| large_pyramid | 1832.9 | 1856.0 | +1.3% |
| large_world | 27.5 | 28.1 | +2.5% |
| trees25 | 386.4 | 408.2 | +5.6% |
| trees50 | 196.4 | 218.5 | **+11.3%** |
| joint_grid | 923.3 | 1064.0 | **+15.2%** |
| rain | 1349.5 | 1579.6 | **+17.1%** |

**Geomean across all eleven: −3.6%. Total wall time across the suite: −19.9%.** The suite is net faster; three scenes are not.

## One more cost, found by CI rather than by the benchmark

Instrumented builds pay far more than optimized ones. The sanitized macOS job went from **1m56s on main to over the 4-minute default** here, and the msan job needed its limit raised again. Both are the same effect: the widening puts 256-bit arithmetic on solver paths, and ASan/UBSan/MSan instrument exactly that shape hardest.

Two timeouts in this branch were raised with comments saying why. That is worth flagging plainly rather than leaving in the workflow file: **everyone's sanitized CI and local debug runs get slower**, by more than double, not by 15%. It does not change the optimized numbers above, and it is not an argument on its own, but it belongs in the decision.

## HELD, and this is the one decision left

The amended gate is "slight merges with the number, more than slight holds", read as single-digit percent on the hot scenes. **joint_grid +15.2% and rain +17.1% are not single-digit**, so by the stated criterion this holds rather than merges.

The case is genuinely two-sided, which is why it is yours:

- **For merging as-is**: the suite is net faster on both aggregates, convex_pile — the largest scene by wall time — is 54% faster, and the correctness the branch buys is the whole point of the wave.
- **Against**: joint-heavy and mesh-heavy scenes pay 11–17%, and those are common shapes in real content. General consumers pay that for a capability only large-bodied content uses.

**The remaining cost looks structural, not lazy.** Typical inverse quantities are of order 1, which at 2^40 is 2^40 raw and squares to 2^80 — past the 128-bit arm's reach for any format in the admissible window [37, 45]. So ~15% on joint scenes is plausibly the floor for this design rather than the next optimization's target. I would not promise to find it.

If you weight the aggregate, this merges as it stands. If you weight the worst scene, it needs a different design for the joint path — and that is a bigger question than this branch.

## Provisional API, additive only

`b3Body_GetInverseMass` and `b3Body_GetWorldInverseRotationalInertia` keep their signatures and return the b3Fixed conversion, now documented as lossy for heavy bodies. Added alongside: `b3Body_GetInverseMassPrecise`, `b3Body_GetWorldInverseRotationalInertiaPrecise`, and `b3GetInverseFractionBits()`. Nothing is removed or repurposed, so if the eventual shape is a different type, unit or name, these can be withdrawn without having broken anyone. **The public-surface shape is Glenn's to finalize.**

## Found along the way

#36 — a sign test spelled as a quantizing product, which the wider storage's geometry walked into and asserted on. Fixed here for `b3CollideCapsuleAndTriangle` (measured: `a = -3751`, `b = -4`, both negative, product quantized to 0, so a same-sign pair took the opposite-sign branch and produced an interpolation parameter of **-0.001053**). Six more instances of the pattern are filed rather than swept in, because each moves a golden.

