### PR TITLE
Support line: link to Patreon membership

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,0 @@
-# These are supported funding model platforms
-
-patreon: MasBandwidth
-github: mas-bandwidth

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://github.com/mas-bandwidth/fixed3d/actions/workflows/build.yml/badge.svg)](https://github.com/mas-bandwidth/fixed3d/actions)
 
+If this work helps you, please support it: **[Become a supporter](https://www.patreon.com/MasBandwidth/membership)**
+
 ![They've gone to plaid.](docs/images/plaid.jpg)
 
 This fork exists to answer two questions:


### PR DESCRIPTION
One support line in the house position linking to https://www.patreon.com/MasBandwidth/membership. Existing support mentions converged on the same URL. Per-repo FUNDING.yml (where present) removed so the org-wide default in mas-bandwidth/.github governs the Sponsor button.