### PR TITLE
Vendor fixed v1.3.2, and give the msan leg a failure state

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,9 +42,27 @@ jobs:
             # The result job at the end of this file is the third layer: it turns a
             # cancelled leg anywhere in this matrix into a failing required check.
             #
-            # PROVISIONAL: these limits are replaced from this branch's own measured runs.
+            # 35m IS SET FROM THE OBSERVED SPREAD, not from one sample -- #34 picked 25
+            # from a single 14m02s run and the very next CI run failed at 25m18s. Five
+            # runs of this leg on the fixed v1.3.2 pin, test step only:
+            #
+            #   5m35s   21m47s   23m46s   23m59s   25m27s
+            #
+            # A 4.6x spread on identical code, and the last of those is a run with
+            # nothing else of mine in flight, so the slow mode is the runner and not
+            # contention. The fast sample is the outlier; roughly 24m is the honest
+            # expectation. 35m is about 1.4x the worst seen, which is the headroom a
+            # distribution this wide needs. timeout-minutes sits above it as the backstop.
+            #
+            # For contrast, the same step on the v1.3.1 pin ran 38m52s WITHOUT FINISHING.
+            # The cost is in the vendored library rather than here: mas-bandwidth/fixed
+            # v1.3.2 put fixMul back on native __int128 operators, worth ~40% of a plain
+            # Debug run and more than that under -fsanitize-memory-track-origins, which
+            # instruments exactly the per-call stack traffic that was being added.
+            # mas-bandwidth/fixed#18 stays open for the rest of it (the fixInt128
+            # reductions in fixed_vec.h); this limit can come down again when that lands.
             timeout: 40
-            test-timeout: 30m
+            test-timeout: 35m
             args: '-DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18 -DCMAKE_C_FLAGS="-fsanitize=memory -fsanitize-memory-track-origins=1 -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-fsanitize=memory -fsanitize-memory-track-origins=1 -fno-omit-frame-pointer" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=memory"'
             test: ./bin/test
             msan-options: abort_on_error=1:halt_on_error=1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,27 +30,21 @@ jobs:
             test: ./bin/test
           - name: ubuntu-clang-msan
             os: ubuntu-latest
-            # 10 until the fixed v1.3.0 pin move, which turned this into a red check with
-            # no sanitizer finding in it. 40 is set for the OBSERVED SPREAD, not for a
-            # single measurement: 8m22s before the pin, then 14m02s, then over 25m, on
-            # runners that differ by roughly 2x for the same commit. A limit picked from
-            # one sample of a distribution this wide just fails later and looks like a
-            # regression -- which is what setting it to 25 from the 14m02s run did.
+            # THE LIMIT THAT MATTERS IS THE ONE ON THE TEST COMMAND, not timeout-minutes.
+            # A job killed by timeout-minutes finishes CANCELLED, and cancelled is not
+            # failure: the run goes grey, `conclusion` reads "cancelled", and an entire
+            # sanitizer leg absents itself without anything going red. This job did that
+            # on main for several consecutive merges. `timeout` exits 124, which fails
+            # the step, which fails the job -- an overrun here is a red X that says
+            # "ubuntu-clang-msan did not finish", which is the honest report.
+            # timeout-minutes stays as a backstop for the case the inner bound cannot
+            # cover (a hung build step, a wedged runner) and is set above it on purpose.
+            # The result job at the end of this file is the third layer: it turns a
+            # cancelled leg anywhere in this matrix into a failing required check.
             #
