### PR TITLE
Vendored fixed moves to v1.4.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -579,16 +579,15 @@ The PORT RECORDs below run newest first and are the detail for each step.
   foundation.md gained a b3Fixed primer section; overview.md gained a
   fork note up top. hello.md and simulation.md explain the two B3_FIX
   traps inline (bare literal truncates 65536x; %f on a b3Fixed is UB).
-- **Determinism goldens**: sleepStep=287, hash=0xB222C195, verified bit-identical
-  across 1-5 workers. Hash updated 2026-07-15 for the 0.8 AU scene origin;
-  sleepStep has carried over unchanged through FOUR origin moves
-  (origin→100 km→120,000 km→1.2e11 m), each an exactly representable rigid
-  translation. Prior hashes: 0x228A3865 (120,000 km), 0xE7D52285 (100 km) (see
-  the scene-origin bullet below); sleepStep is UNCHANGED from the origin-scene
-  value because an exactly representable origin shift is a bit-exact rigid
-  translation of the whole trajectory — only the absolute transform bytes the
-  hash covers moved. Any solver-affecting change invalidates these, see the
-  test conventions section for how to regenerate.
+- **Determinism goldens**: ragdoll sleepStep=312, hash=0xC745DFFF (ludicrous
+  0x5A1D71FF), verified bit-identical across 1-5 workers. The full set lives in
+  `test/test_determinism.c` (wave pile, query spawn, mesh drop carry their own).
+  Re-derived for the fixed v1.4.0 pin (the lift-before-divide fixNormalize fix
+  moves contact normals and joint axes — a ruled baseline move, fixed#20). An
+  exactly representable origin shift is a bit-exact rigid translation of the
+  whole trajectory, so origin moves change only the hash, never the sleep step.
+  Any solver-affecting change invalidates these, see the test conventions
+  section for how to regenerate.
 - **Scene origin invariant (2026-07-14, from Glenn: "we should always work
   there"; moved to 120,000 km the same day to match vanilla-double's maximum
   world — a ±120,000 km cube with ~1 m float-broadphase padding, per Erin —
@@ -1431,16 +1430,14 @@ Fixes landed in session 2 (beyond the session-1 list):
   `b3Sin`/`b3Cos` (the deterministic approximations carry ~1e-3 error and were
   never meant as references — see `ExactQuat` in test_manifold.c, the cylinder
   expectations in test_hull.c, and the trig comparisons in test_math.c).
-- Determinism goldens (`test/test_determinism.c`): `RAGDOLL_SLEEP_STEP 287`,
-  `RAGDOLL_HASH 0xB222C195` (macros renamed from EXPECTED_* in the dfa5e6a
-  port, following upstream; hash updated 2026-07-15 for the 0.8 AU scene
-  origin, previously 0x228A3865 at 120,000 km and 0xE7D52285 at 100 km; the
-  sleep step carried over unchanged through all four origin moves because
-  the shift is a bit-exact rigid translation; previously 0x6FA8A4C5 for the
-  e961bfb friction-center port; verified bit-identical across 1-5 workers).
-  Any solver-affecting change invalidates these: rerun, take the printed
-  values, confirm they're identical for all worker counts
-  before updating.
+- Determinism goldens (`test/test_determinism.c`): `RAGDOLL_SLEEP_STEP 312`,
+  `RAGDOLL_HASH 0xC745DFFF` standard / `0x5A1D71FF` ludicrous, with wave pile,
+  query spawn and mesh drop goldens alongside them (sleep steps shared between
+  builds; hashes per-build because they cover absolute transform bytes;
+  verified bit-identical across all worker counts, two clean generation runs
+  each build). Any solver-affecting change invalidates these: rerun, take the
+  printed values, confirm they're identical for all worker counts and that two
+  generation runs agree before updating.
 - `ATAN_TOL` in test_math.c is `B3_FIX(0.0001f)` (poly error + output quantization).
 
 ## Conversion tooling (copies in `tools/fixed-point/`, originals were in a

--- a/extern/fixed/NOTES.md
+++ b/extern/fixed/NOTES.md
@@ -4,7 +4,7 @@ This directory is a **generated copy** of [mas-bandwidth/fixed](https://github.c
 the deterministic fixed-point math library that Fixed3D's own fixed-point core was
 extracted into.
 
-    Pinned at: v1.3.2  (06128963b5e154d9abef6d0b207a87e64174801c)
+    Pinned at: v1.4.0  (a0fa624d739790844af34499381c55abaa65180f)
 
 ## Do not edit anything in this directory
 

--- a/extern/fixed/include/fixed/fixed_int128.h
+++ b/extern/fixed/include/fixed/fixed_int128.h
@@ -590,13 +590,16 @@ typedef fixEmuUInt128 fixUInt128;
 // The vocabulary. Every 128-bit operation in this library goes through one of these
 // names, which is what makes the emulated arm possible at all.
 //
-// ONE FUNCTION IS EXEMPT, and it is written down here so the exemption stays countable:
-// fixMul in fixed.h spells its rounding expression a second time in bare native
-// operators, under `#if FIX_INT128_EMULATED`, because at -O0 the per-call stack traffic
-// of the seam spelling costs a consumer 40% of its debug test run. It is a transcription
-// of these bodies rather than a second algorithm, and the emulated build of the entire
-// test suite asserts the same frozen hashes, so the two arms cannot drift apart in
-// silence. Anything else reaching for a bare operator should use these names instead.
+// A COUNTED SET OF FUNCTIONS IS EXEMPT, written down here so the exemptions stay
+// countable: fixMul in fixed.h, and the solver-rate reductions in fixed_vec.h --
+// fixDotRaw, fixFromDotRaw, fixDotQuat, fixMulQuat and fixInvMulQuat -- each spell their
+// expression a second time in bare native operators, under `#if FIX_INT128_EMULATED`,
+// because at -O0 the per-call stack traffic of the seam spelling costs a consumer's
+// debug test run about 40%. Every native spelling is a transcription of these bodies
+// rather than a second algorithm -- including the unsigned round trips that keep the
+// overflow behavior defined -- and the emulated build of the entire test suite asserts
+// the same frozen hashes, so the arms cannot drift apart in silence. Anything else
+// reaching for a bare operator should use these names instead.
 //
 // On the native arm each one is a FIX_ALWAYS_INLINE one-liner over the operator it
 // replaced, so -O2 code generation is unchanged. That is checked rather than asserted:

--- a/extern/fixed/include/fixed/fixed_int256.h
+++ b/extern/fixed/include/fixed/fixed_int256.h
@@ -86,11 +86,6 @@ FIX_ALWAYS_INLINE fixUInt256 fixUInt256Neg( fixUInt256 a )
 	return fixUInt256Sub( zero, a );
 }
 
-FIX_ALWAYS_INLINE bool fixUInt256Eq( fixUInt256 a, fixUInt256 b )
-{
-	return fixUInt128Eq( a.hi, b.hi ) && fixUInt128Eq( a.lo, b.lo );
-}
-
 FIX_ALWAYS_INLINE bool fixUInt256Lt( fixUInt256 a, fixUInt256 b )
 {
 	if ( !fixUInt128Eq( a.hi, b.hi ) )

--- a/extern/fixed/include/fixed/fixed_vec.h
+++ b/extern/fixed/include/fixed/fixed_vec.h
@@ -151,20 +151,38 @@ FIX_INLINE fixVec3 fixVecNeg( fixVec3 a )
 	return FIX_LITERAL( fixVec3 ){ -a.x, -a.y, -a.z };
 }
 
+// THE 128-BIT REDUCTIONS BELOW ARE SPELLED TWICE, exactly as fixMul is and for the same
+// reason (see the note on fixMul in fixed.h): at -O0 every inlined seam call materializes
+// its operands to stack slots, and these functions -- the dot family and the quaternion
+// products -- are the solver-rate reductions a consumer's debug build runs constantly.
+// Each native spelling is a transcription of the seam's own native bodies, including the
+// unsigned round trips that keep the overflow behavior defined; the emulated build of the
+// entire suite asserts the same frozen hashes, so the arms cannot drift in silence. The
+// exempt set is enumerated in fixed_int128.h next to the no-bare-operator rule.
+
 /// Exact dot product accumulated at 128 bits, scaled by 2^(2*FIX_FRACTION_BITS).
 /// No per-component rounding or saturation, so sign tests and comparisons on the
 /// raw value are exact even for sub-resolution results.
 FIX_INLINE fixInt128 fixDotRaw( fixVec3 a, fixVec3 b )
 {
+#if FIX_INT128_EMULATED
 	return fixInt128Add( fixInt128Add( fixInt128MulI64( a.x, b.x ), fixInt128MulI64( a.y, b.y ) ),
 						 fixInt128MulI64( a.z, b.z ) );
+#else
+	return (fixInt128)( (fixUInt128)( (fixInt128)a.x * b.x ) + (fixUInt128)( (fixInt128)a.y * b.y ) +
+						(fixUInt128)( (fixInt128)a.z * b.z ) );
+#endif
 }
 
 /// Round a raw 128-bit dot product to fixed point with a single round-half-up
 /// step (divide last), matching fixMul rounding and overflow policy.
 FIX_INLINE fixed_t fixFromDotRaw( fixInt128 raw )
 {
+#if FIX_INT128_EMULATED
 	fixInt128 r = fixInt128Shr( fixInt128Add( raw, fixInt128FromI64( FIX_HALF ) ), FIX_FRACTION_BITS );
+#else
+	fixInt128 r = (fixInt128)( (fixUInt128)raw + (fixUInt128)(fixInt128)FIX_HALF ) >> FIX_FRACTION_BITS;
+#endif
 #if defined( FIX_SATURATE )
 	if ( fixInt128Gt( r, fixInt128FromI64( INT64_MAX ) ) )
 	{
@@ -212,11 +230,47 @@ FIX_INLINE fixed_t fixDistanceSquared( fixVec3 a, fixVec3 b )
 	return fixFromDotRaw( fixDotRaw( dv, dv ) );
 }
 
+/// The exponent fixNormalize lifts a short vector to before dividing. Chosen so
+/// the squares stay far inside 128 bits: components reach ~2^46, squares ~2^92,
+/// and the three-term sum ~2^94.
+#define FIX_NORMALIZE_LIFT_BITS 46
+
 /// Normalize a vector. Returns a zero vector if the input vector is zero.
-/// The squared length and the division run at 128-bit precision, so even
-/// vectors far below unit length normalize to within an ulp of unit length.
+///
+/// PRECISION: the squared length is exact in 128 bits, but the length is a fixed_t --
+/// a whole raw unit -- with a relative truncation error of ~0.5/L at raw length L,
+/// which would land in the result's squared length as ~1/L. Normalization is
+/// scale-invariant and a left shift is EXACT, so the vector is lifted until its
+/// widest component fills the range before the same math runs: the direction is
+/// unchanged bit for bit, only the divisor's precision improves. The result is unit
+/// length within fixIsNormalized's tolerance at every input magnitude, down to a raw
+/// length of 1, and normalize is exactly scale-invariant across power-of-two scales
+/// inside the lift range. Inputs whose widest component already fills the range lift
+/// by zero and are untouched.
 FIX_INLINE fixVec3 fixNormalize( fixVec3 a )
 {
+	// magnitude of the widest component, as an unsigned value so the negation is
+	// defined for every input
+	uint64_t ux = a.x < 0 ? ( 0u - (uint64_t)a.x ) : (uint64_t)a.x;
+	uint64_t uy = a.y < 0 ? ( 0u - (uint64_t)a.y ) : (uint64_t)a.y;
+	uint64_t uz = a.z < 0 ? ( 0u - (uint64_t)a.z ) : (uint64_t)a.z;
+	uint64_t widest = ux | uy | uz;
+	if ( widest != 0 )
+	{
+		int bits = 0;
+		while ( ( widest >> bits ) != 0 )
+		{
+			bits++;
+		}
+		if ( bits < FIX_NORMALIZE_LIFT_BITS )
+		{
+			const int lift = FIX_NORMALIZE_LIFT_BITS - bits;
+			a.x = fixShiftLeft( a.x, lift ); // exact: shifts preserve direction
+			a.y = fixShiftLeft( a.y, lift );
+			a.z = fixShiftLeft( a.z, lift );
+		}
+	}
+
 	fixInt128 ls = fixDotRaw( a, a ); // Q32.32 in 128 bits
 	if ( fixInt128Gt( ls, FIX_INT128_ZERO ) )
 	{
@@ -426,7 +480,11 @@ FIX_INLINE fixVec3 fixInvRotateVector( fixQuat q, fixVec3 v )
 /// One rounding on the exact 128-bit sum.
 FIX_INLINE fixed_t fixDotQuat( fixQuat a, fixQuat b )
 {
+#if FIX_INT128_EMULATED
 	return fixFromDotRaw( fixInt128Add( fixDotRaw( a.v, b.v ), fixInt128MulI64( a.s, b.s ) ) );
+#else
+	return fixFromDotRaw( (fixInt128)( (fixUInt128)fixDotRaw( a.v, b.v ) + (fixUInt128)( (fixInt128)a.s * b.s ) ) );
+#endif
 }
 
 /// Multiply two quaternions. Each component is a fused 128-bit reduction with
@@ -435,6 +493,7 @@ FIX_INLINE fixQuat fixMulQuat( fixQuat q1, fixQuat q2 )
 {
 	// v = cross(q1.v, q2.v) + q1.s * q2.v + q2.s * q1.v
 	// s = q1.s * q2.s - dot(q1.v, q2.v)
+#if FIX_INT128_EMULATED
 	fixQuat q = {
 		{
 			fixFromDotRaw( fixInt128Add(
@@ -452,6 +511,19 @@ FIX_INLINE fixQuat fixMulQuat( fixQuat q1, fixQuat q2 )
 		},
 		fixFromDotRaw( fixInt128Sub( fixInt128MulI64( q1.s, q2.s ), fixDotRaw( q1.v, q2.v ) ) ),
 	};
+#else
+	fixQuat q = {
+		{
+			fixFromDotRaw( (fixInt128)( (fixUInt128)( (fixInt128)q1.v.y * q2.v.z ) - (fixUInt128)( (fixInt128)q1.v.z * q2.v.y ) +
+										(fixUInt128)( (fixInt128)q1.s * q2.v.x ) + (fixUInt128)( (fixInt128)q2.s * q1.v.x ) ) ),
+			fixFromDotRaw( (fixInt128)( (fixUInt128)( (fixInt128)q1.v.z * q2.v.x ) - (fixUInt128)( (fixInt128)q1.v.x * q2.v.z ) +
+										(fixUInt128)( (fixInt128)q1.s * q2.v.y ) + (fixUInt128)( (fixInt128)q2.s * q1.v.y ) ) ),
+			fixFromDotRaw( (fixInt128)( (fixUInt128)( (fixInt128)q1.v.x * q2.v.y ) - (fixUInt128)( (fixInt128)q1.v.y * q2.v.x ) +
+										(fixUInt128)( (fixInt128)q1.s * q2.v.z ) + (fixUInt128)( (fixInt128)q2.s * q1.v.z ) ) ),
+		},
+		fixFromDotRaw( (fixInt128)( (fixUInt128)( (fixInt128)q1.s * q2.s ) - (fixUInt128)fixDotRaw( q1.v, q2.v ) ) ),
+	};
+#endif
 	return q;
 }
 
@@ -461,6 +533,7 @@ FIX_INLINE fixQuat fixInvMulQuat( fixQuat q1, fixQuat q2 )
 {
 	// v = cross(q2.v, q1.v) + q1.s * q2.v - q2.s * q1.v
 	// s = q1.s * q2.s + dot(q1.v, q2.v)
+#if FIX_INT128_EMULATED
 	fixQuat q = {
 		{
 			fixFromDotRaw( fixInt128Sub(
@@ -478,6 +551,19 @@ FIX_INLINE fixQuat fixInvMulQuat( fixQuat q1, fixQuat q2 )
 		},
 		fixFromDotRaw( fixInt128Add( fixInt128MulI64( q1.s, q2.s ), fixDotRaw( q1.v, q2.v ) ) ),
 	};
+#else
+	fixQuat q = {
+		{
+			fixFromDotRaw( (fixInt128)( (fixUInt128)( (fixInt128)q2.v.y * q1.v.z ) - (fixUInt128)( (fixInt128)q2.v.z * q1.v.y ) +
+										(fixUInt128)( (fixInt128)q1.s * q2.v.x ) - (fixUInt128)( (fixInt128)q2.s * q1.v.x ) ) ),
+			fixFromDotRaw( (fixInt128)( (fixUInt128)( (fixInt128)q2.v.z * q1.v.x ) - (fixUInt128)( (fixInt128)q2.v.x * q1.v.z ) +
+										(fixUInt128)( (fixInt128)q1.s * q2.v.y ) - (fixUInt128)( (fixInt128)q2.s * q1.v.y ) ) ),
+			fixFromDotRaw( (fixInt128)( (fixUInt128)( (fixInt128)q2.v.x * q1.v.y ) - (fixUInt128)( (fixInt128)q2.v.y * q1.v.x ) +
+										(fixUInt128)( (fixInt128)q1.s * q2.v.z ) - (fixUInt128)( (fixInt128)q2.s * q1.v.z ) ) ),
+		},
+		fixFromDotRaw( (fixInt128)( (fixUInt128)( (fixInt128)q1.s * q2.s ) + (fixUInt128)fixDotRaw( q1.v, q2.v ) ) ),
+	};
+#endif
 	return q;
 }
 

--- a/test/test_determinism.c
+++ b/test/test_determinism.c
@@ -28,30 +28,30 @@
 //
 // A SLEEP STEP OF 0 MEANS THE RAGDOLLS NEVER SETTLED, which is what a missed scale
 // crossing looks like from here. Read a zero as that before re-capturing anything.
-#define RAGDOLL_SLEEP_STEP 287
+#define RAGDOLL_SLEEP_STEP 312
 #if defined( BOX3D_LUDICROUS_MODE )
-#define RAGDOLL_HASH 0xAD895018
+#define RAGDOLL_HASH 0x5A1D71FF
 #else
-#define RAGDOLL_HASH 0x09699541
+#define RAGDOLL_HASH 0xC745DFFF
 #endif
 
 // Goldens for the wave pile, query spawn and mesh drop scenarios. Fixed-point goldens
 // hold across platforms and worker counts by construction. The sleep steps are shared
 // between builds; the hashes cover absolute transform bytes, so the ludicrous build
 // (128-bit positions, 80-byte b3WorldTransform) carries its own values.
-#define WAVE_PILE_SLEEP_STEP 277
+#define WAVE_PILE_SLEEP_STEP 286
 #define QUERY_SPAWN_SLEEP_STEP 243
 #define QUERY_SPAWN_HIT_COUNT 59
 #define QUERY_SPAWN_QUERY_HASH 0xE583B246
-#define MESH_DROP_SLEEP_STEP 215
+#define MESH_DROP_SLEEP_STEP 210
 #if defined( BOX3D_LUDICROUS_MODE )
-#define WAVE_PILE_HASH 0xCD74B232
-#define QUERY_SPAWN_HASH 0x72EDD20C
-#define MESH_DROP_HASH 0xEE4D0F7A
+#define WAVE_PILE_HASH 0x180F40D3
+#define QUERY_SPAWN_HASH 0x7C6B3268
+#define MESH_DROP_HASH 0xABA23F15
 #else
-#define WAVE_PILE_HASH 0x33AFFF2D
-#define QUERY_SPAWN_HASH 0x17EC3891
-#define MESH_DROP_HASH 0x2045D332
+#define WAVE_PILE_HASH 0x9B108F93
+#define QUERY_SPAWN_HASH 0x49ECDEA8
+#define MESH_DROP_HASH 0x458A95E7
 #endif
 
 static int SingleMultithreadingTest( int workerCount )

--- a/tools/revendor-fixed.sh
+++ b/tools/revendor-fixed.sh
@@ -18,10 +18,10 @@
 set -euo pipefail
 
 FIXED_REPO="https://github.com/mas-bandwidth/fixed.git"
-# v1.3.2. Pinned as a SHA rather than the tag name on purpose: a tag can be moved,
+# v1.4.0. Pinned as a SHA rather than the tag name on purpose: a tag can be moved,
 # a commit cannot, and "vendored at v1.3.2" should mean one specific tree forever.
-FIXED_PIN="06128963b5e154d9abef6d0b207a87e64174801c"
-FIXED_VERSION="v1.3.2"
+FIXED_PIN="a0fa624d739790844af34499381c55abaa65180f"
+FIXED_VERSION="v1.4.0"
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DEST="$ROOT/extern/fixed"


### PR DESCRIPTION
Moves the vendored fixed pin from v1.3.2 (0612896) to v1.4.0 (a0fa624d7397), regenerated by tools/revendor-fixed.sh; NOTES.md pin line updated in the same commit. The vendor-drift check proves the tree matches the pin.

Second commit enacts the staged determinism re-derivation. Provenance: fixed v1.4.0 carries the lift-before-divide fixNormalize fix, done red-first as fixed#20 during the overnight fixed campaign, and its trajectory shift was RULED a baseline move at that time (normalize feeds contact normals and joint axes, so the result is a different but equally valid simulation). fixed#20 explicitly staged the fixed3d golden re-baseline for the pin bump; this PR is that pass.

Re-derivation record: goldens regenerated in both builds (standard and BOX3D_LUDICROUS_MODE), each from two clean generation runs that agree bit-for-bit, values identical across all worker counts (ragdoll 1-5 workers plus the cross-platform pass, wave pile 1-4, query spawn 1-4, mesh drop 1 and 4). Ragdoll sleepStep 287 -> 312, hash 0xC745DFFF standard / 0x5A1D71FF ludicrous. Wave pile 277 -> 286, query spawn sleep step unmoved at 243 (query hit count and query hash also unmoved), mesh drop 215 -> 210. Sleep steps stay shared between builds. CLAUDE.md's two current-golden sites updated to match.