### PR TITLE
The game conversion roster, landed on the fixed seam

### DIFF
--- a/include/box3d/base.h
+++ b/include/box3d/base.h
@@ -128,9 +128,14 @@ B3_API void b3SetAssertFcn( b3AssertFcn* assertFcn );
 #define B3_BREAKPOINT assert( 0 )
 #endif
 
-#if !defined( NDEBUG ) || defined( B3_ENABLE_ASSERT )
-/// Internal assertion handler. Allows for host intervention.
+/// Internal assertion handler. Allows for host intervention. Declared and
+/// defined unconditionally — see src/core.c: the B3_ASSERT macro below is
+/// per-TU, but the inline math in these headers is compiled by the CALLER, so
+/// a caller without NDEBUG must be able to link against a library built with
+/// it.
 B3_API int b3InternalAssert( const char* condition, const char* fileName, int lineNumber );
+
+#if !defined( NDEBUG ) || defined( B3_ENABLE_ASSERT )
 /// Assert that a condition is true.
 #define B3_ASSERT( condition )                                                                                                  \
 	( (void)( ( !!( condition ) ) || ( b3InternalAssert( #condition, __FILE__, (int)( __LINE__ ) ), 0 ) ) )

--- a/include/box3d/fixed_compat.h
+++ b/include/box3d/fixed_compat.h
@@ -10,9 +10,12 @@
 // b3FixMul and B3_FIX, because STAYING DROP-IN COMPATIBLE WITH BOX3D IS A DESIGN GOAL
 // of this fork -- the public interface is not ours to evolve to suit a dependency.
 //
-// GENERATED. Every name below was read out of the previous box3d/fixed.h and mapped
-// through the rename that moved the library off the b3 prefix, so the set is exactly
-// what box3d defined before -- no more, no less.
+// The bulk of this file is GENERATED: every name in the sections marked so was read out
+// of the previous box3d/fixed.h and mapped through the rename that moved the library off
+// the b3 prefix, so that set is exactly what box3d defined before -- no more, no less.
+// Sections marked ADDED carry the same mapping applied by hand to parts of `fixed` that
+// box3d had no name for yet, and they follow the same rule: box3d's spelling, the
+// library's arithmetic, no second implementation anywhere.
 //
 // Forwarders rather than #defines: a macro would stop b3FixMul being a declared
 // identifier, so debuggers would show fixMul and a consumer could no longer name
@@ -94,6 +97,31 @@ B3_FIXED_INLINE int b3FixTruncToInt( fixed_t a ) { return fixTruncToInt( a ); }
 B3_FIXED_INLINE uint64_t b3ISqrt128High( uint64_t hi, uint64_t lo ) { return fixISqrt128High( hi, lo ); }
 B3_FIXED_INLINE fixInt128 b3Int128Div( fixInt128 a, fixInt128 b ) { return fixInt128Div( a, b ); }
 B3_FIXED_INLINE fixInt128 b3Int128ShiftLeft( fixInt128 a, int shift ) { return fixInt128ShiftLeft( a, shift ); }
+
+// ---- ADDED: the Q2.30 packed scalar domain ----------------------------------------
+// A SECOND raw fixed-point domain: 32-bit storage, 2 integer bits (sign included), 30
+// fraction bits. Built for always-normalized quantities -- a quaternion component never
+// leaves [-1, 1], so nearly every bit can go to fraction. box3d's use for it is
+// b3Quat30 (math_functions.h), the storage form the game puts on the wire.
+//
+// The type is a STRUCT on purpose, upstream and here: b3Fixed is a bare int64 typedef
+// and the Q48.16 and Q2.30 raws differ by 2^14, so a bare 32-bit typedef would let a
+// mixup compile silently -- the same trap as assigning a double into a b3Fixed. Wrapped,
+// arithmetic and cross-domain assignment refuse to compile and the converters below are
+// the only way across.
+//
+// ROUNDING RULE (pinned upstream): dropping bits rounds to nearest via
+// ( raw + ( 1 << ( drop - 1 ) ) ) >> drop, the same form as the wire's quantizers.
+typedef fixed30_t              b3Fixed30;
+
+#define B3_FIXED30_FRACTION_BITS   FIX30_FRACTION_BITS
+#define B3_FIXED30_ONE             FIX30_ONE
+#define B3_FIXED30_SHIFT           FIX30_SHIFT
+
+B3_FIXED_INLINE b3Fixed30 b3Fix30FromFix( fixed_t a ) { return fix30FromFix( a ); }
+B3_FIXED_INLINE fixed_t b3FixFromFix30( b3Fixed30 a ) { return fixFromFix30( a ); }
+B3_FIXED_INLINE double b3Fix30ToDouble( b3Fixed30 a ) { return fix30ToDouble( a ); }
+B3_FIXED_INLINE b3Fixed30 b3Fix30FromDouble( double x ) { return fix30FromDouble( x ); }
 
 // ===================================================================================
 // VECTORS, ROTATION, AND THE AGGREGATES BUILT ON THEM

--- a/include/box3d/math_functions.h
+++ b/include/box3d/math_functions.h
@@ -80,6 +80,85 @@ B3_API b3Fixed b3Atan2( b3Fixed y, b3Fixed x );
 /// for cross-platform determinism.
 B3_API b3CosSin b3ComputeCosSin( b3Fixed radians );
 
+/// Base-2 logarithm of a positive fixed-point number. Returns the most negative
+/// representable value for inputs <= 0. Implemented with pure integer squaring
+/// (exact binary digits, rounded to Q48.16 output) for cross-platform determinism.
+B3_API b3Fixed b3FixLog2( b3Fixed a );
+
+/// Two raised to a fixed-point power. Saturates on overflow (exponents >= 47),
+/// underflows to zero. Pure integer table product for cross-platform determinism.
+B3_API b3Fixed b3FixExp2( b3Fixed a );
+
+/// A positive fixed-point base raised to a fixed-point exponent, via
+/// exp2( exponent * log2( base ) ). Returns 0 for base <= 0 (the game's damage/
+/// control conventions want a hard floor, not a NaN analogue). Deterministic over
+/// accuracy. Measured against double pow over the control domain ( base in
+/// [2^-14, 2], exponent in [1/4, 4] ): error <= 2 output ulps + 1e-4 * result
+/// at every grid point (the two terms are Q48.16 output quantization, which
+/// dominates small results, and the exp2/log2 ladder error, which dominates
+/// large ones); results >= 0.5 stay within ~5e-5 relative. MathTest pins both.
+B3_API b3Fixed b3FixPow( b3Fixed base, b3Fixed exponent );
+
+// ---------------------------------------------------------------------------------------------
+// Q2.30 quaternions: 32-bit packed components for always-normalized rotations.
+// Storage precision protects the wire and accumulated math; physics consumes
+// rotations at Q48.16 through the pack/unpack pair (see fixed_compat.h, b3Fixed30).
+// ---------------------------------------------------------------------------------------------
+
+/// A rotation quaternion with Q2.30 packed components (16 bytes; always keep it normalized).
+typedef struct b3Quat30
+{
+	b3Fixed30 x, y, z, w;
+} b3Quat30;
+
+/// Pack a Q48.16 quaternion to Q2.30 (gains precision; saturating, exact in [-2, 2)).
+B3_API b3Quat30 b3Quat30FromQuat( b3Quat q );
+
+/// Unpack a Q2.30 quaternion to Q48.16 (drops 14 fraction bits, round to nearest).
+B3_API b3Quat b3QuatFromQuat30( b3Quat30 q );
+
+/// Normalize a quaternion IN the Q2.30 domain, at full 30-bit fraction precision --
+/// normalizing at Q48.16 and repacking would waste 14 of the storage's fraction bits.
+/// Components are clamped to [-1, 1] on output (the truncated-divide overshoot can
+/// otherwise exceed one by an ulp). A degenerate (zero) quaternion becomes identity.
+B3_API b3Quat30 b3NormalizeQuat30( b3Quat30 q );
+
+/// Is this Q2.30 quaternion normalized within tolerance?
+B3_API bool b3IsNormalizedQuat30( b3Quat30 q );
+
+// ---------------------------------------------------------------------------------------------
+// Critically damped smoothing on fixed point (the game control dynamics, deterministic).
+// Mirrors the double-precision formula: omega = 2 pi / smoothTime;
+// velocity = ( velocity - omega^2 * dt * ( current - target ) ) / ( 1 + omega * dt )^2;
+// result = current + velocity * dt.
+// ---------------------------------------------------------------------------------------------
+
+/// Critically damped smoothing toward a target. Updates velocity in place.
+B3_API b3Fixed b3SmoothCriticallyDamped( b3Fixed current, b3Fixed target, b3Fixed* velocity, b3Fixed smoothTime,
+										 b3Fixed deltaTime );
+
+/// Critically damped smoothing with separate smoothing times for moving up (toward a larger
+/// magnitude) and down. The time is selected by comparing |target| to |current|.
+B3_API b3Fixed b3SmoothCriticallyDampedUpDown( b3Fixed current, b3Fixed target, b3Fixed* velocity, b3Fixed smoothTimeUp,
+											   b3Fixed smoothTimeDown, b3Fixed deltaTime );
+
+/// Vector critically damped smoothing toward a target. Updates velocity in place.
+B3_API b3Vec3 b3SmoothCriticallyDampedVec3( b3Vec3 current, b3Vec3 target, b3Vec3* velocity, b3Fixed smoothTime,
+											b3Fixed deltaTime );
+
+/// Vector critically damped smoothing with up/down smoothing times, selected by comparing
+/// the target length to the current length (one time for the whole vector, not per component).
+B3_API b3Vec3 b3SmoothCriticallyDampedUpDownVec3( b3Vec3 current, b3Vec3 target, b3Vec3* velocity, b3Fixed smoothTimeUp,
+												  b3Fixed smoothTimeDown, b3Fixed deltaTime );
+
+/// A uniform random source for b3MakeRandomQuat: returns a fixed-point value in [-1, 1].
+typedef b3Fixed b3RandomFcn( void* context );
+
+/// A uniformly random unit quaternion by Marsaglia rejection sampling -- pure fixed point,
+/// sqrt only, no trig, so the draw is cross-platform deterministic given a deterministic
+/// random source. Consumes a variable number of draws (expected ~2.6).
+B3_API b3Quat b3MakeRandomQuat( b3RandomFcn* random, void* context );
+
 /// Extract a quaternion from a rotation matrix.
 B3_API b3Quat b3MakeQuatFromMatrix( const b3Matrix3* m );
 

--- a/src/core.c
+++ b/src/core.c
@@ -79,7 +79,22 @@ void b3SetAssertFcn( b3AssertFcn* assertFcn )
 	b3AssertHandler = assertFcn;
 }
 
-#if !defined( NDEBUG ) || defined( B3_ENABLE_ASSERT )
+// DEFINED UNCONDITIONALLY, unlike the B3_ASSERT macro that calls it.
+//
+// The macro is compiled per translation unit: a TU with NDEBUG gets the no-op
+// form, a TU without it gets the real one. That is fine WITHIN this library,
+// but the inline math in the public headers is compiled by the CALLER. An
+// application that builds Fixed3D with NDEBUG for speed while building its own
+// code without it — a completely reasonable combination, and what the space
+// game's CMake does deliberately — ends up referencing b3InternalAssert from
+// its own object files while this file compiled the definition away. The
+// result is an undefined-symbol link failure whose message points at
+// b3MakeQuatFromAxisAngle or b3Lerp and gives no hint that the cause is a
+// mismatched NDEBUG between two sides of an inline function.
+//
+// Always defining it costs one small function that the linker drops when
+// unused, and lets a caller enable assertions on the inline math it calls
+// without forcing the same choice on this library's internals.
 int b3InternalAssert( const char* condition, const char* fileName, int lineNumber )
 {
 	int result = b3AssertHandler( condition, fileName, lineNumber );
@@ -89,7 +104,6 @@ int b3InternalAssert( const char* condition, const char* fileName, int lineNumbe
 	}
 	return result;
 }
-#endif
 
 static void b3DefaultLogFcn( const char* message )
 {

--- a/src/math_functions.c
+++ b/src/math_functions.c
@@ -644,3 +644,199 @@ bool b3IsValidRay( const b3RayCastInput* input )
 				   b3IsValidFixed( input->maxFraction ) && B3_FIX( 0.0f ) <= input->maxFraction && input->maxFraction < B3_HUGE;
 	return isValid;
 }
+
+// ---------------------------------------------------------------------------------------------
+// The deterministic transcendental ladder, under box3d's names.
+//
+// The arithmetic itself lives in `fixed` (extern/fixed, fixLog2/fixExp2/fixPow): pure
+// integer squaring for log2, a pure integer table product for exp2, and pow composed from
+// the two. These are B3_API exports rather than header inlines, so they are declared in
+// math_functions.h and forwarded here -- fixed_compat.h cannot hold them, because base.h
+// includes fixed.h before B3_API exists.
+// ---------------------------------------------------------------------------------------------
+
+b3Fixed b3FixLog2( b3Fixed a )
+{
+	return fixLog2( a );
+}
+
+b3Fixed b3FixExp2( b3Fixed a )
+{
+	return fixExp2( a );
+}
+
+b3Fixed b3FixPow( b3Fixed base, b3Fixed exponent )
+{
+	return fixPow( base, exponent );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Q2.30 quaternions
+//
+// The SCALAR half of Q2.30 is the library's (b3Fixed30 and its converters, fixed_compat.h).
+// The quaternion built on it is box3d's, the way b3Quat is: box3d owns its rotation types.
+// ---------------------------------------------------------------------------------------------
+
+b3Quat30 b3Quat30FromQuat( b3Quat q )
+{
+	b3Quat30 result;
+	result.x = b3Fix30FromFix( q.v.x );
+	result.y = b3Fix30FromFix( q.v.y );
+	result.z = b3Fix30FromFix( q.v.z );
+	result.w = b3Fix30FromFix( q.s );
+	return result;
+}
+
+b3Quat b3QuatFromQuat30( b3Quat30 q )
+{
+	b3Quat result;
+	result.v.x = b3FixFromFix30( q.x );
+	result.v.y = b3FixFromFix30( q.y );
+	result.v.z = b3FixFromFix30( q.z );
+	result.s = b3FixFromFix30( q.w );
+	return result;
+}
+
+// Squared length of a Q2.30 quaternion as a 128-bit ( high, low ) pair, in Q4.60.
+//
+// Carried as two uint64s rather than a 128-bit type on purpose. Each component is an
+// int32, so each square is at most 2^62 and four of them can reach 2^64 exactly -- one
+// bit past a uint64, and only when every component is INT32_MIN, which is precisely the
+// input a "surely it fits" argument gets wrong. Two words with an explicit carry is
+// exact for every input and needs no 128-bit division, which is the operation ClangCL
+// cannot link.
+static void b3Quat30LengthSquared( b3Quat30 q, uint64_t* high, uint64_t* low )
+{
+	const int64_t x = q.x.raw;
+	const int64_t y = q.y.raw;
+	const int64_t z = q.z.raw;
+	const int64_t w = q.w.raw;
+
+	const uint64_t squares[4] = {
+		(uint64_t)( x * x ),
+		(uint64_t)( y * y ),
+		(uint64_t)( z * z ),
+		(uint64_t)( w * w ),
+	};
+
+	uint64_t lo = 0;
+	uint64_t hi = 0;
+	for ( int i = 0; i < 4; ++i )
+	{
+		lo += squares[i];
+		hi += ( lo < squares[i] ) ? 1u : 0u;
+	}
+
+	*high = hi;
+	*low = lo;
+}
+
+b3Quat30 b3NormalizeQuat30( b3Quat30 q )
+{
+	uint64_t high, low;
+	b3Quat30LengthSquared( q, &high, &low );
+
+	if ( high == 0 && low == 0 )
+	{
+		b3Quat30 identity = { { 0 }, { 0 }, { 0 }, { B3_FIXED30_ONE } };
+		return identity;
+	}
+
+	// the square root of a Q4.60 raw is the Q2.30 length raw
+	const uint64_t length = b3ISqrt128High( high, low );
+
+	b3Quat30 result;
+	result.x.raw = fixNormalizeComponent30( q.x.raw, length );
+	result.y.raw = fixNormalizeComponent30( q.y.raw, length );
+	result.z.raw = fixNormalizeComponent30( q.z.raw, length );
+	result.w.raw = fixNormalizeComponent30( q.w.raw, length );
+	return result;
+}
+
+bool b3IsNormalizedQuat30( b3Quat30 q )
+{
+	uint64_t high, low;
+	b3Quat30LengthSquared( q, &high, &low );
+
+	// one is 2^60 in Q4.60, so a normalized quaternion has nothing in the high word
+	if ( high != 0 )
+	{
+		return false;
+	}
+
+	// |length^2 - 1| < 2^-20, mirroring b3IsNormalizedQuat's tolerance
+	const uint64_t one = (uint64_t)1 << ( 2 * B3_FIXED30_FRACTION_BITS );
+	const uint64_t tolerance = (uint64_t)1 << ( 2 * B3_FIXED30_FRACTION_BITS - 20 );
+	const uint64_t difference = low > one ? low - one : one - low;
+	return difference < tolerance;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Critically damped smoothing
+//
+// Scalar arithmetic from `fixed`; the vector forms are box3d's, because b3Vec3 is.
+// ---------------------------------------------------------------------------------------------
+
+b3Fixed b3SmoothCriticallyDamped( b3Fixed current, b3Fixed target, b3Fixed* velocity, b3Fixed smoothTime,
+								  b3Fixed deltaTime )
+{
+	return fixSmoothCriticallyDamped( current, target, velocity, smoothTime, deltaTime );
+}
+
+b3Fixed b3SmoothCriticallyDampedUpDown( b3Fixed current, b3Fixed target, b3Fixed* velocity, b3Fixed smoothTimeUp,
+										b3Fixed smoothTimeDown, b3Fixed deltaTime )
+{
+	return fixSmoothCriticallyDampedUpDown( current, target, velocity, smoothTimeUp, smoothTimeDown, deltaTime );
+}
+
+b3Vec3 b3SmoothCriticallyDampedVec3( b3Vec3 current, b3Vec3 target, b3Vec3* velocity, b3Fixed smoothTime,
+									 b3Fixed deltaTime )
+{
+	b3Vec3 result;
+	result.x = b3SmoothCriticallyDamped( current.x, target.x, &velocity->x, smoothTime, deltaTime );
+	result.y = b3SmoothCriticallyDamped( current.y, target.y, &velocity->y, smoothTime, deltaTime );
+	result.z = b3SmoothCriticallyDamped( current.z, target.z, &velocity->z, smoothTime, deltaTime );
+	return result;
+}
+
+b3Vec3 b3SmoothCriticallyDampedUpDownVec3( b3Vec3 current, b3Vec3 target, b3Vec3* velocity, b3Fixed smoothTimeUp,
+										   b3Fixed smoothTimeDown, b3Fixed deltaTime )
+{
+	// ONE smoothing time for the whole vector, selected by length -- not per component
+	b3Fixed smoothTime = b3Length( target ) >= b3Length( current ) ? smoothTimeUp : smoothTimeDown;
+	return b3SmoothCriticallyDampedVec3( current, target, velocity, smoothTime, deltaTime );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Random unit quaternion (Marsaglia rejection sampling: sqrt only, no trig)
+// ---------------------------------------------------------------------------------------------
+
+b3Quat b3MakeRandomQuat( b3RandomFcn* random, void* context )
+{
+	b3Fixed x, y, z, u, v, w;
+
+	do
+	{
+		x = random( context );
+		y = random( context );
+		z = b3FixMul( x, x ) + b3FixMul( y, y );
+	}
+	while ( z >= B3_FIXED_ONE || z == 0 );
+
+	do
+	{
+		u = random( context );
+		v = random( context );
+		w = b3FixMul( u, u ) + b3FixMul( v, v );
+	}
+	while ( w >= B3_FIXED_ONE || w == 0 );
+
+	b3Fixed s = b3FixSqrt( b3FixDiv( B3_FIXED_ONE - z, w ) );
+
+	b3Quat result;
+	result.v.x = x;
+	result.v.y = y;
+	result.v.z = b3FixMul( s, u );
+	result.s = b3FixMul( s, v );
+	return b3NormalizeQuat( result );
+}

--- a/test/test_math.c
+++ b/test/test_math.c
@@ -12,6 +12,317 @@
 // Q48.16 output resolution (1.5e-5) on top.
 #define ATAN_TOL B3_FIX( 0.0001f )
 
+// ---------------------------------------------------------------------------------------------
+// The game conversion roster: the exp2/log2/pow ladder, Q2.30 quaternions, critically damped
+// smoothing, random quaternions. Every one of these is a name the game asks box3d for, so the
+// tests measure them through box3d's spelling even where the arithmetic lives in `fixed`.
+// ---------------------------------------------------------------------------------------------
+
+static int Exp2Log2PowTest( void )
+{
+	// exact powers round-trip exactly
+	ENSURE( b3FixLog2( B3_FIXED_ONE ) == 0 );
+	ENSURE( b3FixLog2( B3_FIX( 2.0f ) ) == B3_FIXED_ONE );
+	ENSURE( b3FixLog2( B3_FIX( 0.5f ) ) == -B3_FIXED_ONE );
+	ENSURE( b3FixExp2( 0 ) == B3_FIXED_ONE );
+	ENSURE( b3FixExp2( B3_FIXED_ONE ) == B3_FIX( 2.0f ) );
+	ENSURE( b3FixExp2( -B3_FIXED_ONE ) == B3_FIX( 0.5f ) );
+
+	// domain edges
+	ENSURE( b3FixLog2( 0 ) == INT64_MIN );
+	ENSURE( b3FixLog2( -B3_FIXED_ONE ) == INT64_MIN );
+	ENSURE( b3FixPow( 0, B3_FIXED_ONE ) == 0 );
+	ENSURE( b3FixPow( -B3_FIXED_ONE, B3_FIXED_ONE ) == 0 );
+	ENSURE( b3FixPow( B3_FIX( 1.5f ), 0 ) == B3_FIXED_ONE );
+	ENSURE( b3FixExp2( B3_FIX( 47.0f ) + 1 ) == INT64_MAX );
+	ENSURE( b3FixExp2( B3_FIX( -18.0f ) ) == 0 );
+
+	// log2 against libm over several magnitudes
+	for ( double t = -14.0; t <= 14.0; t += 0.03125 )
+	{
+		double value = pow( 2.0, t );
+		b3Fixed fixedValue = b3FixFromDouble( value );
+		if ( fixedValue <= 0 )
+		{
+			continue;
+		}
+		double quantized = b3FixToDouble( fixedValue );
+		double expected = log2( quantized );
+		double got = b3FixToDouble( b3FixLog2( fixedValue ) );
+		// exact binary digits rounded to Q48.16: within one output ulp plus input quantization
+		ENSURE( fabs( got - expected ) < 3.1e-5 );
+	}
+
+	// exp2 against libm
+	for ( double t = -16.0; t <= 16.0; t += 0.015625 )
+	{
+		b3Fixed fixedT = b3FixFromDouble( t );
+		double quantized = b3FixToDouble( fixedT );
+		double expected = pow( 2.0, quantized );
+		double got = b3FixToDouble( b3FixExp2( fixedT ) );
+		// relative error: table product carries ~16 rounded Q32 multiplies
+		double scale = expected > 1.0 ? expected : 1.0;
+		ENSURE( fabs( got - expected ) < 3.1e-5 * scale + 3.1e-5 );
+	}
+
+	// pow over the CONTROL DOMAIN ( base in [2^-14, 2], exponent in [1/4, 4] ), against double
+	// pow. The honest bound is COMPOSITE: Q48.16 output quantization dominates small results
+	// (one output ulp is 1.5e-5) and the ladder's relative error dominates large ones, so each
+	// point must satisfy error <= 2 ulps + 1e-4 * expected. Both components are reported; the
+	// documented claim in math_functions.h mirrors this bound.
+	double ulp = 1.0 / (double)B3_FIXED_ONE;
+	double worstRelativeLarge = 0.0; // over results >= 0.5, where quantization noise < 3.1e-5
+	double worstMargin = 0.0;		 // error / ( 2 ulps + 1e-4 * expected ), must stay < 1
+	for ( double b = 0.00006103515625; b <= 2.0; b *= 1.0442737824274138 ) // 2^(1/16) steps
+	{
+		for ( double e = 0.25; e <= 4.0; e += 0.0625 )
+		{
+			b3Fixed fixedBase = b3FixFromDouble( b );
+			b3Fixed fixedExponent = b3FixFromDouble( e );
+			if ( fixedBase <= 0 )
+			{
+				continue;
+			}
+			double expected = pow( b3FixToDouble( fixedBase ), b3FixToDouble( fixedExponent ) );
+			double got = b3FixToDouble( b3FixPow( fixedBase, fixedExponent ) );
+			double error = fabs( got - expected );
+
+			double margin = error / ( 2.0 * ulp + 1.0e-4 * expected );
+			if ( margin > worstMargin )
+			{
+				worstMargin = margin;
+			}
+
+			if ( expected >= 0.5 )
+			{
+				double relative = error / expected;
+				if ( relative > worstRelativeLarge )
+				{
+					worstRelativeLarge = relative;
+				}
+			}
+		}
+	}
+	printf( "  pow over the control domain: worst %.3g relative (results >= 0.5), worst composite margin %.2f of bound\n",
+			worstRelativeLarge, worstMargin );
+	ENSURE( worstRelativeLarge < 1.0e-4 );
+	ENSURE( worstMargin < 1.0 );
+
+	return 0;
+}
+
+static int Quat30Test( void )
+{
+	// pack/unpack round trip: packing gains precision, so Q48.16 -> Q2.30 -> Q48.16 is exact
+	for ( double t = -1.0; t <= 1.0; t += 0.001953125 )
+	{
+		b3Fixed a = b3FixFromDouble( t );
+		b3Fixed back = b3FixFromFix30( b3Fix30FromFix( a ) );
+		ENSURE( back == a );
+	}
+
+	// the pinned rounding rule on unpack: raw 2^13 (half of the drop) rounds up to 1 Q48.16 ulp
+	{
+		b3Fixed30 half = { (int32_t)1 << 13 };
+		ENSURE( b3FixFromFix30( half ) == 1 );
+		b3Fixed30 justUnder = { ( (int32_t)1 << 13 ) - 1 };
+		ENSURE( b3FixFromFix30( justUnder ) == 0 );
+	}
+
+	// pack saturates outside [-2, 2)
+	{
+		b3Fixed30 top = b3Fix30FromFix( B3_FIX( 3.0f ) );
+		ENSURE( top.raw == INT32_MAX );
+		b3Fixed30 bottom = b3Fix30FromFix( B3_FIX( -3.0f ) );
+		ENSURE( bottom.raw == INT32_MIN );
+	}
+
+	// double converters: Q2.30 resolution round trips through double exactly
+	{
+		b3Fixed30 v = b3Fix30FromDouble( 0.333333333333 );
+		double back = b3Fix30ToDouble( v );
+		ENSURE( fabs( back - 0.333333333333 ) < 1.0e-9 );
+		b3Fixed30 again = b3Fix30FromDouble( back );
+		ENSURE( again.raw == v.raw );
+	}
+
+	// normalize IN the Q2.30 domain: unit result at 30-bit precision, components clamped
+	{
+		b3Quat30 q;
+		q.x = b3Fix30FromDouble( 0.3 );
+		q.y = b3Fix30FromDouble( -0.5 );
+		q.z = b3Fix30FromDouble( 0.7 );
+		q.w = b3Fix30FromDouble( 0.4 );
+		b3Quat30 n = b3NormalizeQuat30( q );
+		ENSURE( b3IsNormalizedQuat30( n ) );
+
+		double nx = b3Fix30ToDouble( n.x );
+		double ny = b3Fix30ToDouble( n.y );
+		double nz = b3Fix30ToDouble( n.z );
+		double nw = b3Fix30ToDouble( n.w );
+		double length = sqrt( nx * nx + ny * ny + nz * nz + nw * nw );
+		ENSURE( fabs( length - 1.0 ) < 1.0e-8 );
+
+		// direction preserved
+		double scale = b3Fix30ToDouble( q.x ) / nx;
+		ENSURE( fabs( b3Fix30ToDouble( q.y ) / ny - scale ) < 1.0e-6 );
+
+		// components never exceed one
+		ENSURE( n.x.raw <= B3_FIXED30_ONE && n.x.raw >= -B3_FIXED30_ONE );
+		ENSURE( n.w.raw <= B3_FIXED30_ONE && n.w.raw >= -B3_FIXED30_ONE );
+	}
+
+	// an axis-aligned unit stays exactly unit, and degenerate becomes identity
+	{
+		b3Quat30 axis = { { 0 }, { 0 }, { 0 }, { B3_FIXED30_ONE } };
+		b3Quat30 n = b3NormalizeQuat30( axis );
+		ENSURE( n.w.raw == B3_FIXED30_ONE && n.x.raw == 0 );
+
+		b3Quat30 zero = { { 0 }, { 0 }, { 0 }, { 0 } };
+		b3Quat30 identity = b3NormalizeQuat30( zero );
+		ENSURE( identity.w.raw == B3_FIXED30_ONE );
+	}
+
+	// The four-INT32_MIN corner: the squared length is exactly 2^64, one bit past a uint64,
+	// and it is the ONLY input that reaches there. A single-word accumulator wraps it to
+	// zero and the quaternion is then read as degenerate, so it comes back as IDENTITY --
+	// which is normalized, and which "is the result a unit quaternion?" therefore cannot
+	// tell apart from the right answer. So pin the VALUE: four equal components normalize
+	// to four equal components, each -1/2, and identity is not that.
+	{
+		b3Quat30 extreme = { { INT32_MIN }, { INT32_MIN }, { INT32_MIN }, { INT32_MIN } };
+		ENSURE( b3IsNormalizedQuat30( extreme ) == false );
+
+		b3Quat30 n = b3NormalizeQuat30( extreme );
+		ENSURE( b3IsNormalizedQuat30( n ) );
+		ENSURE( n.x.raw == -( B3_FIXED30_ONE / 2 ) );
+		ENSURE( n.y.raw == -( B3_FIXED30_ONE / 2 ) );
+		ENSURE( n.z.raw == -( B3_FIXED30_ONE / 2 ) );
+		ENSURE( n.w.raw == -( B3_FIXED30_ONE / 2 ) );
+	}
+
+	// Q48.16 quaternion pack path
+	{
+		b3Quat q = b3MakeQuatFromAxisAngle( ( b3Vec3 ){ 0, B3_FIXED_ONE, 0 }, B3_FIX( 0.7f ) );
+		b3Quat30 packed = b3Quat30FromQuat( q );
+		b3Quat back = b3QuatFromQuat30( packed );
+		ENSURE( back.v.x == q.v.x && back.v.y == q.v.y && back.v.z == q.v.z && back.s == q.s );
+	}
+
+	return 0;
+}
+
+static int SmoothingTest( void )
+{
+	// the fixed smoothing must track the double-precision formula closely over a control-style
+	// trajectory (stick magnitudes, sub-second smooth times, 60 Hz steps)
+	double current = 0.0, velocity = 0.0;
+	b3Fixed fixedCurrent = 0, fixedVelocity = 0;
+
+	b3Fixed fixedSmoothTime = b3FixFromDouble( 0.25 );
+	b3Fixed fixedDeltaTime = b3FixFromDouble( 1.0 / 60.0 );
+	double smoothTime = 0.25;
+	double deltaTime = b3FixToDouble( fixedDeltaTime ); // compare against the same quantized dt
+
+	for ( int i = 0; i < 240; ++i )
+	{
+		double target = ( i < 120 ) ? 1.0 : -0.5;
+		b3Fixed fixedTarget = b3FixFromDouble( target );
+
+		// the double reference uses the SAME pi constant as B3_PI quantizes from
+		double w = 2.0 * (double)B3_PI / (double)B3_FIXED_ONE / smoothTime;
+		velocity = ( velocity - w * w * deltaTime * ( current - target ) ) /
+				   ( ( 1.0 + w * deltaTime ) * ( 1.0 + w * deltaTime ) );
+		current = current + velocity * deltaTime;
+
+		fixedCurrent =
+			b3SmoothCriticallyDamped( fixedCurrent, fixedTarget, &fixedVelocity, fixedSmoothTime, fixedDeltaTime );
+
+		ENSURE( fabs( b3FixToDouble( fixedCurrent ) - current ) < 0.002 );
+	}
+
+	// converged
+	ENSURE( fabs( b3FixToDouble( fixedCurrent ) - ( -0.5 ) ) < 0.01 );
+
+	// zero smooth time snaps to target; zero dt holds
+	b3Fixed v0 = 0;
+	ENSURE( b3SmoothCriticallyDamped( 0, B3_FIXED_ONE, &v0, 0, fixedDeltaTime ) == B3_FIXED_ONE );
+	ENSURE( b3SmoothCriticallyDamped( 0, B3_FIXED_ONE, &v0, fixedSmoothTime, 0 ) == 0 );
+
+	// up/down selection: moving toward larger magnitude uses the up time
+	{
+		b3Fixed vUp = 0, vRef = 0;
+		b3Fixed up = b3SmoothCriticallyDampedUpDown( 0, B3_FIXED_ONE, &vUp, fixedSmoothTime, b3FixFromDouble( 1.0 ),
+													 fixedDeltaTime );
+		b3Fixed reference = b3SmoothCriticallyDamped( 0, B3_FIXED_ONE, &vRef, fixedSmoothTime, fixedDeltaTime );
+		ENSURE( up == reference );
+	}
+
+	// vector variant matches the scalar componentwise
+	{
+		b3Vec3 c = { 0, 0, 0 };
+		b3Vec3 t = { B3_FIX( 0.5f ), -B3_FIX( 0.25f ), 0 };
+		b3Vec3 v = { 0, 0, 0 };
+		b3Fixed sx = 0, sy = 0;
+		b3Fixed vx = 0, vy = 0;
+		for ( int i = 0; i < 60; ++i )
+		{
+			c = b3SmoothCriticallyDampedVec3( c, t, &v, fixedSmoothTime, fixedDeltaTime );
+			sx = b3SmoothCriticallyDamped( sx, t.x, &vx, fixedSmoothTime, fixedDeltaTime );
+			sy = b3SmoothCriticallyDamped( sy, t.y, &vy, fixedSmoothTime, fixedDeltaTime );
+		}
+		ENSURE( c.x == sx && c.y == sy && c.z == 0 );
+	}
+
+	// the vector up/down form selects ONE time by length, not per component: a target
+	// longer than the current vector takes the up time for every component at once
+	{
+		b3Vec3 c = { 0, 0, 0 };
+		b3Vec3 t = { B3_FIX( 0.5f ), -B3_FIX( 0.25f ), 0 };
+		b3Vec3 v = { 0, 0, 0 };
+		b3Vec3 cRef = { 0, 0, 0 };
+		b3Vec3 vRef = { 0, 0, 0 };
+		b3Vec3 got = b3SmoothCriticallyDampedUpDownVec3( c, t, &v, fixedSmoothTime, b3FixFromDouble( 1.0 ),
+														 fixedDeltaTime );
+		b3Vec3 expected = b3SmoothCriticallyDampedVec3( cRef, t, &vRef, fixedSmoothTime, fixedDeltaTime );
+		ENSURE( got.x == expected.x && got.y == expected.y && got.z == expected.z );
+	}
+
+	return 0;
+}
+
+// a small deterministic xorshift for the random-quat test
+static b3Fixed RandomFixedSource( void* context )
+{
+	uint64_t* state = (uint64_t*)context;
+	uint64_t x = *state;
+	x ^= x << 13;
+	x ^= x >> 7;
+	x ^= x << 17;
+	*state = x;
+	// uniform in [-1, 1] at Q48.16: 17 bits of entropy mapped onto [-65536, 65536]
+	return (b3Fixed)( (int64_t)( x % ( 2 * 65536 + 1 ) ) - 65536 );
+}
+
+static int RandomQuatTest( void )
+{
+	uint64_t state = 0x123456789ABCDEFull;
+
+	for ( int i = 0; i < 1000; ++i )
+	{
+		b3Quat q = b3MakeRandomQuat( RandomFixedSource, &state );
+		ENSURE( b3IsNormalizedQuat( q ) );
+	}
+
+	// deterministic: same seed, same sequence
+	uint64_t stateA = 42, stateB = 42;
+	b3Quat a = b3MakeRandomQuat( RandomFixedSource, &stateA );
+	b3Quat b = b3MakeRandomQuat( RandomFixedSource, &stateB );
+	ENSURE( a.v.x == b.v.x && a.v.y == b.v.y && a.v.z == b.v.z && a.s == b.s );
+
+	return 0;
+}
+
 int MathTest( void )
 {
 	// Compare the fixed-point trig against double precision references from libm.
@@ -341,6 +652,12 @@ int MathTest( void )
 		ENSURE_SMALL( relAB.p.y - tB.p.y, 8 * B3_FIXED_EPSILON );
 		ENSURE_SMALL( relAB.p.z - tB.p.z, 8 * B3_FIXED_EPSILON );
 	}
+
+	// the game conversion roster
+	RUN_SUBTEST( Exp2Log2PowTest );
+	RUN_SUBTEST( Quat30Test );
+	RUN_SUBTEST( SmoothingTest );
+	RUN_SUBTEST( RandomQuatTest );
 
 	return 0;
 }


### PR DESCRIPTION
`feat/game-roster` has been 57 commits behind `main` and holds four things the game needs from box3d: a deterministic exp2/log2/pow ladder, Q2.30 packed quaternions, critically damped smoothing, and a random unit quaternion. Space Game's `SetupLevel.h` calls `b3MakeRandomQuat`, so space cannot re-vendor from `main` until they are here. This lands them.

## Not a replay of the fork, and the difference is the point

In those 57 commits box3d's fixed-point core moved out into `mas-bandwidth/fixed` (`extern/fixed`, generated and pin-checked). **The scalar half of the roster went with it and is already there**: `fixLog2`, `fixExp2`, `fixPow`, the `fixed30_t` domain and its converters, `fixSmoothCriticallyDamped` and its up/down form, and `fixNormalizeComponent30` — which had **no caller at all**, because the quaternion that needed it stayed behind on the fork.

Replaying the fork's implementations would have made a second copy of every one of them. So the roster lands as a **surface** over what the library already has, plus the part the library does not:

| | where it lands | why |
|---|---|---|
| `b3Fixed30`, `B3_FIXED30_*`, the four converters | `fixed_compat.h` | header-inline, the same mapping the rest of that file applies |
| `b3FixLog2` / `b3FixExp2` / `b3FixPow`, the two scalar smoothing entry points | `math_functions.h` + `.c`, as `B3_API` forwarders | they cannot live in `fixed_compat.h`: `base.h` includes `fixed.h` before `B3_API` is defined, which is why that file holds inlines only |
| `b3Quat30` and its four operations, the two `b3Vec3` smoothing forms, `b3MakeRandomQuat` | box3d's own, in `math_functions.c` | for the same reason `b3Quat` and `b3Vec3` are box3d's. `b3NormalizeQuat30` calls `fixNormalizeComponent30`, which gives that function the consumer it was extracted for |

`fixed_compat.h`'s "GENERATED … no more, no less" note now says which sections are generated and which were added by hand under the same rule.

## One deliberate rewrite

The fork summed a Q2.30 quaternion's four squared components into a native 128-bit value and divided it natively. **ClangCL cannot link 128-bit division** — the same hazard `fixNormalizeComponent30` documents upstream. The squared length is now carried as an explicit `( high, low )` uint64 pair with a carry, and the division is the library's.

Four components of `INT32_MIN` sum to exactly 2^64 — one bit past a uint64, and the only input that reaches there.

## Tests

The fork's four subtests come across as they were, and `MathTest` runs them:

```
  pow over the control domain: worst 2.58e-05 relative (results >= 0.5), worst composite margin 0.25 of bound
  subtest passed: Exp2Log2PowTest
  subtest passed: Quat30Test
  subtest passed: SmoothingTest
  subtest passed: RandomQuatTest
```

The `INT32_MIN` corner is added, and it is written the way it is because **the obvious version does not work**: a single-word accumulator wraps that input to zero, the quaternion reads as degenerate, and it comes back as **identity** — which *is* normalized, so "is the result a unit quaternion?" cannot see the bug. The test pins the four component values instead.

**Verified by negative control**, not by assumption:

- collapsing the accumulator to one word → `Quat30Test` red
- flipping the up/down length comparison in `b3SmoothCriticallyDampedUpDownVec3` → `SmoothingTest` red (`condition false: got.x == expected.x && ...`)

Full suite green locally: 23 suites, `All Fixed3D tests passed`.

## Not carried, and not lost

The fork's `b3Normalize` short-vector lift (commit `08885e5`). `b3Normalize` is now a forwarder into `fixNormalize`, and `extern/fixed` is a generated tree that `vendor-drift.yml` fails on any hand edit — that fix belongs upstream, with the pin bump behind it. Filed as **mas-bandwidth/fixed#20** with the measurements and a note that it will move fixed3d's determinism baseline.

Because it is not here, `test_determinism.c` keeps `main`'s baseline. The fork re-based it (sleep step 287 → 292) precisely because the lift moves contact normals.