-            # The cost is in the vendored library and not in this repository: measured
-            # across the pin at 19.54s -> 37.84s for a plain Debug test run, with the
-            # inverse work contributing 0.4s of the 18. The mechanism is fixMul, which
-            # moved from native __int128 operators to seam calls. Both spellings inline,
-            # so that was the wrong question -- at -O0 each inlined call materialises its
-            # operands to the stack, and that is exactly the traffic
-            # -fsanitize-memory-track-origins instruments most heavily, which is why this
-            # job is hit harder than the 1.94x an uninstrumented Debug build shows.
-            # Optimized builds are unaffected or faster.
-            #
-            # Tracked as mas-bandwidth/fixed#18, where restoring native operators in
-            # fixMul alone is measured to recover two thirds of it. This limit comes back
-            # down when that lands rather than staying quietly generous.
+            # PROVISIONAL: these limits are replaced from this branch's own measured runs.
             timeout: 40
+            test-timeout: 30m
             args: '-DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18 -DCMAKE_C_FLAGS="-fsanitize=memory -fsanitize-memory-track-origins=1 -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-fsanitize=memory -fsanitize-memory-track-origins=1 -fno-omit-frame-pointer" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=memory"'
             test: ./bin/test
             msan-options: abort_on_error=1:halt_on_error=1
@@ -126,12 +120,18 @@ jobs:
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{ matrix.config || env.BUILD_TYPE }}
 
+    # `test-timeout`, where a matrix entry sets one, wraps the command in coreutils
+    # `timeout`. That is deliberately not the same thing as timeout-minutes: this one
+    # FAILS (exit 124) instead of cancelling, so a leg that cannot finish reports as a
+    # red X rather than as a grey run with no conclusion in it. --kill-after promotes
+    # the TERM to a KILL for a process that ignores it (a sanitizer mid-report can),
+    # and --verbose puts the reason in the log instead of leaving a bare 124.
     - name: Test
       working-directory: ${{github.workspace}}/build
       env:
         MSAN_OPTIONS: ${{ matrix['msan-options'] || '' }}
         UBSAN_OPTIONS: print_stacktrace=1
-      run: ${{ matrix.test }}
+      run: ${{ matrix['test-timeout'] && format('timeout --verbose --kill-after=60s {0} ', matrix['test-timeout']) || '' }}${{ matrix.test }}
 
   # mingw needs some extra setup so keeping it separate from the matrix.
   # Debug -O0 copies whole structs and hid the b3SurfaceMaterial padding dedup bug.
@@ -245,3 +245,52 @@ jobs:
     - name: Conversion audit
       if: ${{ matrix['conversion-audit'] }}
       run: python3 tools/fixed-point/conversion_audit.py --db ${{github.workspace}}/build/compile_commands.json
+
+  # THE FAILURE STATE FOR THIS WORKFLOW.
+  #
+  # Every job above carries a timeout-minutes, and a job killed by one finishes
+  # CANCELLED. Cancelled is not failure: the run reports conclusion "cancelled", the
+  # commit gets a grey mark rather than a red one, and anything reading for
+  # `conclusion == 'failure'` sees nothing at all. So the loudest symptom a CI leg can
+  # have -- it did not finish -- was the quietest thing this workflow could report, and
+  # ubuntu-clang-msan sat past its limit on main for several consecutive merges without
+  # a red X anywhere.
+  #
+  # This job is the reader. It needs every other job, runs even when they fail, and
+  # fails unless each one succeeded or was legitimately skipped (the draft-PR guard).
+  # A cancelled leg becomes a failing check here, which is what "required check" can
+  # then be pointed at. If a HUMAN cancels the whole run, this job is cancelled with it
+  # and never runs, so that case stays what it is rather than turning into a false red.
+  result:
+    name: build_test result
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    needs: [test, build-windows-mingw, emscripten, samples]
+    if: always()
+    steps:
+      - name: Every job finished, and finished green
+        run: |
+          set -euo pipefail
+          failed=0
+          for entry in \
+            "test=${{ needs.test.result }}" \
+            "build-windows-mingw=${{ needs['build-windows-mingw'].result }}" \
+            "emscripten=${{ needs.emscripten.result }}" \
+            "samples=${{ needs.samples.result }}"
+          do
+            name="${entry%%=*}"
+            result="${entry#*=}"
+            printf '%-22s %s\n' "$name" "$result"
+            case "$result" in
+              success|skipped) ;;
+              cancelled)
+                echo "::error::$name did not finish -- it hit its time limit and was cancelled. A leg that cannot finish is a failure, not a neutral result."
+                failed=1
+                ;;
+              *)
+                echo "::error::$name reported '$result'"
+                failed=1
+                ;;
+            esac
+          done
+          exit $failed

