### PR TITLE
Discharge the port cursor's condition: fixed3d#21 is closed, so the cursor states a fact

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,11 +14,14 @@ than no cursor:
   stb_truetype, the world_text shader). Held for a bench with a display; no simulation
   content, so it does not gate the cursor.
 
-*(**fixed3d#21 closes WITH this change, not before it** — `f42be21`'s remainder and
-`30c67b5` are carried across together, so the cursor moves two steps at once. Stated as a
-condition rather than as a fact because this line lands on a branch: a cursor that claims
-a closure the merge has not performed is a false green in the one file the next daily pass
-reads first. Record below.)*
+*(~~**fixed3d#21 closes WITH this change, not before it**~~ — **DISCHARGED 2026-08-25, verified
+rather than assumed: the branch merged and fixed3d#21 is CLOSED, so the cursor above states a
+fact and no longer a promise.** `f42be21`'s remainder and `30c67b5` were carried across
+together and the cursor moved two steps at once. The condition is struck rather than deleted
+because its reason is the reusable part and still true: **a cursor that claims a closure the
+merge has not performed is a false green in the one file the next daily pass reads first** —
+so a cursor line written on a branch says *closes with*, and the run that merges it comes back
+and says *closed*. Record below.)*
 
 The PORT RECORDs below run newest first and are the detail for each step.
 


### PR DESCRIPTION
Today's Box3D -> Fixed3D pass found upstream unchanged: `upstream/main` is
`30c67b5` exactly, which is the cursor, so `git log 30c67b5..upstream/main` is
empty and nothing was ported. Erin's last commit is 2026-08-12.

What this change does is finish the previous pass's bookkeeping. The cursor block
carried fixed3d#21's closure as a **condition** — "closes WITH this change, not
before it" — because that line was authored on a branch, and a cursor claiming a
closure the merge has not performed is a false green in the first file the daily
pass reads.

The branch merged and fixed3d#21 is CLOSED, checked against the issue board
rather than taken from the record. So the cursor is a plain fact now and the
conditional wording is the stale half.

The condition is struck rather than deleted, because its reason is the reusable
part and stays true: a cursor line written on a branch says *closes with*, and
the run that merges it comes back and says *closed*.

Docs only — no code touched, `git diff --stat` is `CLAUDE.md` alone, so
determinism cannot be reached by it. The fast config was built and run anyway:
all tests pass, 1.16 s, exit 0 taken from the run itself and not from a pipe.