--- a/extern/fixed/NOTES.md
+++ b/extern/fixed/NOTES.md
@@ -4,7 +4,7 @@ This directory is a **generated copy** of [mas-bandwidth/fixed](https://github.c
 the deterministic fixed-point math library that Fixed3D's own fixed-point core was
 extracted into.
 
-    Pinned at: v1.3.1  (cb48d9db245745292ec946b409a91bec07eb9d34)
+    Pinned at: v1.3.2  (06128963b5e154d9abef6d0b207a87e64174801c)
 
 ## Do not edit anything in this directory
 

--- a/extern/fixed/include/fixed/base.h
+++ b/extern/fixed/include/fixed/base.h
@@ -1,10 +1,9 @@
 // SPDX-FileCopyrightText: 2025-2026 Erin Catto -- derived from Box3D (https://github.com/erincatto/box3d)
 // SPDX-FileCopyrightText: 2026 Más Bandwidth LLC -- fixed-point conversion
 // SPDX-License-Identifier: MIT
-// Minimal macro base for the fixed library. Originally lifted from box3d/base.h so
-// box3d could depend on this library without renaming its API -- that premise is gone:
-// nothing here is named b3 any more, and a consumer wraps these types in its own
-// vocabulary rather than sharing a namespace with them.
+// Minimal macro base for the fixed library, derived from box3d/base.h. Nothing here is
+// named b3: a consumer wraps these types in its own vocabulary rather than sharing a
+// namespace with them.
 #pragma once
 
 // EACH MACRO IS GUARDED SEPARATELY, and that is the whole point of the shape below.

--- a/extern/fixed/include/fixed/fixed.h
+++ b/extern/fixed/include/fixed/fixed.h
@@ -173,11 +173,39 @@ FIX_ALWAYS_INLINE fixInt128 fixInt128Div( fixInt128 a, fixInt128 b )
 /// far below the +/-1.4e14 range and the checks cost real time in the solver.
 /// Define FIX_SATURATE to saturate on overflow instead of wrapping. (box3d passes its
 /// own BOX3D_FIXED_SATURATE down through its compatibility header.)
+///
+/// THE ROUNDING EXPRESSION IS WRITTEN TWICE, and the native spelling is not an
+/// alternative implementation -- it is the seam's own native bodies substituted by hand:
+///
+///   fixInt128MulI64( a, b )   ==  (fixInt128)a * b
+///   fixInt128Add( x, y )      ==  (fixInt128)( (fixUInt128)x + (fixUInt128)y )
+///   fixInt128Shr( x, n )      ==  x >> n
+///
+/// so the two arms cannot compute different values; the whole test suite runs a second
+/// time under FIX_FORCE_EMULATED_INT128 against the same frozen hashes to hold that.
+/// The unsigned round trip in the add is copied along with everything else, because it is
+/// what keeps the overflow behavior defined -- see the note above fixInt128Add.
+///
+/// WHY THE DUPLICATION EARNS ITS KEEP HERE AND NOWHERE ELSE. FIX_ALWAYS_INLINE makes both
+/// spellings inline, so "is it inlined?" is the wrong question: at -O0 an inlined body is
+/// still compiled naively, and each call materializes its operand and its result to a
+/// stack slot. Three inlined calls with stores and reloads between them, on the most
+/// frequently executed function in the library, cost 40% of an unoptimized consumer's
+/// entire test run (fixed3d's Debug suite: 40s on the seam spelling, 24s on this one) --
+/// and far more than that under a sanitizer, which instruments exactly that stack traffic.
+/// AT -O2 THE FORK IS INVISIBLE: both spellings fold to the same instructions, checked by
+/// compiling fixed3d's 83 optimized objects each way and finding them byte-identical.
+/// The saturation tail deliberately stays on the seam: it is off by default, cold when
+/// on, and duplicating it would buy nothing.
 FIX_ALWAYS_INLINE fixed_t fixMul( fixed_t a, fixed_t b )
 {
-	fixInt128 product = fixInt128MulI64( a, b );
 	// Round half up, then shift out the fraction bits (arithmetic shift)
+#if FIX_INT128_EMULATED
+	fixInt128 product = fixInt128MulI64( a, b );
 	fixInt128 r = fixInt128Shr( fixInt128Add( product, fixInt128FromI64( FIX_HALF ) ), FIX_FRACTION_BITS );
+#else
+	fixInt128 r = (fixInt128)( (fixUInt128)( (fixInt128)a * b ) + (fixUInt128)(fixInt128)FIX_HALF ) >> FIX_FRACTION_BITS;
+#endif
 #if defined( FIX_SATURATE )
 	if ( fixInt128Gt( r, fixInt128FromI64( INT64_MAX ) ) )
 	{

--- a/extern/fixed/include/fixed/fixed_int128.h
+++ b/extern/fixed/include/fixed/fixed_int128.h
@@ -588,8 +588,15 @@ typedef fixEmuUInt128 fixUInt128;
 #endif
 
 // The vocabulary. Every 128-bit operation in this library goes through one of these
-// names, which is what makes the emulated arm possible at all: there is no bare
-// operator on a fixInt128 anywhere in the headers or the sources.
+// names, which is what makes the emulated arm possible at all.
+//
+// ONE FUNCTION IS EXEMPT, and it is written down here so the exemption stays countable:
+// fixMul in fixed.h spells its rounding expression a second time in bare native
+// operators, under `#if FIX_INT128_EMULATED`, because at -O0 the per-call stack traffic
+// of the seam spelling costs a consumer 40% of its debug test run. It is a transcription
+// of these bodies rather than a second algorithm, and the emulated build of the entire
+// test suite asserts the same frozen hashes, so the two arms cannot drift apart in
+// silence. Anything else reaching for a bare operator should use these names instead.
 //
 // On the native arm each one is a FIX_ALWAYS_INLINE one-liner over the operator it
 // replaced, so -O2 code generation is unchanged. That is checked rather than asserted:

--- a/extern/fixed/include/fixed/fixed_vec.h
+++ b/extern/fixed/include/fixed/fixed_vec.h
@@ -400,7 +400,7 @@ FIX_INLINE bool fixIsNormalizedQuat( fixQuat q )
 /// Rotate a vector.
 /// Kept in the two-cross form: fused single-rounding variants of this and
 /// fixVecLerp/fixMulMV/fixCross perturb knife-edge equilibria (mesh-drop sleep,
-/// convex pile SAT cache). See the round-3 notes in CLAUDE.md.
+/// convex pile SAT cache).
 FIX_INLINE fixVec3 fixRotateVector( fixQuat q, fixVec3 v )
 {
 	// v + 2 * cross(q.v, cross(q.v, v) + q.s * v)
@@ -1002,7 +1002,7 @@ FIX_INLINE fixVec3 fixMulMV( fixMatrix3 m, fixVec3 a )
 {
 	// Kept as per-product rounding: the single-rounding form shifted the SAT
 	// edge-query geometry by an ulp and put convex hull piles into a persistent
-	// cache-miss regime (convex_pile +40%). See the round-3 notes in CLAUDE.md.
+	// cache-miss regime (convex_pile +40%).
 	fixVec3 b = {
 		fixMul( m.cx.x , a.x ) + fixMul( m.cy.x , a.y ) + fixMul( m.cz.x , a.z ),
 		fixMul( m.cx.y , a.x ) + fixMul( m.cy.y , a.y ) + fixMul( m.cz.y , a.z ),

--- a/tools/revendor-fixed.sh
+++ b/tools/revendor-fixed.sh
@@ -18,10 +18,10 @@
 set -euo pipefail
 
 FIXED_REPO="https://github.com/mas-bandwidth/fixed.git"
-# v1.3.1. Pinned as a SHA rather than the tag name on purpose: a tag can be moved,
-# a commit cannot, and "vendored at v1.3.1" should mean one specific tree forever.
-FIXED_PIN="cb48d9db245745292ec946b409a91bec07eb9d34"
-FIXED_VERSION="v1.3.1"
+# v1.3.2. Pinned as a SHA rather than the tag name on purpose: a tag can be moved,
+# a commit cannot, and "vendored at v1.3.2" should mean one specific tree forever.
+FIXED_PIN="06128963b5e154d9abef6d0b207a87e64174801c"
+FIXED_VERSION="v1.3.2"
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DEST="$ROOT/extern/fixed"


### PR DESCRIPTION
Two things, and the second is the one that matters.

## 1. The pin moves to fixed v1.3.2

[mas-bandwidth/fixed#22](https://github.com/mas-bandwidth/fixed/pull/22) puts `fixMul` back on native `__int128` operators on the native arm, under the seam's existing `#if FIX_INT128_EMULATED`. `FIX_ALWAYS_INLINE` meant "is it inlined?" was the wrong question — both spellings are; `always_inline` substitutes a body without optimizing it, so at `-O0` each inlined seam call materializes its operands to a stack slot. Measured on this repo's Debug suite, three interleaved runs each: **39.4 / 40.4 / 40.8 s before, 24.2 / 23.6 / 24.7 s after**. Optimized builds do not move at all — 83 of 83 project objects compile byte-identical at `-O2` across the pin.

The vendored diff is that change plus a few comment cleanups from fixed#21. `tools/revendor-fixed.sh --check` is clean; NOTES.md moves with it.

MSan with `-fsanitize-memory-track-origins=1` instruments exactly the stack traffic that was being added, which is why this leg was hit harder than the ~1.9x an uninstrumented Debug build showed, and why it should come back the same way.

## 2. The leg gets a failure state

`ubuntu-clang-msan` sat past its 40-minute `timeout-minutes` on main for several consecutive merges. Every one of those runs reported like this:

```
run   conclusion: cancelled
job   conclusion: cancelled
```

**Cancelled is not failure.** The commit gets a grey mark rather than a red one, and anything reading for `conclusion == 'failure'` sees nothing at all. So an entire sanitizer leg absented itself from CI, repeatedly, and the loudest symptom a job can have — it did not finish — was the quietest thing this workflow could report. That is the instrument-with-no-failure-state class: a gate that cannot go red is not a gate.

Fixed at two layers:

- **`test-timeout` on a matrix entry** wraps the test command in coreutils `timeout`. Exit 124 fails the step, which fails the job, which is a red X that says *ubuntu-clang-msan did not finish*. `--verbose` puts the reason in the log; `--kill-after` covers a sanitizer that ignores TERM mid-report. `timeout-minutes` stays above it as the backstop it should always have been (a wedged runner, a hung build step).
- **A `result` job** needs every other job, runs with `if: always()`, and fails unless each one reported `success` or `skipped`. This catches the class rather than the instance — a cancelled leg *anywhere* in this workflow now turns a check red. A run cancelled by a human cancels this job too, so that case stays what it is instead of becoming a false red.

## The limits

Set from this branch's own runs rather than from one sample, per the precedent in #34. The numbers and the final comment go in before this merges; the commit that pushed the branch says so in as many words.

🤖 Generated with [Claude Code](https://claude.com/claude-code)