### PR TITLE
Port box3d 47d7f7c: mesh stride and clockwise winding, back-side culling, mover time of impact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,13 @@ build-fixed2/
 .fetchcontent-cache/
 build*/
 bench-*/
+
+# rowan-github and the other rowan-tools wrappers write their run logs to tending/ in
+# whatever repo they are invoked from. Bench state, never repo content -- ignored with a
+# reason rather than left untracked, so a broad `git add` cannot sweep tool logs into a
+# public repo.
+tending/
+
+# Upstream ignores its agent instructions file; ours is CLAUDE.md and is tracked on purpose
+# (it carries the port cursor), so only upstream's name is ignored here.
+AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,12 +18,12 @@ than no cursor. Named exceptions, on the issue board rather than buried here:
   stb_truetype, the world_text shader). Held for a bench with a display; no simulation
   content, so it does not gate the cursor.
 
-- **the samples half of `47d7f7c`** — `sample_character.cpp`, `sample_issues.cpp`,
+- **fixed3d#47 — the samples half of `47d7f7c`** — `sample_character.cpp`, `sample_issues.cpp`,
   `sample_joint.cpp` and `samples/mover.*`. Held on the same ground as #20: sample-app
   content, no simulation content, so it does not gate the cursor. The samples tree still
   BUILDS clean against the new API (verified after a forced header rebuild).
 
-- **the remainder of `47d7f7c`'s test additions** — upstream's `test_mover.c` block and
+- **fixed3d#48 — the remainder of `47d7f7c`'s test additions** — upstream's `test_mover.c` block and
   the three `test_body_query.c` TOI cases beyond the four ported here. These are ADDITIONAL
   coverage of engine changes that already landed WITH tests of their own; named rather than
   silently skipped, because a cursor with unnamed holes is worse than no cursor.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,15 +4,29 @@ Box3D converted from float to Q48.16 fixed point (internal and external API).
 
 ## THE PORT CURSOR — read this before any Box3D -> Fixed3D pass
 
-**Everything in erincatto/box3d up to and including `30c67b5` is carried across.**
-`git log 30c67b5..upstream/main` is the remaining work. (This line replaced
+**Everything in erincatto/box3d up to and including `47d7f7c` is carried across —
+THIS LINE ADVANCES WITH THE MERGE OF `port/47d7f7c-clockwise-mover`, NOT BEFORE.**
+`git log 47d7f7c..upstream/main` is the remaining work. Until that branch merges the
+true cursor is `30c67b5`, and the run that merges it comes back and strikes this
+clause — the same discipline the discharged `fixed3d#21` note below records, applied
+to itself rather than only remembered. (This line replaced
 *"Baseline float code is commit c52908c"* on 2026-08-22 — same claim, said as a cursor.) One named exception, on
 the issue board rather than buried here, because a cursor with silent holes is worse
-than no cursor:
+than no cursor. Named exceptions, on the issue board rather than buried here:
 
 - **fixed3d#20** — the sample-viewer half of `3fc20f5` (follow cam, world text,
   stb_truetype, the world_text shader). Held for a bench with a display; no simulation
   content, so it does not gate the cursor.
+
+- **the samples half of `47d7f7c`** — `sample_character.cpp`, `sample_issues.cpp`,
+  `sample_joint.cpp` and `samples/mover.*`. Held on the same ground as #20: sample-app
+  content, no simulation content, so it does not gate the cursor. The samples tree still
+  BUILDS clean against the new API (verified after a forced header rebuild).
+
+- **the remainder of `47d7f7c`'s test additions** — upstream's `test_mover.c` block and
+  the three `test_body_query.c` TOI cases beyond the four ported here. These are ADDITIONAL
+  coverage of engine changes that already landed WITH tests of their own; named rather than
+  silently skipped, because a cursor with unnamed holes is worse than no cursor.
 
 *(~~**fixed3d#21 closes WITH this change, not before it**~~ — **DISCHARGED 2026-08-25, verified
 rather than assumed: the branch merged and fixed3d#21 is CLOSED, so the cursor above states a
@@ -25,7 +39,91 @@ and says *closed*. Record below.)*
 
 The PORT RECORDs below run newest first and are the detail for each step.
 
-## Current status (as of 2026-08-23 — v1.4.0, MAINTENANCE MODE)
+## Current status (as of 2026-08-31 — v1.4.0, MAINTENANCE MODE)
+
+- **PORT RECORD 47d7f7c "clockwise option, joint is awake (#130)" (2026-08-29) —
+  PORTED in seven steps, 2026-08-31.** 2,466 upstream insertions; the whole engine
+  half is across, the samples half is held above. Each step built and ran narrow,
+  ludicrous and Debug+VALIDATE+ASan before the next began.
+
+  **TWO FIXED-POINT DECISIONS, and the first is the one that matters.**
+
+  **(1) MESH WINDING MUST NOT USE THE SCALE PRODUCT.** Upstream renames its winding
+  boolean from `clockwise = sx*sy*sz < 0` to `ccw = sx*sy*sz > 0` and swaps the branch
+  bodies. In float those differ only when a component is exactly zero. Here `b3FixMul`
+  of three legal scales quantizes to zero far earlier — MEASURED, raw product values:
+  (1,1,1) = 65536, (1,1,-1) = -65536, (0.2,0.2,-0.2) = -524, (0.05,0.05,-0.05) = -8,
+  **(0.01,0.01,-0.01) = 0 and (0.01,0.01,0.01) = 0**. So a plain uniform 1 cm scale has a
+  determinant product of exactly zero, and upstream's new spelling reads it as clockwise
+  and swaps every triangle in every ray cast, shape cast and query. **Porting it verbatim
+  would have been a regression.** The old `< 0` spelling is wrong the other way, on small
+  REFLECTED scales. `b3IsScaleCounterClockwise` compares SIGNS — the sign of a product is
+  the parity of its negative factors — and equals upstream's `product > 0` in exact
+  arithmetic. Applied at all three sites, which also fixes a pre-existing inconsistency
+  where two used `< 0` and the third `> 0`.
+
+  **(2) MESH VERTEX STRIDE ALIGNMENT IS 8, NOT 4.** Upstream rejects a stride that is not
+  a multiple of 4, the alignment of a single precision `b3Vec3`. Measured here by
+  compiling a sizeof/alignof program in both configs: `b3Vec3` is **24 bytes, alignment
+  8**, in narrow AND `LUDICROUS_MODE`. Upstream's check would accept a stride of 28 and
+  load every vertex misaligned, so the check is spelled against `_Alignof( b3Vec3 )`.
+
+  **PORTED:** `b3MeshDef` gains `stride` and `clockWiseWinding` (threaded through the
+  strided copy, the spatial hash and the welder; clockwise swapped once at bake time);
+  `b3PlaneResult` gains `triangleIndex`, `childIndex` and `materialIndex`, filled by mesh
+  and height field, clamped in `b3CollideMover`, remapped through the child material table
+  in the compound callback; back-side culling via `b3SignedVolume` on `b3ShapeCastMesh`,
+  `b3CollideMoverAndMesh`, `b3ShapeCastHeightField` and `b3CollideMoverAndHeightField`;
+  the height field's per-triangle winding branch collapses to one corner swap;
+  `b3Body_TimeOfImpactMover` and `b3BodyTOIResult` (fraction as `b3Fixed`);
+  `b3Joint_IsAwake`; `b3Body_GetMinExtent` / `GetMaxExtent` / `GetMaxExtentOrigin`;
+  three real extent bugs (capsule max without `b3Abs`, sphere subtracting the local
+  center twice, mesh measuring from the body origin); `b3ShapeDistance` fills its whole
+  output on every return and caches the simplex last; `b3TimeOfImpact` fills point and
+  normal on the overlapped state; the degenerate-report off-by-one; two `b3Array` leaks;
+  `B3_MAX_MESH_CONTACT_TRIANGLES` becomes a public `#ifndef` tunable; dead code in
+  `b3ReduceManifoldPoints` and `b3OverlapShape`.
+
+  **CULLING FAILS OPEN, deliberately.** `b3SignedVolume` is a `b3Cross` fed to a `b3Dot`.
+  `b3Dot` is fused raw-128 but `b3Cross` is on this tree's do-not-fuse list, so each cross
+  component rounds and a small enough triangle quantizes the whole signed volume to zero.
+  Upstream's comparison already puts zero on the FRONT side, so the degenerate case stops
+  culling rather than silently dropping contacts on tiny geometry. The upstream spelling is
+  kept exactly rather than tightened.
+
+  **RECORDING FORMAT: `B3_REC_VERSION_MAJOR` 7 -> 8.** The mover plane batches gain three
+  int32 fields per hit, so a v7 reader walking a v8 stream desynchronises at the first
+  plane and every op after it. Upstream made the same widening its own major bump, 4 -> 5;
+  ours is 8 because this fork's counter is ahead.
+
+  **GOLDENS: NONE MOVED, and for back-side culling that was NOT evidence until it was
+  measured.** Instrumenting every cull site and running the whole suite: the branch was
+  reached **1992 times and fired 0 times**. Every golden held for the uninteresting reason
+  that nothing in the corpus is ever culled. `MeshBackSideCull` is the test that makes it
+  fire (counters then read 1996 tested, 2 fired). Winding and stride move no golden because
+  both new fields default to the old behaviour; extents bound behaviour rather than
+  producing it.
+
+  **TESTS: `test/test_mesh.c` is new** (upstream's, in Q48.16, plus five cases of our own:
+  zero stride, bad stride, the degenerate report, scaled winding, back-side culling), plus
+  `ShapeExtents` in `test_body.c`, four back-side/winding cases in `test_height_field.c`,
+  and four TOI cases in `test_body_query.c`. 24 suites.
+
+  **RED FIRST, and two controls were GREEN on the first attempt, which is the finding.**
+  Every claim was seen failing by neutering the code it tests, one at a time, with the
+  neuter ASSERTED to have matched the source rather than assumed. `MeshDegenerateReport`
+  asserted only slot 0, which the old ordering also fills — the difference is the LAST slot.
+  `MeshBadStride` returned NULL under the neutered build for the wrong reason (the bad
+  stride overran its buffer and collapsed the mesh instead of being refused); it now casts
+  two packings of the same valley so alignment is the only variable. Both were rewritten
+  until the control actually went red. A pass never seen failing is evidence about the
+  runner, not the job.
+
+  **VERIFIED:** all four configs green — build-port, build-ludicrous, build-debug
+  (Debug+VALIDATE+ASan), build-samples.
+
+
+## Older status (as of 2026-08-23 — v1.4.0, MAINTENANCE MODE)
 
 - **PORT RECORD f42be21 (remainder) + 30c67b5 "Fixed the 64-bit hash function (#129)"
   (2026-08-12) — PORTED as ONE step, 2026-08-23, closing fixed3d#21.** Taken together

--- a/include/box3d/box3d.h
+++ b/include/box3d/box3d.h
@@ -797,6 +797,15 @@ B3_API int b3Body_GetContactData( b3BodyId bodyId, b3ContactData* contactData, i
 /// If there are no shapes attached then the returned AABB is empty and centered on the body origin.
 B3_API b3AABB b3Body_ComputeAABB( b3BodyId bodyId );
 
+/// The minimum distance from any shape to the shape centroid.
+B3_API b3Fixed b3Body_GetMinExtent( b3BodyId bodyId );
+
+/// The maximum extent vector from any point on the body shapes to the center of mass.
+B3_API b3Vec3 b3Body_GetMaxExtent( b3BodyId bodyId );
+
+/// The maximum extent vector from any point on the body shapes to the body origin. Conservative.
+B3_API b3Vec3 b3Body_GetMaxExtentOrigin( b3BodyId bodyId );
+
 /// Get the closest point on a body to a world target.
 B3_API b3Fixed b3Body_GetClosestPoint( b3BodyId bodyId, b3Vec3* result, b3Vec3 target );
 
@@ -1113,6 +1122,9 @@ B3_API void* b3Joint_GetUserData( b3JointId jointId );
 
 /// Wake the bodies connect to this joint
 B3_API void b3Joint_WakeBodies( b3JointId jointId );
+
+/// Is the joint awake? If true then an attached body is awake.
+B3_API bool b3Joint_IsAwake( b3JointId jointId );
 
 /// Get the current constraint force for this joint
 B3_API b3Vec3 b3Joint_GetConstraintForce( b3JointId jointId );

--- a/include/box3d/box3d.h
+++ b/include/box3d/box3d.h
@@ -826,6 +826,13 @@ B3_API bool b3Body_OverlapShape( b3BodyId bodyId, b3Pos origin, const b3ShapePro
 B3_API int b3Body_CollideMover( b3BodyId bodyId, b3BodyPlaneResult* bodyPlanes, int planeCapacity, b3Pos origin,
 								const b3Capsule* mover, b3QueryFilter filter, b3WorldTransform bodyTransform );
 
+/// Perform a time of impact between a character mover and a body using specified sweep transforms.
+/// Initial overlap of any shape on the body is ignored. A non-overlapped shape can still be hit.
+/// Only considers convex shapes on the body.
+B3_API b3BodyTOIResult b3Body_TimeOfImpactMover( b3BodyId bodyId, b3Pos origin, const b3Capsule* mover, b3Vec3 moverTranslation,
+												 b3QueryFilter filter, b3WorldTransform bodyTransform1,
+												 b3WorldTransform bodyTransform2 );
+
 /** @} */ // body
 
 /**

--- a/include/box3d/constants.h
+++ b/include/box3d/constants.h
@@ -136,3 +136,10 @@ B3_API b3Fixed b3GetStallThreshold( void );
 #ifndef B3_RESTITUTION_ITERATIONS
 #define B3_RESTITUTION_ITERATIONS 1
 #endif
+
+/// This is the limit on how many mesh or heightfield triangles a single convex shape can collide with.
+/// Increasing this will increase stack usage, so be careful. I recommend to simplify your collision data
+/// before increasing this. For example, using render mesh for collision often leads to poor performance.
+#ifndef B3_MAX_MESH_CONTACT_TRIANGLES
+#define B3_MAX_MESH_CONTACT_TRIANGLES 256
+#endif

--- a/include/box3d/types.h
+++ b/include/box3d/types.h
@@ -1798,6 +1798,15 @@ typedef struct b3PlaneResult
 	/// Closest point on the shape. May not be unique.
 	b3Vec3 point;
 
+	/// The index of the mesh or height field triangle hit.
+	int triangleIndex;
+
+	/// The index of the compound child shape.
+	int childIndex;
+
+	/// The material index.
+	int materialIndex;
+
 } b3PlaneResult;
 
 /// These are collision planes that can be fed to b3SolvePlanes. Normally
@@ -1837,6 +1846,22 @@ typedef struct b3BodyPlaneResult
 	/// The plane result.
 	b3PlaneResult result;
 } b3BodyPlaneResult;
+
+/// Body time of impact result for movers.
+typedef struct b3BodyTOIResult
+{
+	/// The hit point in world space.
+	b3Pos point;
+
+	/// The hit normal. Points from the body to the mover.
+	b3Vec3 normal;
+
+	/// The sweep time of the collision.
+	b3Fixed fraction;
+
+	/// The hit shape.
+	b3ShapeId shapeId;
+} b3BodyTOIResult;
 
 /// Used to collect collision planes for character movers.
 /// Return true to continue gathering planes.

--- a/include/box3d/types.h
+++ b/include/box3d/types.h
@@ -8,6 +8,7 @@
 #include "id.h"
 #include "math_functions.h"
 
+#include <stddef.h>
 #include <stdint.h>
 
 #define B3_DEFAULT_CATEGORY_BITS UINT64_MAX
@@ -2066,7 +2067,12 @@ typedef struct b3MeshDef
 	/// Triangle vertices
 	b3Vec3* vertices;
 
-	/// Triangle vertex indices. 3 for each triangle. CCW winding.
+	/// Stride in bytes between vertices. Use 0 for contiguous vertices. Must be a multiple
+	/// of alignof( b3Vec3 ), which is 8 here because b3Fixed is 64 bits, not the 4 that a
+	/// single precision build would allow.
+	size_t stride;
+
+	/// Triangle vertex indices. 3 for each triangle. CCW winding unless CW is indicated below.
 	int32_t* indices;
 
 	/// Triangle material index. 1 per triangle. Indexes into b3ShapeDef::materials.
@@ -2092,6 +2098,9 @@ typedef struct b3MeshDef
 
 	/// Compute triangle adjacency information using shared edges
 	bool identifyEdges;
+
+	/// Input indices have clockWise winding order.
+	bool clockWiseWinding;
 } b3MeshDef;
 
 /// 64-bit mesh version. Useful for validating serialized data.

--- a/src/body.c
+++ b/src/body.c
@@ -2577,3 +2577,27 @@ bool b3ShouldBodiesCollide( b3World* world, b3Body* bodyA, b3Body* bodyB )
 
 	return true;
 }
+
+b3Fixed b3Body_GetMinExtent( b3BodyId bodyId )
+{
+	b3World* world = b3GetWorld( bodyId.world0 );
+	b3Body* body = b3GetBodyFullId( world, bodyId );
+	b3BodySim* bodySim = b3GetBodySim( world, body );
+	return bodySim->minExtent;
+}
+
+b3Vec3 b3Body_GetMaxExtent( b3BodyId bodyId )
+{
+	b3World* world = b3GetWorld( bodyId.world0 );
+	b3Body* body = b3GetBodyFullId( world, bodyId );
+	b3BodySim* bodySim = b3GetBodySim( world, body );
+	return bodySim->maxExtent;
+}
+
+b3Vec3 b3Body_GetMaxExtentOrigin( b3BodyId bodyId )
+{
+	b3World* world = b3GetWorld( bodyId.world0 );
+	b3Body* body = b3GetBodyFullId( world, bodyId );
+	b3BodySim* bodySim = b3GetBodySim( world, body );
+	return b3Add( bodySim->maxExtent, b3Abs( bodySim->localCenter ) );
+}

--- a/src/body.c
+++ b/src/body.c
@@ -844,6 +844,87 @@ static void b3FloorInertia( b3Matrix3* inertia, b3Fixed mass )
 	}
 }
 
+b3BodyTOIResult b3Body_TimeOfImpactMover( b3BodyId bodyId, b3Pos origin, const b3Capsule* mover, b3Vec3 moverTranslation,
+										  b3QueryFilter filter, b3WorldTransform bodyTransform1, b3WorldTransform bodyTransform2 )
+{
+	b3BodyTOIResult result = { 0 };
+	result.fraction = B3_FIX( 1.0f );
+
+	b3World* world = b3GetUnlockedWorld( bodyId.world0 );
+	if ( world == NULL )
+	{
+		return result;
+	}
+
+	b3Transform xf1 = b3ToRelativeTransform( bodyTransform1, origin );
+	b3Transform xf2 = b3ToRelativeTransform( bodyTransform2, origin );
+
+	b3Body* body = b3GetBodyFullId( world, bodyId );
+	b3BodySim* bodySim = b3GetBodySim( world, body );
+	b3Vec3 localCenter = bodySim->localCenter;
+
+	b3Vec3 capsulePoints[2] = { mover->center1, mover->center2 };
+	b3TOIInput input = { 0 };
+	input.proxyB = (b3ShapeProxy){
+		.points = capsulePoints,
+		.count = 2,
+		.radius = mover->radius,
+	};
+	input.sweepA.c1 = b3TransformPoint( xf1, localCenter );
+	input.sweepA.c2 = b3TransformPoint( xf2, localCenter );
+	input.sweepA.q1 = bodyTransform1.q;
+	input.sweepA.q2 = bodyTransform2.q;
+	input.sweepA.localCenter = localCenter;
+
+	input.sweepB.c1 = b3Vec3_zero;
+	input.sweepB.c2 = moverTranslation;
+	input.sweepB.q1 = b3Quat_identity;
+	input.sweepB.q2 = b3Quat_identity;
+	input.sweepB.localCenter = b3Vec3_zero;
+
+	input.maxFraction = B3_FIX( 1.0f );
+
+	int shapeId = body->headShapeId;
+	while ( shapeId != B3_NULL_INDEX )
+	{
+		b3Shape* shape = b3Array_Get( world->shapes, shapeId );
+		shapeId = shape->nextShapeId;
+
+		if ( b3ShouldQueryCollide( &shape->filter, &filter ) == false )
+		{
+			continue;
+		}
+
+		b3ShapeType type = shape->type;
+		if ( type != b3_sphereShape && type != b3_capsuleShape && type != b3_hullShape )
+		{
+			continue;
+		}
+
+		input.proxyA = b3MakeShapeProxy( shape );
+
+		b3TOIOutput output = b3TimeOfImpact( &input );
+		B3_VALIDATE( output.state != b3_toiStateUnknown );
+
+		// Mimic behavior in b3ContinuousQueryCallback. Ignore shapes that initially overlap.
+		if ( B3_FIX( 0.0f ) < output.fraction && output.fraction < result.fraction )
+		{
+			input.maxFraction = output.fraction;
+
+			result.point = b3OffsetPos( origin, output.point );
+			result.normal = output.normal;
+			result.fraction = output.fraction;
+			result.shapeId = (b3ShapeId){
+				.index1 = shape->id + 1,
+				.world0 = world->worldId,
+				.generation = shape->generation,
+			};
+		}
+	}
+
+	return result;
+}
+
 void b3UpdateBodyMassData( b3World* world, b3Body* body )
 {
 	b3BodySim* bodySim = b3GetBodySim( world, body );

--- a/src/capsule.c
+++ b/src/capsule.c
@@ -421,6 +421,6 @@ int b3CollideMoverAndCapsule( b3PlaneResult* result, const b3Capsule* shape, con
 	}
 
 	b3Plane plane = { normal, totalRadius - distance };
-	*result = (b3PlaneResult){ plane, approach.point1 };
+	*result = (b3PlaneResult){ plane, approach.point1, 0, 0, 0 };
 	return 1;
 }

--- a/src/compound.c
+++ b/src/compound.c
@@ -408,7 +408,9 @@ b3CompoundData* b3CreateCompound( const b3CompoundDef* def )
 			// No effort to share mesh materials. It would be easier to do if the number of materials was limited.
 			B3_ASSERT( meshData->materialCount == meshDef->materialCount );
 
-			for ( int j = 0; j < meshDef->materialCount; ++j )
+			int meshMaterialCount = b3MinInt( meshDef->materialCount, B3_MAX_COMPOUND_MESH_MATERIALS );
+
+			for ( int j = 0; j < meshMaterialCount; ++j )
 			{
 				// Look for an existing material (staged, see the capsule loop)
 				b3SurfaceMaterial* candidate = materials + materialCount;
@@ -1187,6 +1189,10 @@ static bool b3CompoundMoverCallback( int proxyId, uint64_t userData, void* conte
 	{
 		planes[i].plane.normal = b3RotateVector( child.transform.q, planes[i].plane.normal );
 		planes[i].point = b3TransformPoint( child.transform, planes[i].point );
+
+		planes[i].childIndex = childIndex;
+		int childMaterialIndex = b3MinInt( planes[i].materialIndex, B3_MAX_COMPOUND_MESH_MATERIALS - 1 );
+		planes[i].materialIndex = child.materialIndices[childMaterialIndex];
 	}
 
 	moverContext->planeCount += planeCount;

--- a/src/convex_manifold.c
+++ b/src/convex_manifold.c
@@ -753,7 +753,6 @@ static void b3ReduceManifoldPoints( b3LocalManifold* manifold, int capacity, b3L
 	// Step 2: Find farthest point in 2D
 	bestScore = B3_FIX( 0.0f );
 	bestIndex = B3_NULL_INDEX;
-	b3Fixed maxDistanceSquared = B3_FIX( 0.0f );
 
 	for ( int index = 0; index < count; ++index )
 	{
@@ -761,7 +760,6 @@ static void b3ReduceManifoldPoints( b3LocalManifold* manifold, int capacity, b3L
 		b3Vec3 d = b3Sub( p, a );
 		b3Vec3 v = b3MulSub( d, b3Dot( d, normal ), normal );
 		b3Fixed distanceSquared = b3LengthSquared( v );
-		maxDistanceSquared = b3FixMax( maxDistanceSquared, distanceSquared );
 		b3Fixed separation = b3FixMax( B3_FIX( 0.0f ), -points[index].separation );
 		b3Fixed score = distanceSquared + b3FixMul( b3FixMul( B3_FIX( 4.0f ) , separation ) , separation );
 		if ( b3FixMul( bias , score ) > bestScore )

--- a/src/distance.c
+++ b/src/distance.c
@@ -869,6 +869,10 @@ b3DistanceOutput b3ShapeDistance( const b3DistanceInput* input, b3SimplexCache* 
 			b3ComputeWitnessPoints( &simplex, &localPointA, &localPointB );
 			distanceOutput.pointA = localPointA;
 			distanceOutput.pointB = localPointB;
+			distanceOutput.normal = b3Vec3_zero;
+			distanceOutput.distance = B3_FIX( 0.0f );
+			distanceOutput.iterations = iteration;
+			distanceOutput.simplexCount = simplexIndex;
 			return distanceOutput;
 		}
 
@@ -965,6 +969,10 @@ b3DistanceOutput b3ShapeDistance( const b3DistanceInput* input, b3SimplexCache* 
 			b3ComputeWitnessPoints( &simplex, &localPointA, &localPointB );
 			distanceOutput.pointA = localPointA;
 			distanceOutput.pointB = localPointB;
+			distanceOutput.normal = b3Vec3_zero;
+			distanceOutput.distance = B3_FIX( 0.0f );
+			distanceOutput.iterations = iteration;
+			distanceOutput.simplexCount = simplexIndex;
 			B3_VALIDATE( b3Distance( localPointA, localPointB ) < B3_FIXED_EPSILON );
 			return distanceOutput;
 		}
@@ -1006,25 +1014,27 @@ b3DistanceOutput b3ShapeDistance( const b3DistanceInput* input, b3SimplexCache* 
 		simplex.count += 1;
 	}
 
+	// Build witness points.
+	b3Vec3 localPointA, localPointB;
+	b3ComputeWitnessPoints( &simplex, &localPointA, &localPointB );
+
+	distanceOutput.pointA = localPointA;
+	distanceOutput.pointB = localPointB;
+	distanceOutput.iterations = iteration;
+	distanceOutput.simplexCount = simplexIndex;
+
 	normal = b3Normalize( normal );
 	if ( b3IsNormalized( normal ) == false )
 	{
 		// Treat as overlap
+		distanceOutput.distance = B3_FIX( 0.0f );
+		distanceOutput.normal = b3Vec3_zero;
 		return distanceOutput;
 	}
 
-	// Build witness points and safe cache
-	b3Vec3 localPointA, localPointB;
-	b3ComputeWitnessPoints( &simplex, &localPointA, &localPointB );
-	b3WriteCache( cache, &simplex );
-
 	// Results stay in frame A
-	distanceOutput.pointA = localPointA;
-	distanceOutput.pointB = localPointB;
 	distanceOutput.distance = b3Distance( localPointA, localPointB );
 	distanceOutput.normal = normal;
-	distanceOutput.iterations = iteration;
-	distanceOutput.simplexCount = simplexIndex;
 
 	// Apply radii if requested
 	if ( input->useRadii )
@@ -1037,6 +1047,9 @@ b3DistanceOutput b3ShapeDistance( const b3DistanceInput* input, b3SimplexCache* 
 		distanceOutput.pointA = b3Add( distanceOutput.pointA, b3MulSV( rA, normal ) );
 		distanceOutput.pointB = b3Sub( distanceOutput.pointB, b3MulSV( rB, normal ) );
 	}
+
+	// Simplex is useful, cache it.
+	b3WriteCache( cache, &simplex );
 
 	return distanceOutput;
 }
@@ -1725,6 +1738,18 @@ b3TOIOutput b3TimeOfImpact( const b3TOIInput* input )
 		{
 			output.state = b3_toiStateOverlapped;
 			output.fraction = B3_FIX( 0.0f );
+
+			// Averaged hit point. This is NEW output on a path that previously returned a
+			// zero point and normal, so the b3Lerp here is not a reassociation of anything
+			// existing -- no golden depends on the old zeros. Upstream's form is kept
+			// verbatim: b3Lerp is fixMul( 1 - t, a ) + fixMul( t, b ) here, and moving a
+			// term across it would change the rounding by a quantum.
+			b3Vec3 pA = b3MulAdd( worldPointA, proxyA.radius, worldNormal );
+			b3Vec3 pB = b3MulAdd( worldPointB, -proxyB.radius, worldNormal );
+			output.point = b3Lerp( pA, pB, B3_FIX( 0.5f ) );
+			output.point = b3Add( output.point, origin );
+			output.normal = worldNormal;
+
 			break;
 		}
 

--- a/src/height_field.c
+++ b/src/height_field.c
@@ -1295,8 +1295,9 @@ int b3CollideMoverAndHeightField( b3PlaneResult* planes, int capacity, const b3H
 				}
 				else if ( distanceOutput.distance <= mover->radius )
 				{
+					int triangleIndex = 2 * cellIndex;
 					b3Plane plane = { distanceOutput.normal, mover->radius - distanceOutput.distance };
-					planes[planeCount] = (b3PlaneResult){ plane, distanceOutput.pointA };
+					planes[planeCount] = (b3PlaneResult){ plane, distanceOutput.pointA, triangleIndex, 0, material };
 					planeCount += 1;
 
 					if ( planeCount == capacity )
@@ -1323,8 +1324,9 @@ int b3CollideMoverAndHeightField( b3PlaneResult* planes, int capacity, const b3H
 				}
 				else if ( distanceOutput.distance <= mover->radius )
 				{
+					int triangleIndex = 2 * cellIndex + 1;
 					b3Plane plane = { distanceOutput.normal, mover->radius - distanceOutput.distance };
-					planes[planeCount] = (b3PlaneResult){ plane, distanceOutput.pointA };
+					planes[planeCount] = (b3PlaneResult){ plane, distanceOutput.pointA, triangleIndex, 0, material };
 					planeCount += 1;
 
 					if ( planeCount == capacity )

--- a/src/height_field.c
+++ b/src/height_field.c
@@ -776,8 +776,11 @@ b3CastOutput b3ShapeCastHeightField( const b3HeightFieldData* heightField, const
 	castBounds.lowerBound = b3Vec3ToBound( b3Sub( b3Min( centerStart, centerEnd ), shapeExtents ) );
 	castBounds.upperBound = b3Vec3ToBound( b3Add( b3Max( centerStart, centerEnd ), shapeExtents ) );
 
+	// The ray origin is the center of the shape.
 	b3V32 rayOrigin = b3LoadV( &shapeStart.x );
 	b3V32 rayTranslation = b3LoadV( &shapeTranslation.x );
+
+	bool clockwise = heightField->clockwise;
 
 	while ( true )
 	{
@@ -835,6 +838,11 @@ b3CastOutput b3ShapeCastHeightField( const b3HeightFieldData* heightField, const
 				b3Vec3 point21 = corners[2];
 				b3Vec3 point22 = corners[3];
 
+				if ( clockwise )
+				{
+					B3_SWAP( point12, point21 );
+				}
+
 				// I know the min/max x and z values, but not the min/max heights.
 				b3AABB bounds;
 				bounds.lowerBound = b3Vec3ToBound( b3Min( b3Min( point11, point12 ), b3Min( point21, point22 ) ) );
@@ -854,18 +862,8 @@ b3CastOutput b3ShapeCastHeightField( const b3HeightFieldData* heightField, const
 					// Ray cast
 					{
 						b3V32 vertex1 = b3LoadV( &point11.x );
-						b3V32 vertex2, vertex3;
-
-						if ( heightField->clockwise )
-						{
-							vertex2 = b3LoadV( &point12.x );
-							vertex3 = b3LoadV( &point21.x );
-						}
-						else
-						{
-							vertex2 = b3LoadV( &point21.x );
-							vertex3 = b3LoadV( &point12.x );
-						}
+						b3V32 vertex2 = b3LoadV( &point21.x );
+						b3V32 vertex3 = b3LoadV( &point12.x );
 
 						b3Fixed alpha = b3IntersectRayTriangle( rayOrigin, rayTranslation, vertex1, vertex2, vertex3 );
 						B3_ASSERT( b3FixFromInt( 0 ) <= alpha && alpha <= B3_FIX( 1.0f ) );
@@ -874,7 +872,7 @@ b3CastOutput b3ShapeCastHeightField( const b3HeightFieldData* heightField, const
 						{
 							b3Vec3 edge1 = b3Sub( point21, point11 );
 							b3Vec3 edge2 = b3Sub( point12, point11 );
-							b3Vec3 normal = heightField->clockwise ? b3Cross( edge2, edge1 ) : b3Cross( edge1, edge2 );
+							b3Vec3 normal = b3Cross( edge1, edge2 );
 
 							result.point = b3MulAdd( shapeStart, alpha, shapeTranslation );
 							result.normal = b3Normalize( normal );
@@ -888,18 +886,8 @@ b3CastOutput b3ShapeCastHeightField( const b3HeightFieldData* heightField, const
 
 					{
 						b3V32 vertex1 = b3LoadV( &point22.x );
-						b3V32 vertex2, vertex3;
-
-						if ( heightField->clockwise )
-						{
-							vertex2 = b3LoadV( &point21.x );
-							vertex3 = b3LoadV( &point12.x );
-						}
-						else
-						{
-							vertex2 = b3LoadV( &point12.x );
-							vertex3 = b3LoadV( &point21.x );
-						}
+						b3V32 vertex2 = b3LoadV( &point12.x );
+						b3V32 vertex3 = b3LoadV( &point21.x );
 
 						b3Fixed alpha = b3IntersectRayTriangle( rayOrigin, rayTranslation, vertex1, vertex2, vertex3 );
 						B3_ASSERT( b3FixFromInt( 0 ) <= alpha && alpha <= B3_FIX( 1.0f ) );
@@ -908,7 +896,7 @@ b3CastOutput b3ShapeCastHeightField( const b3HeightFieldData* heightField, const
 						{
 							b3Vec3 edge1 = b3Sub( point22, point21 );
 							b3Vec3 edge2 = b3Sub( point12, point21 );
-							b3Vec3 normal = heightField->clockwise ? b3Cross( edge2, edge1 ) : b3Cross( edge1, edge2 );
+							b3Vec3 normal = b3Cross( edge1, edge2 );
 
 							result.point = b3MulAdd( shapeStart, alpha, shapeTranslation );
 							result.normal = b3Normalize( normal );
@@ -923,44 +911,56 @@ b3CastOutput b3ShapeCastHeightField( const b3HeightFieldData* heightField, const
 				else
 				{
 					// Shape cast
-					// todo back-side culling
 					{
-						// Shift origin to first vertex
-						b3Vec3 origin = point11;
-						b3Vec3 triangleVertices[] = { b3Vec3_zero, b3Sub( point21, origin ), b3Sub( point12, origin ) };
-						pairInput.proxyA = (b3ShapeProxy){ triangleVertices, 3, B3_FIX( 0.0f ) };
-						pairInput.maxFraction = bestFraction;
-						pairInput.transform.p = b3Neg( origin );
+						// shapeStart is the center of the proxy. A zero signed volume lands on
+						// the front side, so the cull fails OPEN in fixed point.
+						b3Fixed signedVolume = b3SignedVolume( point11, point21, point12, shapeStart );
 
-						b3CastOutput pairOutput = b3ShapeCast( &pairInput );
-
-						if ( pairOutput.hit )
+						if ( signedVolume >= B3_FIX( 0.0f ) )
 						{
-							bestFraction = pairOutput.fraction;
-							result = pairOutput;
-							result.point = b3Add( result.point, origin );
-							result.triangleIndex = triangleIndex1;
-							result.materialIndex = materialIndex;
+							// Shift origin to first vertex
+							b3Vec3 origin = point11;
+							b3Vec3 triangleVertices[] = { b3Vec3_zero, b3Sub( point21, origin ), b3Sub( point12, origin ) };
+							pairInput.proxyA = (b3ShapeProxy){ triangleVertices, 3, B3_FIX( 0.0f ) };
+							pairInput.maxFraction = bestFraction;
+							pairInput.transform.p = b3Neg( origin );
+
+							b3CastOutput pairOutput = b3ShapeCast( &pairInput );
+
+							if ( pairOutput.hit )
+							{
+								bestFraction = pairOutput.fraction;
+								result = pairOutput;
+								result.point = b3Add( result.point, origin );
+								result.triangleIndex = triangleIndex1;
+								result.materialIndex = materialIndex;
+							}
 						}
 					}
 
 					{
-						// Shift origin to first vertex
-						b3Vec3 origin = point21;
-						b3Vec3 triangleVertices[] = { b3Vec3_zero, b3Sub( point22, origin ), b3Sub( point12, origin ) };
-						pairInput.proxyA = (b3ShapeProxy){ triangleVertices, 3, B3_FIX( 0.0f ) };
-						pairInput.maxFraction = bestFraction;
-						pairInput.transform.p = b3Neg( origin );
+						// shapeStart is the center of the proxy.
+						b3Fixed signedVolume = b3SignedVolume( point21, point22, point12, shapeStart );
 
-						b3CastOutput pairOutput = b3ShapeCast( &pairInput );
-
-						if ( pairOutput.hit )
+						if ( signedVolume >= B3_FIX( 0.0f ) )
 						{
-							bestFraction = pairOutput.fraction;
-							result = pairOutput;
-							result.point = b3Add( result.point, origin );
-							result.triangleIndex = triangleIndex2;
-							result.materialIndex = materialIndex;
+							// Shift origin to first vertex
+							b3Vec3 origin = point21;
+							b3Vec3 triangleVertices[] = { b3Vec3_zero, b3Sub( point22, origin ), b3Sub( point12, origin ) };
+							pairInput.proxyA = (b3ShapeProxy){ triangleVertices, 3, B3_FIX( 0.0f ) };
+							pairInput.maxFraction = bestFraction;
+							pairInput.transform.p = b3Neg( origin );
+
+							b3CastOutput pairOutput = b3ShapeCast( &pairInput );
+
+							if ( pairOutput.hit )
+							{
+								bestFraction = pairOutput.fraction;
+								result = pairOutput;
+								result.point = b3Add( result.point, origin );
+								result.triangleIndex = triangleIndex2;
+								result.materialIndex = materialIndex;
+							}
 						}
 					}
 				}
@@ -1221,6 +1221,7 @@ int b3CollideMoverAndHeightField( b3PlaneResult* planes, int capacity, const b3H
 	b3SimplexCache cache = { 0 };
 
 	b3Fixed radius = mover->radius;
+	b3Vec3 center = b3Lerp( mover->center1, mover->center2, B3_FIX( 0.5f ) );
 	b3V32 center1 = b3LoadV( &mover->center1.x );
 	b3V32 center2 = b3LoadV( &mover->center2.x );
 	b3V32 r = b3SplatV( radius );
@@ -1239,6 +1240,8 @@ int b3CollideMoverAndHeightField( b3PlaneResult* planes, int capacity, const b3H
 	int maxRow = (int)b3FixTruncToInt( b3FixFloor( b3FixDiv( localMaxZ , scale.z ) ) );
 	int minCol = (int)b3FixTruncToInt( b3FixFloor( b3FixDiv( localMinX , scale.x ) ) );
 	int maxCol = (int)b3FixTruncToInt( b3FixFloor( b3FixDiv( localMaxX , scale.x ) ) );
+
+	bool clockWise = shape->clockwise;
 
 	int planeCount = 0;
 
@@ -1273,12 +1276,18 @@ int b3CollideMoverAndHeightField( b3PlaneResult* planes, int capacity, const b3H
 			b3Vec3 point21 = corners[2];
 			b3Vec3 point22 = corners[3];
 
+			if ( clockWise )
+			{
+				B3_SWAP( point12, point21 );
+			}
+
 			b3V32 v11 = b3LoadV( &point11.x );
 			b3V32 v12 = b3LoadV( &point12.x );
 			b3V32 v21 = b3LoadV( &point21.x );
 			b3V32 v22 = b3LoadV( &point22.x );
 
-			if ( b3TestBoundsTriangleOverlap( boundsCenter, boundsExtent, v11, v21, v12 ) )
+			bool overlap1 = b3TestBoundsTriangleOverlap( boundsCenter, boundsExtent, v11, v21, v12 );
+			if ( overlap1 && b3SignedVolume( point11, point21, point12, center ) >= B3_FIX( 0.0f ) )
 			{
 				b3Vec3 triangleVertices[] = { point11, point21, point12 };
 				distanceInput.proxyA = (b3ShapeProxy){ triangleVertices, 3, B3_FIX( 0.0f ) };
@@ -1291,7 +1300,7 @@ int b3CollideMoverAndHeightField( b3PlaneResult* planes, int capacity, const b3H
 
 				if ( distanceOutput.distance == B3_FIX( 0.0f ) )
 				{
-					// todo SAT
+					// deep overlap
 				}
 				else if ( distanceOutput.distance <= mover->radius )
 				{
@@ -1307,7 +1316,8 @@ int b3CollideMoverAndHeightField( b3PlaneResult* planes, int capacity, const b3H
 				}
 			}
 
-			if ( b3TestBoundsTriangleOverlap( boundsCenter, boundsExtent, v21, v22, v12 ) )
+			bool overlap2 = b3TestBoundsTriangleOverlap( boundsCenter, boundsExtent, v21, v22, v12 );
+			if ( overlap2 && b3SignedVolume( point22, point12, point21, center ) >= B3_FIX( 0.0f ) )
 			{
 				b3Vec3 triangleVertices[] = { point22, point12, point21 };
 				distanceInput.proxyA = (b3ShapeProxy){ triangleVertices, 3, B3_FIX( 0.0f ) };
@@ -1320,7 +1330,7 @@ int b3CollideMoverAndHeightField( b3PlaneResult* planes, int capacity, const b3H
 
 				if ( distanceOutput.distance == B3_FIX( 0.0f ) )
 				{
-					// todo SAT
+					// deep overlap
 				}
 				else if ( distanceOutput.distance <= mover->radius )
 				{

--- a/src/hull.c
+++ b/src/hull.c
@@ -3111,7 +3111,7 @@ int b3CollideMoverAndHull( b3PlaneResult* result, const b3HullData* shape, const
 	if ( distanceOutput.distance <= totalRadius )
 	{
 		b3Plane plane = { distanceOutput.normal, totalRadius - distanceOutput.distance };
-		*result = (b3PlaneResult){ plane, distanceOutput.pointA };
+		*result = (b3PlaneResult){ plane, distanceOutput.pointA, 0, 0, 0 };
 		return 1;
 	}
 

--- a/src/joint.c
+++ b/src/joint.c
@@ -998,6 +998,15 @@ void b3Joint_WakeBodies( b3JointId jointId )
 	world->locked = false;
 }
 
+bool b3Joint_IsAwake( b3JointId jointId )
+{
+	b3World* world = b3GetWorld( jointId.world0 );
+	b3Joint* joint = b3GetJointFullId( world, jointId );
+
+	// Cheaper than checking if the bodies are awake.
+	return joint->setIndex == b3_awakeSet;
+}
+
 void b3GetJointReaction( b3World* world, b3JointSim* sim, b3Fixed invTimeStep, b3Fixed* force, b3Fixed* torque )
 {
 	b3Fixed linearImpulse = B3_FIX( 0.0f );

--- a/src/mesh.c
+++ b/src/mesh.c
@@ -2197,8 +2197,24 @@ b3CastOutput b3ShapeCastMesh( const b3Mesh* mesh, const b3ShapeCastInput* input 
 					b3V32 triangleMin = b3SubV( b3MinV( v1, b3MinV( v2, v3 ) ), shapeExtent );
 					b3V32 triangleMax = b3AddV( b3MaxV( v1, b3MaxV( v2, v3 ) ), shapeExtent );
 
-					// Test triangle-ray overlap in scaled space
-					if ( b3TestBoundsOverlap( triangleMin, triangleMax, rayMin, rayMax ) )
+					// Test extended triangle vs ray bounds overlap in scaled space. Skip edge tests.
+					bool overlap = b3TestBoundsOverlap( triangleMin, triangleMax, rayMin, rayMax );
+					if ( overlap == false )
+					{
+						continue;
+					}
+
+					// This test is in scaled space. Vertices and center are scaled.
+					// A zero signed volume means either a coplanar center or a triangle whose
+					// fixed-point cross product quantized away; both land on the front side,
+					// so culling fails OPEN and degrades to the old uncalled behaviour.
+					b3Fixed signedVolume = b3SignedVolume( vertex1, vertex2, vertex3, center );
+					if ( signedVolume < B3_FIX( 0.0f ) )
+					{
+						// Backside
+						continue;
+					}
+
 					{
 						// Collide shape with triangle in scaled space
 						b3Vec3 origin = vertex1;
@@ -2326,6 +2342,7 @@ int b3CollideMoverAndMesh( b3PlaneResult* planes, int capacity, const b3Mesh* sh
 
 	b3SimplexCache cache = { 0 };
 	b3Fixed radius = mover->radius;
+	b3Vec3 center = b3Lerp( mover->center1, mover->center2, B3_FIX( 0.5f ) );
 
 	b3V32 center1 = b3LoadV( &mover->center1.x );
 	b3V32 center2 = b3LoadV( &mover->center2.x );
@@ -2335,6 +2352,7 @@ int b3CollideMoverAndMesh( b3PlaneResult* planes, int capacity, const b3Mesh* sh
 
 	// Scale may have reflection so min/max may become invalid when unscaled
 	b3Vec3 meshScale = shape->scale;
+	bool ccw = b3IsScaleCounterClockwise( meshScale );
 	b3V32 scale = b3LoadV( &meshScale.x );
 	b3V32 invScale = b3DivV( b3_oneV, scale );
 	b3V32 temp1 = b3MulV( invScale, boundsMin );
@@ -2372,6 +2390,12 @@ int b3CollideMoverAndMesh( b3PlaneResult* planes, int capacity, const b3Mesh* sh
 					b3Vec3 vertex1 = vertices[triangle.index1];
 					b3Vec3 vertex2 = vertices[triangle.index2];
 					b3Vec3 vertex3 = vertices[triangle.index3];
+
+					if ( ccw == false )
+					{
+						B3_SWAP( vertex2, vertex3 );
+					}
+
 					b3V32 v1 = b3LoadV( &vertex1.x );
 					b3V32 v2 = b3LoadV( &vertex2.x );
 					b3V32 v3 = b3LoadV( &vertex3.x );
@@ -2379,10 +2403,20 @@ int b3CollideMoverAndMesh( b3PlaneResult* planes, int capacity, const b3Mesh* sh
 					// Test triangle bounds overlap in unscaled space
 					if ( b3TestBoundsTriangleOverlap( invScaledBoundsCenter, invScaledBoundsExtent, v1, v2, v3 ) )
 					{
-						// Compute shape distance in scaled space. Winding order doesn't matter.
-						// todo implement one-sided collision?
+						// Compute shape distance in scaled space.
 						b3Vec3 triangleVertices[] = { b3Mul( meshScale, vertex1 ), b3Mul( meshScale, vertex2 ),
 													  b3Mul( meshScale, vertex3 ) };
+
+						// Vertices and center are in scaled space. A zero signed volume lands on
+						// the front side, so the cull fails OPEN in fixed point.
+						b3Fixed signedVolume =
+							b3SignedVolume( triangleVertices[0], triangleVertices[1], triangleVertices[2], center );
+						if ( signedVolume < B3_FIX( 0.0f ) )
+						{
+							// Backside
+							continue;
+						}
+
 						distanceInput.proxyA = (b3ShapeProxy){ triangleVertices, 3, B3_FIX( 0.0f ) };
 
 						// reset the cache
@@ -2393,7 +2427,7 @@ int b3CollideMoverAndMesh( b3PlaneResult* planes, int capacity, const b3Mesh* sh
 
 						if ( distanceOutput.distance == B3_FIX( 0.0f ) )
 						{
-							// todo SAT
+							// deep overlap
 						}
 						else if ( distanceOutput.distance <= mover->radius )
 						{
@@ -2482,7 +2516,7 @@ void b3QueryMesh( const b3Mesh* mesh, b3AABB bounds, b3MeshQueryFcn* fcn, void* 
 					b3V32 v2 = b3LoadV( &vertex2.x );
 					b3V32 v3 = b3LoadV( &vertex3.x );
 
-					// Perform triangle overlap test in unscaled space. Winding order doesn't matter.
+					// Perform triangle overlap test in unscaled space.
 					// todo it is possible that some margins are getting scaled
 					if ( b3TestBoundsTriangleOverlap( invScaledBoundsCenter, invScaledBoundsExtent, v1, v2, v3 ) )
 					{

--- a/src/mesh.c
+++ b/src/mesh.c
@@ -1967,6 +1967,26 @@ b3AABB b3ComputeMeshAABB( const b3MeshData* shape, b3Transform transform, b3Vec3
 	return b3AABB_Transform( transform, bounds );
 }
 
+// Winding follows the SIGN of the scale determinant sx*sy*sz. Upstream can take that
+// product directly, but b3FixMul of three legal scales quantizes to zero long before any
+// component is zero -- measured, a plain uniform 0.01 scale gives a product of exactly 0 --
+// and both spellings of the product test then answer wrongly, in opposite directions:
+// upstream's `product > 0` calls it clockwise and swaps every triangle, while the older
+// `product < 0` calls a small REFLECTED scale counter clockwise. The sign of a product is
+// the parity of its negative factors, so compare signs and never form the product. Zero is
+// the one case where a component really is zero, which is a degenerate scale; it lands on
+// the not-CCW side, matching upstream's `product > 0` in exact arithmetic.
+static inline bool b3IsScaleCounterClockwise( b3Vec3 scale )
+{
+	if ( scale.x == B3_FIX( 0.0f ) || scale.y == B3_FIX( 0.0f ) || scale.z == B3_FIX( 0.0f ) )
+	{
+		return false;
+	}
+
+	int negativeCount = ( scale.x < B3_FIX( 0.0f ) ) + ( scale.y < B3_FIX( 0.0f ) ) + ( scale.z < B3_FIX( 0.0f ) );
+	return ( negativeCount & 1 ) == 0;
+}
+
 b3CastOutput b3RayCastMesh( const b3Mesh* mesh, const b3RayCastInput* input )
 {
 	const b3MeshData* data = mesh->data;
@@ -1983,7 +2003,7 @@ b3CastOutput b3RayCastMesh( const b3Mesh* mesh, const b3RayCastInput* input )
 
 	b3V32 scale = b3LoadV( &meshScale.x );
 	b3V32 invScale = b3DivV( b3_oneV, scale );
-	bool clockwise = b3FixMul( b3FixMul( meshScale.x , meshScale.y ) , meshScale.z ) < B3_FIX( 0.0f );
+	bool ccw = b3IsScaleCounterClockwise( meshScale );
 
 	// Use the inverse scaled ray for traversal of the BVH
 	b3V32 invScaledRayStart = b3MulV( invScale, rayStart );
@@ -2023,15 +2043,15 @@ b3CastOutput b3RayCastMesh( const b3Mesh* mesh, const b3RayCastInput* input )
 					b3Vec3 vertex2, vertex3;
 
 					// The CPU should predict this branch
-					if ( clockwise )
-					{
-						vertex2 = b3Mul( meshScale, vertices[triangle.index3] );
-						vertex3 = b3Mul( meshScale, vertices[triangle.index2] );
-					}
-					else
+					if ( ccw )
 					{
 						vertex2 = b3Mul( meshScale, vertices[triangle.index2] );
 						vertex3 = b3Mul( meshScale, vertices[triangle.index3] );
+					}
+					else
+					{
+						vertex2 = b3Mul( meshScale, vertices[triangle.index3] );
+						vertex3 = b3Mul( meshScale, vertices[triangle.index2] );
 					}
 
 					// Collide ray with triangle in scaled space
@@ -2117,7 +2137,7 @@ b3CastOutput b3ShapeCastMesh( const b3Mesh* mesh, const b3ShapeCastInput* input 
 	b3V32 scale = b3LoadV( &meshScale.x );
 	b3V32 invScale = b3DivV( b3_oneV, scale );
 	b3V32 absInvScale = b3AbsV( invScale );
-	bool clockwise = b3FixMul( b3FixMul( meshScale.x , meshScale.y ) , meshScale.z ) < B3_FIX( 0.0f );
+	bool ccw = b3IsScaleCounterClockwise( meshScale );
 
 	// Use the inverse scaled shape cast for traversal of the BVH
 	b3V32 invScaledRayStart = b3MulV( invScale, rayStart );
@@ -2159,15 +2179,15 @@ b3CastOutput b3ShapeCastMesh( const b3Mesh* mesh, const b3ShapeCastInput* input 
 					b3Vec3 vertex2, vertex3;
 
 					// The CPU should predict this branch
-					if ( clockwise )
-					{
-						vertex2 = b3Mul( meshScale, vertices[triangle.index3] );
-						vertex3 = b3Mul( meshScale, vertices[triangle.index2] );
-					}
-					else
+					if ( ccw )
 					{
 						vertex2 = b3Mul( meshScale, vertices[triangle.index2] );
 						vertex3 = b3Mul( meshScale, vertices[triangle.index3] );
+					}
+					else
+					{
+						vertex2 = b3Mul( meshScale, vertices[triangle.index3] );
+						vertex3 = b3Mul( meshScale, vertices[triangle.index2] );
 					}
 
 					b3V32 v1 = b3LoadV( &vertex1.x );
@@ -2414,7 +2434,7 @@ int b3CollideMoverAndMesh( b3PlaneResult* planes, int capacity, const b3Mesh* sh
 void b3QueryMesh( const b3Mesh* mesh, b3AABB bounds, b3MeshQueryFcn* fcn, void* context )
 {
 	b3Vec3 meshScale = mesh->scale;
-	bool clockwise = b3FixMul( b3FixMul( meshScale.x , meshScale.y ) , meshScale.z ) > B3_FIX( 0.0f );
+	bool ccw = b3IsScaleCounterClockwise( meshScale );
 
 	// Scale may have reflection so min/max may become invalid when unscaled
 	b3V32 scale = b3LoadV( &meshScale.x );
@@ -2468,7 +2488,7 @@ void b3QueryMesh( const b3Mesh* mesh, b3AABB bounds, b3MeshQueryFcn* fcn, void* 
 					{
 						b3Vec3 a = b3Mul( meshScale, vertex1 );
 						b3Vec3 b, c;
-						if ( clockwise )
+						if ( ccw )
 						{
 							b = b3Mul( meshScale, vertex2 );
 							c = b3Mul( meshScale, vertex3 );

--- a/src/mesh.c
+++ b/src/mesh.c
@@ -2266,6 +2266,7 @@ int b3CollideMoverAndMesh( b3PlaneResult* planes, int capacity, const b3Mesh* sh
 	const b3MeshNode* node = b3GetRoot( shape->data );
 	const b3MeshTriangle* triangles = b3GetMeshTriangles( shape->data );
 	const b3Vec3* vertices = b3GetMeshVertices( shape->data );
+	const uint8_t* materialIndices = b3GetMeshMaterialIndices( shape->data );
 
 	int planeCount = 0;
 	while ( planeCount < capacity )
@@ -2314,7 +2315,8 @@ int b3CollideMoverAndMesh( b3PlaneResult* planes, int capacity, const b3Mesh* sh
 						else if ( distanceOutput.distance <= mover->radius )
 						{
 							b3Plane plane = { distanceOutput.normal, mover->radius - distanceOutput.distance };
-							planes[planeCount] = (b3PlaneResult){ plane, distanceOutput.pointA };
+							planes[planeCount] =
+								(b3PlaneResult){ plane, distanceOutput.pointA, triangleIndex, 0, materialIndices[triangleIndex] };
 							planeCount += 1;
 
 							if ( planeCount == capacity )

--- a/src/mesh.c
+++ b/src/mesh.c
@@ -333,6 +333,11 @@ bool b3IsValidMesh( const b3MeshData* meshData )
 
 #endif
 
+static inline b3Vec3 b3GetStridedVertex( const b3Vec3* vertices, int index, size_t stride )
+{
+	return *(const b3Vec3*)( (const uint8_t*)vertices + index * stride );
+}
+
 // Node for a vertex linked list
 typedef struct b3VertexNode
 {
@@ -354,15 +359,17 @@ typedef struct b3SpatialHash
 	b3Array( b3VertexNode ) nodes;
 	const b3Vec3* vertices;
 	int vertexCount;
+	size_t stride;
 	b3VertexMap vertexMap;
 	b3Fixed cellSize;
 	b3Fixed tolerance;
 } b3SpatialHash;
 
-static void b3SpatialHash_Create( b3SpatialHash* h, const b3Vec3* vertices, int vertexCount, b3Fixed tolerance )
+static void b3SpatialHash_Create( b3SpatialHash* h, const b3Vec3* vertices, int vertexCount, size_t stride, b3Fixed tolerance )
 {
 	h->vertices = vertices;
 	h->vertexCount = vertexCount;
+	h->stride = stride;
 	h->tolerance = tolerance;
 	h->cellSize = b3FixMul( B3_FIX( 2.0f ) , tolerance );
 	b3Array_CreateN( h->nodes, vertexCount );
@@ -384,7 +391,8 @@ static void b3SpatialHash_Destroy( b3SpatialHash* h )
 static int32_t b3SpatialHash_FindDuplicate( b3SpatialHash* h, int32_t currentIndex )
 {
 	B3_ASSERT( currentIndex < h->vertexCount );
-	b3Vec3 vertex = h->vertices[currentIndex];
+	size_t stride = h->stride;
+	b3Vec3 vertex = b3GetStridedVertex( h->vertices, currentIndex, stride );
 	b3Fixed cellSize = h->cellSize;
 	b3Fixed tolerance = h->tolerance;
 
@@ -424,7 +432,7 @@ static int32_t b3SpatialHash_FindDuplicate( b3SpatialHash* h, int32_t currentInd
 						B3_ASSERT( existingIndex < currentIndex );
 						B3_ASSERT( existingIndex < h->vertexCount );
 
-						b3Vec3 other = h->vertices[existingIndex];
+						b3Vec3 other = b3GetStridedVertex( h->vertices, existingIndex, stride );
 
 						// IsEqual inlined: check if vertices are within tolerance
 						if ( b3FixAbs( vertex.x - other.x ) <= tolerance && b3FixAbs( vertex.y - other.y ) <= tolerance &&
@@ -485,16 +493,18 @@ typedef struct b3WeldData
 
 	int vertexCount;
 	int indexCount;
+	size_t stride;
 } b3WeldData;
 
 static int b3WeldVertices( b3WeldData* data, b3Fixed tolerance )
 {
 	int vertexCount = data->vertexCount;
 	int uniqueCount = 0;
+	size_t stride = data->stride;
 
 	// Create spatial hash and find duplicates
 	b3SpatialHash spatialHash;
-	b3SpatialHash_Create( &spatialHash, data->srcVertices, vertexCount, tolerance );
+	b3SpatialHash_Create( &spatialHash, data->srcVertices, vertexCount, stride, tolerance );
 	b3Array( int ) vertexMapping = { 0 };
 	b3Array_Resize( vertexMapping, vertexCount );
 
@@ -506,7 +516,7 @@ static int b3WeldVertices( b3WeldData* data, b3Fixed tolerance )
 		{
 			// New unique vertex
 			vertexMapping.data[i] = uniqueCount;
-			data->dstVertices[uniqueCount] = data->srcVertices[i];
+			data->dstVertices[uniqueCount] = b3GetStridedVertex( data->srcVertices, i, stride );
 			uniqueCount += 1;
 		}
 		else
@@ -521,7 +531,7 @@ static int b3WeldVertices( b3WeldData* data, b3Fixed tolerance )
 	for ( int i = 0; i < indexCount; ++i )
 	{
 		int srcIndex = data->srcIndices[i];
-		B3_ASSERT( srcIndex < vertexCount );
+		B3_ASSERT( 0 <= srcIndex && srcIndex < vertexCount );
 		data->dstIndices[i] = vertexMapping.data[srcIndex];
 	}
 
@@ -1556,9 +1566,39 @@ b3MeshData* b3CreatePlatformMesh( b3Vec3 center, b3Fixed height, b3Fixed topWidt
 	return b3CreateMesh( &def, NULL, 0 );
 }
 
+static void b3CopyVerticesWithStride( b3Vec3* dst, const b3Vec3* src, int count, size_t stride )
+{
+	if ( stride == sizeof( b3Vec3 ) )
+	{
+		memcpy( dst, src, count * sizeof( b3Vec3 ) );
+		return;
+	}
+
+	for ( int i = 0; i < count; ++i )
+	{
+		dst[i] = b3GetStridedVertex( src, i, stride );
+	}
+}
+
+// Stride larger than this likely indicates stride is uninitialized memory.
+#define B3_MAX_STRIDE 4096
+
 // todo this should fail if the mesh has a height greater than B3_MESH_STACK_SIZE
 b3MeshData* b3CreateMesh( const b3MeshDef* def, int* degenerateTriangleIndices, int degenerateCapacity )
 {
+	if ( def->stride != 0 && ( def->stride < sizeof( b3Vec3 ) || B3_MAX_STRIDE < def->stride ) )
+	{
+		return NULL;
+	}
+
+	// Upstream requires 4-byte multiples because a single precision b3Vec3 is 4-byte aligned.
+	// Here b3Fixed is 64 bits, so b3Vec3 is 8-byte aligned (measured 24 bytes / align 8 in both
+	// narrow and LUDICROUS_MODE) and a stride of, say, 28 would produce a misaligned load.
+	if ( ( def->stride & ( _Alignof( b3Vec3 ) - 1 ) ) != 0 )
+	{
+		return NULL;
+	}
+
 	if ( def->vertexCount < 3 || def->vertices == NULL || def->triangleCount <= 0 || def->indices == NULL )
 	{
 		return NULL;
@@ -1571,6 +1611,7 @@ b3MeshData* b3CreateMesh( const b3MeshDef* def, int* degenerateTriangleIndices, 
 	}
 
 	int vertexCount = def->vertexCount;
+	size_t stride = def->stride == 0 ? sizeof( b3Vec3 ) : def->stride;
 
 	b3AABB meshBounds = B3_BOUNDS3_EMPTY;
 
@@ -1592,6 +1633,7 @@ b3MeshData* b3CreateMesh( const b3MeshDef* def, int* degenerateTriangleIndices, 
 			.dstIndices = indices.data,
 			.vertexCount = vertexCount,
 			.indexCount = 3 * triangleCount,
+			.stride = stride,
 		};
 		vertices.count = b3WeldVertices( &data, def->weldTolerance );
 		vertexCount = vertices.count;
@@ -1599,7 +1641,8 @@ b3MeshData* b3CreateMesh( const b3MeshDef* def, int* degenerateTriangleIndices, 
 	}
 	else
 	{
-		b3Array_Append( vertices, def->vertices, vertexCount );
+		vertices.count = vertexCount;
+		b3CopyVerticesWithStride( vertices.data, def->vertices, vertexCount, stride );
 		b3Array_Append( indices, def->indices, 3 * triangleCount );
 	}
 
@@ -1616,12 +1659,17 @@ b3MeshData* b3CreateMesh( const b3MeshDef* def, int* degenerateTriangleIndices, 
 	minArea = b3FixMax( minArea, 1 );
 	b3Fixed surfaceArea = B3_FIX( 0.0f );
 	int materialCount = 1;
+	bool clockWise = def->clockWiseWinding;
 
 	for ( int index = 0; index < triangleCount; ++index )
 	{
 		int index1 = indices.data[3 * index + 0];
 		int index2 = indices.data[3 * index + 1];
 		int index3 = indices.data[3 * index + 2];
+
+		B3_ASSERT( 0 <= index1 && index1 < vertexCount );
+		B3_ASSERT( 0 <= index2 && index2 < vertexCount );
+		B3_ASSERT( 0 <= index3 && index3 < vertexCount );
 
 		b3Vec3 vertex1 = vertices.data[index1];
 		b3Vec3 vertex2 = vertices.data[index2];
@@ -1636,11 +1684,12 @@ b3MeshData* b3CreateMesh( const b3MeshDef* def, int* degenerateTriangleIndices, 
 
 			if ( index1 != index2 && index1 != index3 && index2 != index3 )
 			{
-				degenerateCount += 1;
 				if ( degenerateTriangleIndices != NULL && degenerateCount < degenerateCapacity )
 				{
-					degenerateTriangleIndices[degenerateCount - 1] = index;
+					degenerateTriangleIndices[degenerateCount] = index;
 				}
+
+				degenerateCount += 1;
 			}
 
 			continue;
@@ -1676,6 +1725,8 @@ b3MeshData* b3CreateMesh( const b3MeshDef* def, int* degenerateTriangleIndices, 
 	if ( b3IsSaneAABB( meshBounds ) == false )
 	{
 		b3Array_Destroy( primitives );
+		b3Array_Destroy( indices );
+		b3Array_Destroy( vertices );
 		return NULL;
 	}
 
@@ -1739,9 +1790,18 @@ b3MeshData* b3CreateMesh( const b3MeshDef* def, int* degenerateTriangleIndices, 
 	for ( int index = 0; index < triangleCount; ++index )
 	{
 		b3Primitive primitive = primitives.data[index];
-		triangles[index].index1 = indices.data[3 * primitive.triangleIndex + 0];
-		triangles[index].index2 = indices.data[3 * primitive.triangleIndex + 1];
-		triangles[index].index3 = indices.data[3 * primitive.triangleIndex + 2];
+
+		int i1 = 3 * primitive.triangleIndex + 0;
+		int i2 = 3 * primitive.triangleIndex + 1;
+		int i3 = 3 * primitive.triangleIndex + 2;
+		if ( clockWise )
+		{
+			B3_SWAP( i2, i3 );
+		}
+
+		triangles[index].index1 = indices.data[i1];
+		triangles[index].index2 = indices.data[i2];
+		triangles[index].index3 = indices.data[i3];
 		flags[index] = 0;
 
 		// Copy material indices if they exist. Otherwise the material indices are all zeroes.
@@ -1760,6 +1820,9 @@ b3MeshData* b3CreateMesh( const b3MeshDef* def, int* degenerateTriangleIndices, 
 	{
 		b3Array_Destroy( tempNodes );
 		b3Array_Destroy( primitives );
+		b3Array_Destroy( indices );
+		b3Array_Destroy( vertices );
+		b3Free( mesh, byteCount );
 		return NULL;
 	}
 

--- a/src/mesh_contact.c
+++ b/src/mesh_contact.c
@@ -10,8 +10,6 @@
 #include "box3d/types.h"
 
 
-// This guards against excessive memory usage and complex collision
-#define B3_MAX_MESH_CONTACT_TRIANGLES 256
 #define B3_MAX_POINTS_PER_TRIANGLE 32
 
 #if B3_ENABLE_VALIDATION

--- a/src/recording.c
+++ b/src/recording.c
@@ -227,6 +227,9 @@ void b3RecW_PLANERESULT( b3RecBuffer* buf, b3PlaneResult v )
 	b3RecW_VEC3( buf, v.plane.normal );
 	b3RecW_F32( buf, v.plane.offset );
 	b3RecW_VEC3( buf, v.point );
+	b3RecW_I32( buf, v.triangleIndex );
+	b3RecW_I32( buf, v.childIndex );
+	b3RecW_I32( buf, v.materialIndex );
 }
 
 void b3RecW_WORLDID( b3RecBuffer* buf, b3WorldId v )

--- a/src/recording.h
+++ b/src/recording.h
@@ -80,7 +80,12 @@ typedef struct b3World b3World;
 // version. Found by two independent cold readers, which flagged the same interim window.
 // Ruling: Glenn, 2026-08-23 -- "Bump major", with the standing grant "as you see fit
 // now and in the future": recording-format majors are the maintainer's call from here on.
-#define B3_REC_VERSION_MAJOR 7
+// Major version 8 widens b3PlaneResult with triangleIndex, childIndex and materialIndex.
+// The mover plane batches written by b3World_CollideMover and b3Body_CollideMover gain
+// three int32 fields per hit, so a v7 reader walking a v8 stream desynchronises at the
+// first plane and every op after it. Upstream box3d made the same widening its own major
+// bump (4 -> 5); ours is 8 because this fork's major counter is ahead.
+#define B3_REC_VERSION_MAJOR 8
 
 // Minor tracks op-stream additions that keep the 48 byte header shape.
 // Minor version 3 added name cache.

--- a/src/recording_replay.c
+++ b/src/recording_replay.c
@@ -300,6 +300,9 @@ b3PlaneResult b3RecR_PLANERESULT( b3RecReader* rdr )
 	v.plane.normal = b3RecR_VEC3( rdr );
 	v.plane.offset = b3RecR_F32( rdr );
 	v.point = b3RecR_VEC3( rdr );
+	v.triangleIndex = b3RecR_I32( rdr );
+	v.childIndex = b3RecR_I32( rdr );
+	v.materialIndex = b3RecR_I32( rdr );
 	return v;
 }
 
@@ -1812,7 +1815,8 @@ static bool b3RecReplayPlaneTrampoline( b3ShapeId id, const b3PlaneResult* plane
 		const b3RecRecordedHit* h = &rc->hits[rc->cursor + i];
 		if ( b3RecVec3Differs( h->plane.plane.normal, planes[i].plane.normal ) ||
 			 b3RecF32Differs( h->plane.plane.offset, planes[i].plane.offset ) ||
-			 b3RecVec3Differs( h->plane.point, planes[i].point ) )
+			 b3RecVec3Differs( h->plane.point, planes[i].point ) || h->plane.triangleIndex != planes[i].triangleIndex ||
+			 h->plane.childIndex != planes[i].childIndex || h->plane.materialIndex != planes[i].materialIndex )
 		{
 			rc->rdr->diverged = true;
 		}

--- a/src/shape.c
+++ b/src/shape.c
@@ -825,7 +825,7 @@ b3ShapeExtent b3ComputeShapeExtent( const b3Shape* shape, b3Vec3 localCenter )
 			b3Vec3 c1 = b3Sub( shape->capsule.center1, localCenter );
 			b3Vec3 c2 = b3Sub( shape->capsule.center2, localCenter );
 			b3Vec3 r = { radius, radius, radius };
-			extent.maxExtent = b3Add( b3Max( c1, c2 ), r );
+			extent.maxExtent = b3Add( b3Max( b3Abs( c1 ), b3Abs( c2 ) ), r );
 		}
 		break;
 
@@ -845,9 +845,9 @@ b3ShapeExtent b3ComputeShapeExtent( const b3Shape* shape, b3Vec3 localCenter )
 		{
 			b3Fixed radius = shape->sphere.radius;
 			extent.minExtent = radius;
+			b3Vec3 h = b3Abs( b3Sub( shape->sphere.center, localCenter ) );
 			b3Vec3 r = { radius, radius, radius };
-			b3Vec3 p = b3Add( b3Sub( shape->sphere.center, localCenter ), r );
-			extent.maxExtent = b3Abs( b3Sub( p, localCenter ) );
+			extent.maxExtent = b3Add( h, r );
 		}
 		break;
 
@@ -863,7 +863,7 @@ b3ShapeExtent b3ComputeShapeExtent( const b3Shape* shape, b3Vec3 localCenter )
 			b3Fixed r2 = b3Length( b3Sub( b3BoundToVec3( aabb.upperBound ), localCenter ) );
 			extent.minExtent = b3FixMin( r1, r2 );
 			b3Vec3 p = b3FarthestPointOnAABB( aabb, localCenter );
-			extent.maxExtent = b3Abs( p );
+			extent.maxExtent = b3Abs( b3Sub( p, localCenter ) );
 		}
 		break;
 

--- a/src/shape.c
+++ b/src/shape.c
@@ -986,32 +986,6 @@ bool b3OverlapShape( const b3Shape* shape, b3Transform transform, const b3ShapeP
 			B3_ASSERT( false );
 			return false;
 	}
-
-#if 0
-	b3Vec3 localPoints[B3_MAX_SHAPE_CAST_POINTS];
-	b3ShapeProxy localProxy;
-
-	b3Transform invTransform = b3InvertTransform( transform );
-	b3Matrix3 R = b3MakeMatrixFromQuat( invTransform.q );
-
-	localProxy.count = b3MinInt( proxy->count, B3_MAX_SHAPE_CAST_POINTS );
-	for ( int i = 0; i < localProxy.count; ++i )
-	{
-		localPoints[i] = b3Add( b3MulMV( R, proxy->points[i] ), invTransform.p );
-	}
-
-	localProxy.points = localPoints;
-	localProxy.radius = proxy->radius;
-
-	if ( type == b3_meshShape )
-	{
-		return b3OverlapMesh( &localProxy, shape->mesh.data, shape->mesh.scale );
-	}
-
-	B3_ASSERT( type == b3_heightShape );
-
-	return b3OverlapHeightField( &localProxy, shape->heightField );
-#endif
 }
 
 int b3CollideMover( b3PlaneResult* planes, int planeCapacity, const b3Shape* shape, b3Transform transform,

--- a/src/shape.c
+++ b/src/shape.c
@@ -1037,6 +1037,7 @@ int b3CollideMover( b3PlaneResult* planes, int planeCapacity, const b3Shape* sha
 	{
 		planes[i].plane.normal = b3RotateVector( transform.q, planes[i].plane.normal );
 		planes[i].point = b3TransformPoint( transform, planes[i].point );
+		planes[i].materialIndex = b3ClampInt( planes[i].materialIndex, 0, shape->materialCount - 1 );
 	}
 
 	return planeCount;

--- a/src/sphere.c
+++ b/src/sphere.c
@@ -242,6 +242,6 @@ int b3CollideMoverAndSphere( b3PlaneResult* result, const b3Sphere* shape, const
 	}
 
 	b3Plane plane = { normal, totalRadius - distance };
-	*result = ( b3PlaneResult ){ plane, shape->center };
+	*result = (b3PlaneResult){ plane, shape->center, 0, 0, 0 };
 	return 1;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,7 @@ set(BOX3D_TEST_FILES
     test_large_world.c
     test_macros.h
     test_manifold.c
+    test_mesh.c
     test_math.c
 	test_mover.c
     test_name_cache.c

--- a/test/main.c
+++ b/test/main.c
@@ -41,6 +41,7 @@ extern int IdTest( void );
 extern int JointTest( void );
 extern int LargeWorldTest( void );
 extern int ManifoldTest( void );
+extern int MeshTest( void );
 extern int MathTest( void );
 extern int MoverTest( void );
 extern int NameCacheTest( void );
@@ -114,6 +115,7 @@ int main( int argc, char** argv )
 	MAYBE_RUN_TEST( JointTest );
 	MAYBE_RUN_TEST( LargeWorldTest );
 	MAYBE_RUN_TEST( ManifoldTest );
+	MAYBE_RUN_TEST( MeshTest );
 	MAYBE_RUN_TEST( MathTest );
 	MAYBE_RUN_TEST( MoverTest );
 	MAYBE_RUN_TEST( NameCacheTest );

--- a/test/test_body.c
+++ b/test/test_body.c
@@ -613,6 +613,111 @@ static int InverseInertiaScaleEnvelope( void )
 	return 0;
 }
 
+// Extents bound the shapes about the center of mass, per axis. An offset shape must count its
+// offset, not just its own size. Upstream's tolerances of 1e-5 sit BELOW this engine's
+// 1.5e-5 quantum, so they are floored to 8 * B3_FIXED_EPSILON per the tree's convention.
+static int ShapeExtents( void )
+{
+	const b3Fixed tol = 8 * B3_FIXED_EPSILON;
+	const b3Fixed meshTol = B3_FIX( 0.0001f );
+
+	b3WorldDef worldDef = b3DefaultWorldDef();
+	b3WorldId worldId = b3CreateWorld( &worldDef );
+
+	b3ShapeDef shapeDef = b3DefaultShapeDef();
+	shapeDef.density = B3_FIX( 1.0f );
+
+	// Kinematic bodies measure from the body origin
+	b3BodyDef bodyDef = b3DefaultBodyDef();
+	bodyDef.type = b3_kinematicBody;
+
+	b3BodyId capsuleId = b3CreateBody( worldId, &bodyDef );
+	b3Capsule capsule = { { -B3_FIX( 2.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) },
+						  { -B3_FIX( 1.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) },
+						  B3_FIX( 0.2f ) };
+	b3CreateCapsuleShape( capsuleId, &shapeDef, &capsule );
+
+	// Both capsule centers sit on the -x side of the origin, so a componentwise max without
+	// b3Abs picks the NEARER end and under-reports the extent by a whole unit.
+	b3Vec3 maxExtent = b3Body_GetMaxExtent( capsuleId );
+	ENSURE_SMALL( maxExtent.x - B3_FIX( 2.2f ), tol );
+	ENSURE_SMALL( maxExtent.y - B3_FIX( 0.2f ), tol );
+	ENSURE_SMALL( maxExtent.z - B3_FIX( 0.2f ), tol );
+	ENSURE_SMALL( b3Body_GetMinExtent( capsuleId ) - B3_FIX( 0.2f ), tol );
+
+	b3BodyId sphereId = b3CreateBody( worldId, &bodyDef );
+	b3Sphere sphere = { { B3_FIX( 1.0f ), B3_FIX( 2.0f ), B3_FIX( 3.0f ) }, B3_FIX( 0.5f ) };
+	b3CreateSphereShape( sphereId, &shapeDef, &sphere );
+
+	maxExtent = b3Body_GetMaxExtent( sphereId );
+	ENSURE_SMALL( maxExtent.x - B3_FIX( 1.5f ), tol );
+	ENSURE_SMALL( maxExtent.y - B3_FIX( 2.5f ), tol );
+	ENSURE_SMALL( maxExtent.z - B3_FIX( 3.5f ), tol );
+	ENSURE_SMALL( b3Body_GetMinExtent( sphereId ) - B3_FIX( 0.5f ), tol );
+
+	// Dynamic bodies measure from the center of mass. A light sphere hung off a cube pulls the
+	// center toward it, so the far side of the sphere is the widest point.
+	bodyDef.type = b3_dynamicBody;
+	b3BodyId cubeId = b3CreateBody( worldId, &bodyDef );
+	b3BoxHull cube = b3MakeCubeHull( B3_FIX( 0.5f ) );
+	b3CreateHullShape( cubeId, &shapeDef, &cube.base );
+	b3Sphere offsetSphere = { { B3_FIX( 1.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) }, B3_FIX( 0.2f ) };
+	b3CreateSphereShape( cubeId, &shapeDef, &offsetSphere );
+
+	b3Vec3 localCenter = b3Body_GetLocalCenter( cubeId );
+	ENSURE( B3_FIX( 0.0f ) < localCenter.x && localCenter.x < B3_FIX( 0.5f ) );
+
+	maxExtent = b3Body_GetMaxExtent( cubeId );
+	ENSURE_SMALL( maxExtent.x - ( B3_FIX( 1.2f ) - localCenter.x ), tol );
+	ENSURE_SMALL( maxExtent.y - B3_FIX( 0.5f ), tol );
+	ENSURE_SMALL( maxExtent.z - B3_FIX( 0.5f ), tol );
+	ENSURE_SMALL( b3Body_GetMinExtent( cubeId ) - B3_FIX( 0.2f ), tol );
+
+	b3Vec3 originExtent = b3Body_GetMaxExtentOrigin( cubeId );
+	ENSURE_SMALL( originExtent.x - B3_FIX( 1.2f ), tol );
+	ENSURE_SMALL( originExtent.y - B3_FIX( 0.5f ), tol );
+	ENSURE_SMALL( originExtent.z - B3_FIX( 0.5f ), tol );
+
+	// A mesh has no mass, so the sphere alone places the center at x = 1 and the far edge of the
+	// mesh at x = -3 is four units out.
+	b3Vec3 vertices[6] = {
+		{ -B3_FIX( 3.0f ), B3_FIX( 0.0f ), -B3_FIX( 1.0f ) },
+		{ -B3_FIX( 2.0f ), B3_FIX( 0.0f ), B3_FIX( 1.0f ) },
+		{ -B3_FIX( 1.0f ), B3_FIX( 0.0f ), -B3_FIX( 1.0f ) },
+		{ B3_FIX( 1.0f ), B3_FIX( 0.0f ), -B3_FIX( 1.0f ) },
+		{ B3_FIX( 2.0f ), B3_FIX( 0.0f ), B3_FIX( 1.0f ) },
+		{ B3_FIX( 3.0f ), B3_FIX( 0.0f ), -B3_FIX( 1.0f ) },
+	};
+	int32_t indices[6] = { 0, 1, 2, 3, 4, 5 };
+	b3MeshDef meshDef = { 0 };
+	meshDef.vertices = vertices;
+	meshDef.stride = sizeof( b3Vec3 );
+	meshDef.indices = indices;
+	meshDef.vertexCount = 6;
+	meshDef.triangleCount = 2;
+	b3MeshData* mesh = b3CreateMesh( &meshDef, NULL, 0 );
+	ENSURE( mesh != NULL );
+
+	b3BodyId meshId = b3CreateBody( worldId, &bodyDef );
+	b3CreateSphereShape( meshId, &shapeDef, &offsetSphere );
+	b3Vec3 unitScale = { B3_FIX( 1.0f ), B3_FIX( 1.0f ), B3_FIX( 1.0f ) };
+	b3CreateMeshShape( meshId, &shapeDef, mesh, unitScale );
+
+	localCenter = b3Body_GetLocalCenter( meshId );
+	ENSURE_SMALL( localCenter.x - B3_FIX( 1.0f ), tol );
+
+	// Without subtracting the local center this reports |p| rather than |p - c|
+	maxExtent = b3Body_GetMaxExtent( meshId );
+	ENSURE_SMALL( maxExtent.x - B3_FIX( 4.0f ), meshTol );
+	ENSURE_SMALL( maxExtent.y - B3_FIX( 0.2f ), meshTol );
+	ENSURE_SMALL( maxExtent.z - B3_FIX( 1.0f ), meshTol );
+	ENSURE_SMALL( b3Body_GetMinExtent( meshId ) - B3_FIX( 0.2f ), tol );
+
+	b3DestroyWorld( worldId );
+	b3DestroyMesh( mesh );
+	return 0;
+}
+
 int BodyTest( void )
 {
 	RUN_SUBTEST( InverseMassQuantumFloor );
@@ -626,5 +731,6 @@ int BodyTest( void )
 	RUN_SUBTEST( SetMassDataFixedRotation );
 	RUN_SUBTEST( SetMassDataZeroMass );
 	RUN_SUBTEST( SetMassDataConsistentVelocity );
+	RUN_SUBTEST( ShapeExtents );
 	return 0;
 }

--- a/test/test_body_query.c
+++ b/test/test_body_query.c
@@ -567,6 +567,133 @@ static int MoverCapacity( void )
 	return 0;
 }
 
+// TimeOfImpactMover ------------------------------------------------------------------------
+
+// The mover capsule is expressed in the query frame, so a core segment starting at the origin
+// stands the character on the query point. Targets sit on the sweep line at y = 0.
+static b3Capsule MakeStandingMover( void )
+{
+	return (b3Capsule){ { B3_FIX( 0.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) },
+						{ B3_FIX( 0.0f ), B3_FIX( 1.0f ), B3_FIX( 0.0f ) },
+						B3_FIX( 0.25f ) };
+}
+
+static int MoverTOIHitsBox( void )
+{
+	b3BodyId bodyId;
+	b3WorldId worldId = CreateQueryWorld( &bodyId );
+
+	b3BoxHull box = b3MakeBoxHull( B3_FIX( 0.5f ), B3_FIX( 0.5f ), B3_FIX( 0.5f ) );
+	b3ShapeDef shapeDef = b3DefaultShapeDef();
+	b3ShapeId shapeId = b3CreateHullShape( bodyId, &shapeDef, &box.base );
+
+	// Face at x = 4.5, mover radius 0.25, so 4.25 of the 10 unit sweep is free.
+	b3Capsule mover = MakeStandingMover();
+	b3WorldTransform bodyTransform = IdentityAt( B3_FIX( 5.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) );
+	b3Vec3 translation = { B3_FIX( 10.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) };
+	b3BodyTOIResult result =
+		b3Body_TimeOfImpactMover( bodyId, b3Pos_zero, &mover, translation, b3DefaultQueryFilter(), bodyTransform, bodyTransform );
+
+	ENSURE_SMALL( result.fraction - B3_FIX( 0.425f ), B3_FIX( 0.01f ) );
+	ENSURE( b3IsNormalized( result.normal ) );
+	ENSURE_SMALL( result.normal.x + B3_FIX( 1.0f ), B3_FIX( 0.001f ) );
+
+	// The result carries a shape id, so the hit shape must come back identified.
+	ENSURE( b3Shape_IsValid( result.shapeId ) );
+	ENSURE( result.shapeId.index1 == shapeId.index1 );
+	ENSURE( result.shapeId.generation == shapeId.generation );
+
+	b3DestroyWorld( worldId );
+	return 0;
+}
+
+static int MoverTOISeparated( void )
+{
+	b3BodyId bodyId;
+	b3WorldId worldId = CreateQueryWorld( &bodyId );
+
+	b3BoxHull box = b3MakeBoxHull( B3_FIX( 0.5f ), B3_FIX( 0.5f ), B3_FIX( 0.5f ) );
+	b3ShapeDef shapeDef = b3DefaultShapeDef();
+	b3CreateHullShape( bodyId, &shapeDef, &box.base );
+
+	// Sweeping along +Y holds the X gap at 4.25 for the whole interval.
+	b3Capsule mover = MakeStandingMover();
+	b3WorldTransform bodyTransform = IdentityAt( B3_FIX( 5.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) );
+	b3Vec3 translation = { B3_FIX( 0.0f ), B3_FIX( 10.0f ), B3_FIX( 0.0f ) };
+	b3BodyTOIResult result =
+		b3Body_TimeOfImpactMover( bodyId, b3Pos_zero, &mover, translation, b3DefaultQueryFilter(), bodyTransform, bodyTransform );
+
+	ENSURE( result.fraction == B3_FIX( 1.0f ) );
+	ENSURE( b3Shape_IsValid( result.shapeId ) == false );
+
+	b3DestroyWorld( worldId );
+	return 0;
+}
+
+static int MoverTOIOverlapped( void )
+{
+	b3BodyId bodyId;
+	b3WorldId worldId = CreateQueryWorld( &bodyId );
+
+	b3BoxHull box = b3MakeBoxHull( B3_FIX( 0.5f ), B3_FIX( 0.5f ), B3_FIX( 0.5f ) );
+	b3ShapeDef shapeDef = b3DefaultShapeDef();
+	b3CreateHullShape( bodyId, &shapeDef, &box.base );
+
+	// Mover starts buried in the box, so there is no free interval to search.
+	b3Capsule mover = MakeStandingMover();
+	b3WorldTransform bodyTransform = IdentityAt( B3_FIX( 0.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) );
+	b3Vec3 translation = { B3_FIX( 10.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) };
+	b3BodyTOIResult result =
+		b3Body_TimeOfImpactMover( bodyId, b3Pos_zero, &mover, translation, b3DefaultQueryFilter(), bodyTransform, bodyTransform );
+
+	// Overlap should be ignored.
+	ENSURE( result.fraction == B3_FIX( 1.0f ) );
+	ENSURE( B3_IS_NULL( result.shapeId ) );
+
+	b3DestroyWorld( worldId );
+	return 0;
+}
+
+// Two shapes on the sweep line must resolve to the nearer one whatever order the shape list
+// hands them to the loop. Shapes are pushed on the head of the list, so the two bodies below
+// walk their shapes in opposite orders.
+static int MoverTOIClosestShape( void )
+{
+	b3BodyId nearFirstId;
+	b3WorldId worldId = CreateQueryWorld( &nearFirstId );
+
+	b3BodyDef bodyDef = b3DefaultBodyDef();
+	b3BodyId nearLastId = b3CreateBody( worldId, &bodyDef );
+
+	b3ShapeDef shapeDef = b3DefaultShapeDef();
+	b3Sphere nearSphere = { { B3_FIX( 5.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) }, B3_FIX( 0.5f ) };
+	b3Sphere farSphere = { { B3_FIX( 9.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) }, B3_FIX( 0.5f ) };
+
+	b3ShapeId nearFirstHit = b3CreateSphereShape( nearFirstId, &shapeDef, &nearSphere );
+	b3CreateSphereShape( nearFirstId, &shapeDef, &farSphere );
+
+	b3CreateSphereShape( nearLastId, &shapeDef, &farSphere );
+	b3ShapeId nearLastHit = b3CreateSphereShape( nearLastId, &shapeDef, &nearSphere );
+
+	b3Capsule mover = MakeStandingMover();
+	b3WorldTransform bodyTransform = IdentityAt( B3_FIX( 0.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) );
+	b3Vec3 translation = { B3_FIX( 10.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) };
+
+	b3BodyTOIResult nearFirst = b3Body_TimeOfImpactMover( nearFirstId, b3Pos_zero, &mover, translation, b3DefaultQueryFilter(),
+														 bodyTransform, bodyTransform );
+	b3BodyTOIResult nearLast = b3Body_TimeOfImpactMover( nearLastId, b3Pos_zero, &mover, translation, b3DefaultQueryFilter(),
+														bodyTransform, bodyTransform );
+
+	ENSURE_SMALL( nearFirst.fraction - B3_FIX( 0.425f ), B3_FIX( 0.01f ) );
+	ENSURE( nearFirst.shapeId.index1 == nearFirstHit.index1 );
+
+	ENSURE_SMALL( nearLast.fraction - nearFirst.fraction, B3_FIX( 0.0001f ) );
+	ENSURE( nearLast.shapeId.index1 == nearLastHit.index1 );
+
+	b3DestroyWorld( worldId );
+	return 0;
+}
+
 int BodyQueryTest( void )
 {
 	RUN_SUBTEST( CastRayHitsSphere );
@@ -591,6 +718,10 @@ int BodyQueryTest( void )
 	RUN_SUBTEST( MoverSeparated );
 	RUN_SUBTEST( MoverRotatedBody );
 	RUN_SUBTEST( MoverCapacity );
+	RUN_SUBTEST( MoverTOIHitsBox );
+	RUN_SUBTEST( MoverTOISeparated );
+	RUN_SUBTEST( MoverTOIOverlapped );
+	RUN_SUBTEST( MoverTOIClosestShape );
 
 	return 0;
 }

--- a/test/test_height_field.c
+++ b/test/test_height_field.c
@@ -676,6 +676,44 @@ static int RayCastClockwiseWinding( void )
 	return 0;
 }
 
+// The MOVER cull on the height field, which no test made fire before this one. The
+// shape-cast cull is covered by ShapeCastBackside above; instrumenting every cull site
+// across the suite showed b3CollideMoverAndHeightField reached and never fired. A wrong
+// sign here drops a character mover's ground contact, and every determinism golden holds
+// regardless because nothing in the corpus is ever culled.
+static int CollideMoverOnField( b3HeightFieldData* hf, b3Fixed y )
+{
+	b3Capsule mover = {
+		{ B3_FIX( 0.3f ), y - B3_FIX( 0.05f ), B3_FIX( 0.25f ) },
+		{ B3_FIX( 0.3f ), y + B3_FIX( 0.05f ), B3_FIX( 0.25f ) },
+		B3_FIX( 0.25f ),
+	};
+
+	b3PlaneResult planes[8] = { 0 };
+	return b3CollideMoverAndHeightField( planes, ARRAY_COUNT( planes ), hf, &mover );
+}
+
+static int MoverHeightFieldBackSideCull( void )
+{
+	b3HeightFieldData* hf = MakeFlatField( NULL, false );
+	ENSURE( hf != NULL );
+
+	// Above the surface and within the mover radius: front side, so a plane is reported.
+	ENSURE( CollideMoverOnField( hf, B3_FIX( 0.2f ) ) > 0 );
+
+	// The same distance below: back side, so the cull drops it.
+	ENSURE( CollideMoverOnField( hf, -B3_FIX( 0.2f ) ) == 0 );
+
+	// Out of range below, so the culled case above cannot be passing merely by distance.
+	ENSURE( CollideMoverOnField( hf, -B3_FIX( 3.0f ) ) == 0 );
+
+	// Out of range above, so the in-range case is reporting contact and not everything.
+	ENSURE( CollideMoverOnField( hf, B3_FIX( 3.0f ) ) == 0 );
+
+	b3DestroyHeightField( hf );
+	return 0;
+}
+
 int HeightFieldTest( void )
 {
 	RUN_SUBTEST( HeightFieldCreate );
@@ -691,6 +729,8 @@ int HeightFieldTest( void )
 	RUN_SUBTEST( ShapeCastClockwiseWinding );
 	RUN_SUBTEST( RayCastBackside );
 	RUN_SUBTEST( RayCastClockwiseWinding );
+
+	RUN_SUBTEST( MoverHeightFieldBackSideCull );
 
 	return 0;
 }

--- a/test/test_height_field.c
+++ b/test/test_height_field.c
@@ -525,6 +525,157 @@ static int RayCastBruteForce( void )
 	return 0;
 }
 
+// Flat 3x3 vertex field at y = 0, one cell material per entry. Caller destroys.
+static b3HeightFieldData* MakeFlatField( uint8_t* materials, bool clockwise )
+{
+	b3Fixed heights[9] = { 0 };
+
+	b3HeightFieldDef def = { 0 };
+	def.heights = heights;
+	def.materialIndices = materials;
+	def.scale = (b3Vec3){ B3_FIX( 1.0f ), B3_FIX( 1.0f ), B3_FIX( 1.0f ) };
+	def.countX = 3;
+	def.countZ = 3;
+	def.globalMinimumHeight = -B3_FIX( 1.0f );
+	def.globalMaximumHeight = B3_FIX( 1.0f );
+	def.clockwiseWinding = clockwise;
+
+	return b3CreateHeightField( &def );
+}
+
+static int ShapeCastBackside( void )
+{
+	uint8_t materials[4] = { 1, 0, 0, 0 };
+	b3HeightFieldData* hf = MakeFlatField( materials, false );
+	ENSURE( hf != NULL );
+
+	// Falling onto the front (upper) face reports the hit, the triangle, and its material.
+	// The surface sits at y = 0, so a sphere of radius 0.2 stops with its center at y = 0.2.
+	b3Vec3 above = { B3_FIX( 0.3f ), B3_FIX( 5.0f ), B3_FIX( 0.25f ) };
+	b3ShapeCastInput down = { 0 };
+	down.proxy = (b3ShapeProxy){ &above, 1, B3_FIX( 0.2f ) };
+	down.translation = (b3Vec3){ B3_FIX( 0.0f ), -B3_FIX( 10.0f ), B3_FIX( 0.0f ) };
+	down.maxFraction = B3_FIX( 1.0f );
+
+	b3CastOutput out = b3ShapeCastHeightField( hf, &down );
+	ENSURE( out.hit == true );
+	ENSURE_SMALL( out.fraction - B3_FIX( 0.48f ), B3_FIX( 0.01f ) );
+	ENSURE( out.normal.y > B3_FIX( 0.99f ) );
+	ENSURE( out.triangleIndex == 0 || out.triangleIndex == 1 );
+	ENSURE( out.materialIndex == 1 );
+
+	// Rising from behind the face is culled
+	b3Vec3 below = { B3_FIX( 0.3f ), -B3_FIX( 5.0f ), B3_FIX( 0.25f ) };
+	b3ShapeCastInput up = { 0 };
+	up.proxy = (b3ShapeProxy){ &below, 1, B3_FIX( 0.2f ) };
+	up.translation = (b3Vec3){ B3_FIX( 0.0f ), B3_FIX( 10.0f ), B3_FIX( 0.0f ) };
+	up.maxFraction = B3_FIX( 1.0f );
+
+	b3CastOutput missed = b3ShapeCastHeightField( hf, &up );
+	ENSURE( missed.hit == false );
+
+	b3DestroyHeightField( hf );
+	return 0;
+}
+
+// A clockwise height field faces down. Shape cast backside culling must respect the flag:
+// a rising sphere hits from below, not from above.
+static int ShapeCastClockwiseWinding( void )
+{
+	uint8_t materials[4] = { 1, 0, 0, 0 };
+	b3HeightFieldData* hf = MakeFlatField( materials, true );
+	ENSURE( hf != NULL );
+
+	b3Vec3 below = { B3_FIX( 0.3f ), -B3_FIX( 5.0f ), B3_FIX( 0.25f ) };
+	b3ShapeCastInput up = { 0 };
+	up.proxy = (b3ShapeProxy){ &below, 1, B3_FIX( 0.2f ) };
+	up.translation = (b3Vec3){ B3_FIX( 0.0f ), B3_FIX( 10.0f ), B3_FIX( 0.0f ) };
+	up.maxFraction = B3_FIX( 1.0f );
+
+	b3CastOutput out = b3ShapeCastHeightField( hf, &up );
+	ENSURE( out.hit == true );
+	ENSURE_SMALL( out.fraction - B3_FIX( 0.48f ), B3_FIX( 0.01f ) );
+	ENSURE( out.normal.y < -B3_FIX( 0.99f ) );
+	ENSURE( out.triangleIndex == 0 || out.triangleIndex == 1 );
+	ENSURE( out.materialIndex == 1 );
+
+	b3Vec3 above = { B3_FIX( 0.3f ), B3_FIX( 5.0f ), B3_FIX( 0.25f ) };
+	b3ShapeCastInput down = { 0 };
+	down.proxy = (b3ShapeProxy){ &above, 1, B3_FIX( 0.2f ) };
+	down.translation = (b3Vec3){ B3_FIX( 0.0f ), -B3_FIX( 10.0f ), B3_FIX( 0.0f ) };
+	down.maxFraction = B3_FIX( 1.0f );
+
+	b3CastOutput missed = b3ShapeCastHeightField( hf, &down );
+	ENSURE( missed.hit == false );
+
+	b3DestroyHeightField( hf );
+	return 0;
+}
+
+// Ray casts run through the shape cast. The default winding faces up, so a ray from below is
+// the back side and gets culled.
+static int RayCastBackside( void )
+{
+	uint8_t materials[4] = { 1, 0, 0, 0 };
+	b3HeightFieldData* hf = MakeFlatField( materials, false );
+	ENSURE( hf != NULL );
+
+	b3RayCastInput down = { 0 };
+	down.origin = (b3Vec3){ B3_FIX( 0.3f ), B3_FIX( 5.0f ), B3_FIX( 0.25f ) };
+	down.translation = (b3Vec3){ B3_FIX( 0.0f ), -B3_FIX( 10.0f ), B3_FIX( 0.0f ) };
+	down.maxFraction = B3_FIX( 1.0f );
+
+	b3CastOutput out = b3RayCastHeightField( hf, &down );
+	ENSURE( out.hit == true );
+	ENSURE_SMALL( out.fraction - B3_FIX( 0.5f ), B3_FIX( 0.001f ) );
+	ENSURE( out.normal.y > B3_FIX( 0.99f ) );
+	ENSURE( out.triangleIndex == 0 || out.triangleIndex == 1 );
+	ENSURE( out.materialIndex == 1 );
+
+	b3RayCastInput up = { 0 };
+	up.origin = (b3Vec3){ B3_FIX( 0.3f ), -B3_FIX( 5.0f ), B3_FIX( 0.25f ) };
+	up.translation = (b3Vec3){ B3_FIX( 0.0f ), B3_FIX( 10.0f ), B3_FIX( 0.0f ) };
+	up.maxFraction = B3_FIX( 1.0f );
+
+	b3CastOutput missed = b3RayCastHeightField( hf, &up );
+	ENSURE( missed.hit == false );
+
+	b3DestroyHeightField( hf );
+	return 0;
+}
+
+// A clockwise field faces down. The winding swap already flips the triangle, so the ray normal
+// must not be flipped a second time.
+static int RayCastClockwiseWinding( void )
+{
+	uint8_t materials[4] = { 1, 0, 0, 0 };
+	b3HeightFieldData* hf = MakeFlatField( materials, true );
+	ENSURE( hf != NULL );
+
+	b3RayCastInput up = { 0 };
+	up.origin = (b3Vec3){ B3_FIX( 0.3f ), -B3_FIX( 5.0f ), B3_FIX( 0.25f ) };
+	up.translation = (b3Vec3){ B3_FIX( 0.0f ), B3_FIX( 10.0f ), B3_FIX( 0.0f ) };
+	up.maxFraction = B3_FIX( 1.0f );
+
+	b3CastOutput out = b3RayCastHeightField( hf, &up );
+	ENSURE( out.hit == true );
+	ENSURE_SMALL( out.fraction - B3_FIX( 0.5f ), B3_FIX( 0.001f ) );
+	ENSURE( out.normal.y < -B3_FIX( 0.99f ) );
+	ENSURE( out.triangleIndex == 0 || out.triangleIndex == 1 );
+	ENSURE( out.materialIndex == 1 );
+
+	b3RayCastInput down = { 0 };
+	down.origin = (b3Vec3){ B3_FIX( 0.3f ), B3_FIX( 5.0f ), B3_FIX( 0.25f ) };
+	down.translation = (b3Vec3){ B3_FIX( 0.0f ), -B3_FIX( 10.0f ), B3_FIX( 0.0f ) };
+	down.maxFraction = B3_FIX( 1.0f );
+
+	b3CastOutput missed = b3RayCastHeightField( hf, &down );
+	ENSURE( missed.hit == false );
+
+	b3DestroyHeightField( hf );
+	return 0;
+}
+
 int HeightFieldTest( void )
 {
 	RUN_SUBTEST( HeightFieldCreate );
@@ -536,6 +687,10 @@ int HeightFieldTest( void )
 	RUN_SUBTEST( ShapeCastVerticalStraddle );
 	RUN_SUBTEST( ShapeCastBruteForce );
 	RUN_SUBTEST( RayCastBruteForce );
+	RUN_SUBTEST( ShapeCastBackside );
+	RUN_SUBTEST( ShapeCastClockwiseWinding );
+	RUN_SUBTEST( RayCastBackside );
+	RUN_SUBTEST( RayCastClockwiseWinding );
 
 	return 0;
 }

--- a/test/test_mesh.c
+++ b/test/test_mesh.c
@@ -531,6 +531,75 @@ static int MeshScaledWinding( void )
 	return 0;
 }
 
+// A flat one-quad mesh in the XZ plane, facing up (+Y)
+#define PLATE_VERTEX_COUNT 4
+#define PLATE_TRIANGLE_COUNT 2
+
+static b3MeshData* MakePlate( void )
+{
+	static b3Vec3 vertices[PLATE_VERTEX_COUNT] = {
+		{ -B3_FIX( 2.0f ), B3_FIX( 0.0f ), -B3_FIX( 2.0f ) },
+		{ B3_FIX( 2.0f ), B3_FIX( 0.0f ), -B3_FIX( 2.0f ) },
+		{ B3_FIX( 2.0f ), B3_FIX( 0.0f ), B3_FIX( 2.0f ) },
+		{ -B3_FIX( 2.0f ), B3_FIX( 0.0f ), B3_FIX( 2.0f ) },
+	};
+
+	// CCW seen from above, so the surface normal is +Y
+	static int32_t indices[3 * PLATE_TRIANGLE_COUNT] = { 0, 3, 1, 1, 3, 2 };
+
+	b3MeshDef def = { 0 };
+	def.vertices = vertices;
+	def.indices = indices;
+	def.vertexCount = PLATE_VERTEX_COUNT;
+	def.triangleCount = PLATE_TRIANGLE_COUNT;
+	return b3CreateMesh( &def, NULL, 0 );
+}
+
+// Cast a small sphere along a translation and report whether it hit the plate
+static bool CastSphereAtPlate( b3MeshData* data, b3Vec3 start, b3Vec3 translation )
+{
+	b3Mesh mesh = { data, { B3_FIX( 1.0f ), B3_FIX( 1.0f ), B3_FIX( 1.0f ) } };
+
+	b3Vec3 points[1] = { start };
+	b3ShapeCastInput input = { 0 };
+	input.proxy = (b3ShapeProxy){ points, 1, B3_FIX( 0.1f ) };
+	input.translation = translation;
+	input.maxFraction = B3_FIX( 1.0f );
+	input.canEncroach = false;
+
+	b3CastOutput output = b3ShapeCastMesh( &mesh, &input );
+	return output.hit;
+}
+
+// Back-side culling. Upstream added it to shape casts against meshes and height fields, and
+// this is the ONLY test that makes it fire: instrumented across the whole suite before this
+// existed, the cull ran 1992 times and fired 0 times, so every determinism golden held for
+// the uninteresting reason that nothing was ever culled. An unmoved golden is not evidence
+// about a branch that never taken.
+static int MeshBackSideCull( void )
+{
+	b3MeshData* plate = MakePlate();
+	ENSURE( plate != NULL );
+
+	// From above, moving down: the front side. Still hits.
+	b3Vec3 above = { B3_FIX( 0.0f ), B3_FIX( 1.0f ), B3_FIX( 0.0f ) };
+	b3Vec3 down = { B3_FIX( 0.0f ), -B3_FIX( 2.0f ), B3_FIX( 0.0f ) };
+	ENSURE( CastSphereAtPlate( plate, above, down ) == true );
+
+	// From below, moving up: the back side. Culled.
+	b3Vec3 below = { B3_FIX( 0.0f ), -B3_FIX( 1.0f ), B3_FIX( 0.0f ) };
+	b3Vec3 up = { B3_FIX( 0.0f ), B3_FIX( 2.0f ), B3_FIX( 0.0f ) };
+	ENSURE( CastSphereAtPlate( plate, below, up ) == false );
+
+	// A cast that starts below and never reaches the plate misses either way, which keeps
+	// the case above from passing merely because the sphere fell short.
+	b3Vec3 shortUp = { B3_FIX( 0.0f ), B3_FIX( 0.1f ), B3_FIX( 0.0f ) };
+	ENSURE( CastSphereAtPlate( plate, below, shortUp ) == false );
+
+	b3DestroyMesh( plate );
+	return 0;
+}
+
 // The built in creators fill their own def, so a missed stride shows up here
 static int MeshCreators( void )
 {
@@ -571,6 +640,7 @@ int MeshTest( void )
 	RUN_SUBTEST( MeshClockWiseStrideWeld );
 	RUN_SUBTEST( MeshDegenerateReport );
 	RUN_SUBTEST( MeshScaledWinding );
+	RUN_SUBTEST( MeshBackSideCull );
 	RUN_SUBTEST( MeshCreators );
 
 	return 0;

--- a/test/test_mesh.c
+++ b/test/test_mesh.c
@@ -233,8 +233,14 @@ static int MeshBadStride( void )
 	// told apart from a mesh that failed for some other reason -- an earlier version of
 	// this test read zeroes through the bad stride, collapsed every triangle, and passed
 	// against a build that never checked alignment at all.
-	uint8_t aligned[VALLEY_VERTEX_COUNT * 64];
-	uint8_t misaligned[VALLEY_VERTEX_COUNT * 28 + 32];
+	// _Alignas because the buffers are cast to b3Vec3* and read through as 64-bit members.
+	// A bare uint8_t array is 1-aligned by the language, so the "aligned" control would be
+	// aligned only by the luck of the frame layout -- and ASan does not check alignment, so
+	// the config this runs under would not catch it. Stating the alignment makes the aligned
+	// buffer aligned by construction and the 28-stride offsets misaligned by construction,
+	// which is what the test claims is the only variable between them.
+	_Alignas( b3Vec3 ) uint8_t aligned[VALLEY_VERTEX_COUNT * 64];
+	_Alignas( b3Vec3 ) uint8_t misaligned[VALLEY_VERTEX_COUNT * 28 + 32];
 	memset( aligned, 0, sizeof( aligned ) );
 	memset( misaligned, 0, sizeof( misaligned ) );
 	for ( int i = 0; i < VALLEY_VERTEX_COUNT; ++i )

--- a/test/test_mesh.c
+++ b/test/test_mesh.c
@@ -1,0 +1,489 @@
+// SPDX-FileCopyrightText: 2026 Erin Catto
+// SPDX-License-Identifier: MIT
+
+#include "test_macros.h"
+
+#include "box3d/collision.h"
+#include "box3d/math_functions.h"
+
+#include <string.h>
+
+// Two quads meeting at a concave crease along the shared edge 1-4. The crease exercises
+// edge identification, which reads the baked winding rather than the input winding.
+#define VALLEY_VERTEX_COUNT 6
+#define VALLEY_TRIANGLE_COUNT 4
+
+static void MakeValley( b3Vec3* vertices, int32_t* indices )
+{
+	b3Vec3 v[VALLEY_VERTEX_COUNT] = {
+		{ -B3_FIX( 1.0f ), B3_FIX( 1.0f ), -B3_FIX( 1.0f ) },
+		{ B3_FIX( 0.0f ), B3_FIX( 0.0f ), -B3_FIX( 1.0f ) },
+		{ B3_FIX( 1.0f ), B3_FIX( 1.0f ), -B3_FIX( 1.0f ) },
+		{ -B3_FIX( 1.0f ), B3_FIX( 1.0f ), B3_FIX( 1.0f ) },
+		{ B3_FIX( 0.0f ), B3_FIX( 0.0f ), B3_FIX( 1.0f ) },
+		{ B3_FIX( 1.0f ), B3_FIX( 1.0f ), B3_FIX( 1.0f ) },
+	};
+
+	int32_t i[3 * VALLEY_TRIANGLE_COUNT] = {
+		0, 3, 1, // left quad
+		3, 4, 1,
+		1, 4, 2, // right quad
+		4, 5, 2,
+	};
+
+	memcpy( vertices, v, sizeof( v ) );
+	memcpy( indices, i, sizeof( i ) );
+}
+
+// A vertex laid out the way a renderer would hand it over. The position sits off the
+// front of the struct so a non-zero base offset gets exercised too. b3Vec3 is 8-byte
+// aligned here, so the compiler pads after weight and sizeof is a multiple of 8 --
+// which is what b3CreateMesh requires of a stride.
+typedef struct FatVertex
+{
+	float weight;
+	b3Vec3 position;
+	float uv[2];
+} FatVertex;
+
+static void MakeFatVertices( FatVertex* fat, const b3Vec3* vertices, int count )
+{
+	for ( int i = 0; i < count; ++i )
+	{
+		// Poison the padding so a stride mistake bakes obvious garbage instead of near misses
+		fat[i].weight = 1000.0f + (float)i;
+		fat[i].position = vertices[i];
+		fat[i].uv[0] = -1000.0f;
+		fat[i].uv[1] = -2000.0f;
+	}
+}
+
+static void ReverseWinding( int32_t* indices, int triangleCount )
+{
+	for ( int i = 0; i < triangleCount; ++i )
+	{
+		int32_t temp = indices[3 * i + 1];
+		indices[3 * i + 1] = indices[3 * i + 2];
+		indices[3 * i + 2] = temp;
+	}
+}
+
+// The hash covers every byte of the mesh block, so this compares the tree, the vertices,
+// the baked triangles and the edge flags in one shot.
+static bool MeshesMatch( const b3MeshData* mesh1, const b3MeshData* mesh2 )
+{
+	return mesh1->byteCount == mesh2->byteCount && mesh1->hash == mesh2->hash;
+}
+
+// Exact equality rather than a tolerance: welding and the strided copy both move whole
+// quanta or nothing at all, so any difference here is a real defect rather than rounding.
+static bool VerticesMatch( const b3MeshData* mesh, const b3Vec3* expected, int count )
+{
+	if ( mesh->vertexCount != count )
+	{
+		return false;
+	}
+
+	const b3Vec3* vertices = b3GetMeshVertices( mesh );
+	for ( int i = 0; i < count; ++i )
+	{
+		if ( vertices[i].x != expected[i].x || vertices[i].y != expected[i].y || vertices[i].z != expected[i].z )
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+// The valley faces up, so every baked triangle should wind counter clockwise about +Y
+static bool FacesUp( const b3MeshData* mesh )
+{
+	const b3Vec3* vertices = b3GetMeshVertices( mesh );
+	const b3MeshTriangle* triangles = b3GetMeshTriangles( mesh );
+
+	for ( int i = 0; i < mesh->triangleCount; ++i )
+	{
+		b3Vec3 v1 = vertices[triangles[i].index1];
+		b3Vec3 v2 = vertices[triangles[i].index2];
+		b3Vec3 v3 = vertices[triangles[i].index3];
+
+		b3Vec3 normal = b3Cross( b3Sub( v2, v1 ), b3Sub( v3, v1 ) );
+		if ( normal.y <= B3_FIX( 0.0f ) )
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+static bool HasConcaveEdge( const b3MeshData* mesh )
+{
+	const uint8_t* flags = b3GetMeshFlags( mesh );
+
+	for ( int i = 0; i < mesh->triangleCount; ++i )
+	{
+		if ( ( flags[i] & b3_allConcaveEdges ) != 0 )
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+static b3MeshDef MakeValleyDef( b3Vec3* vertices, int32_t* indices )
+{
+	b3MeshDef def = { 0 };
+	def.vertices = vertices;
+	def.stride = sizeof( b3Vec3 );
+	def.indices = indices;
+	def.vertexCount = VALLEY_VERTEX_COUNT;
+	def.triangleCount = VALLEY_TRIANGLE_COUNT;
+	def.identifyEdges = true;
+	return def;
+}
+
+// Dense input is the reference the other cases are measured against
+static int MeshDenseStride( void )
+{
+	b3Vec3 vertices[VALLEY_VERTEX_COUNT];
+	int32_t indices[3 * VALLEY_TRIANGLE_COUNT];
+	MakeValley( vertices, indices );
+
+	b3MeshDef def = MakeValleyDef( vertices, indices );
+	b3MeshData* mesh = b3CreateMesh( &def, NULL, 0 );
+	ENSURE( mesh != NULL );
+
+	ENSURE( mesh->vertexCount == VALLEY_VERTEX_COUNT );
+	ENSURE( mesh->triangleCount == VALLEY_TRIANGLE_COUNT );
+	ENSURE( mesh->degenerateCount == 0 );
+	ENSURE( VerticesMatch( mesh, vertices, VALLEY_VERTEX_COUNT ) );
+	ENSURE( FacesUp( mesh ) );
+	ENSURE( HasConcaveEdge( mesh ) );
+
+	b3DestroyMesh( mesh );
+	return 0;
+}
+
+// A zero stride means contiguous and must bake the same mesh as an explicit dense stride
+static int MeshZeroStride( void )
+{
+	b3Vec3 vertices[VALLEY_VERTEX_COUNT];
+	int32_t indices[3 * VALLEY_TRIANGLE_COUNT];
+	MakeValley( vertices, indices );
+
+	b3MeshDef denseDef = MakeValleyDef( vertices, indices );
+	b3MeshData* denseMesh = b3CreateMesh( &denseDef, NULL, 0 );
+	ENSURE( denseMesh != NULL );
+
+	b3MeshDef zeroDef = MakeValleyDef( vertices, indices );
+	zeroDef.stride = 0;
+	b3MeshData* zeroMesh = b3CreateMesh( &zeroDef, NULL, 0 );
+	ENSURE( zeroMesh != NULL );
+
+	ENSURE( MeshesMatch( denseMesh, zeroMesh ) );
+
+	b3DestroyMesh( zeroMesh );
+	b3DestroyMesh( denseMesh );
+	return 0;
+}
+
+// Interleaved input must bake to exactly the same mesh as dense input
+static int MeshFatStride( void )
+{
+	b3Vec3 vertices[VALLEY_VERTEX_COUNT];
+	int32_t indices[3 * VALLEY_TRIANGLE_COUNT];
+	MakeValley( vertices, indices );
+
+	b3MeshDef denseDef = MakeValleyDef( vertices, indices );
+	b3MeshData* denseMesh = b3CreateMesh( &denseDef, NULL, 0 );
+	ENSURE( denseMesh != NULL );
+
+	FatVertex fat[VALLEY_VERTEX_COUNT];
+	MakeFatVertices( fat, vertices, VALLEY_VERTEX_COUNT );
+
+	b3MeshDef fatDef = MakeValleyDef( &fat[0].position, indices );
+	fatDef.stride = sizeof( FatVertex );
+	b3MeshData* fatMesh = b3CreateMesh( &fatDef, NULL, 0 );
+	ENSURE( fatMesh != NULL );
+
+	ENSURE( VerticesMatch( fatMesh, vertices, VALLEY_VERTEX_COUNT ) );
+	ENSURE( FacesUp( fatMesh ) );
+	ENSURE( MeshesMatch( denseMesh, fatMesh ) );
+
+	b3DestroyMesh( fatMesh );
+	b3DestroyMesh( denseMesh );
+	return 0;
+}
+
+// A stride that would misalign a b3Vec3 load must be refused rather than read. Upstream
+// allows any multiple of 4 because a single precision b3Vec3 is 4-byte aligned; b3Fixed
+// is 64 bits here, so the same stride is a misaligned load and b3CreateMesh returns NULL.
+static int MeshBadStride( void )
+{
+	b3Vec3 vertices[VALLEY_VERTEX_COUNT];
+	int32_t indices[3 * VALLEY_TRIANGLE_COUNT];
+	MakeValley( vertices, indices );
+
+	// Two packings of the SAME valley. Both are large enough and both carry real vertex
+	// data at their own spacing, so the only thing separating them is alignment: 64 is a
+	// multiple of alignof( b3Vec3 ) and 28 is not. Without that, a rejection cannot be
+	// told apart from a mesh that failed for some other reason -- an earlier version of
+	// this test read zeroes through the bad stride, collapsed every triangle, and passed
+	// against a build that never checked alignment at all.
+	uint8_t aligned[VALLEY_VERTEX_COUNT * 64];
+	uint8_t misaligned[VALLEY_VERTEX_COUNT * 28 + 32];
+	memset( aligned, 0, sizeof( aligned ) );
+	memset( misaligned, 0, sizeof( misaligned ) );
+	for ( int i = 0; i < VALLEY_VERTEX_COUNT; ++i )
+	{
+		memcpy( aligned + i * 64, &vertices[i], sizeof( b3Vec3 ) );
+		memcpy( misaligned + i * 28, &vertices[i], sizeof( b3Vec3 ) );
+	}
+
+	b3MeshDef def = MakeValleyDef( vertices, indices );
+
+	// The aligned packing must build the same mesh the dense input does, which pins the
+	// refusal below on alignment rather than on the data or the buffer size.
+	def.vertices = (b3Vec3*)aligned;
+	def.stride = 64;
+	b3MeshData* ok = b3CreateMesh( &def, NULL, 0 );
+	ENSURE( ok != NULL );
+	ENSURE( VerticesMatch( ok, vertices, VALLEY_VERTEX_COUNT ) );
+	ENSURE( FacesUp( ok ) );
+	b3DestroyMesh( ok );
+
+	// Same valley, same completeness, misaligned for a 64-bit member. Upstream's 4-byte
+	// check accepts this and builds a mesh from misaligned loads.
+	def.vertices = (b3Vec3*)misaligned;
+	def.stride = 28;
+	ENSURE( b3CreateMesh( &def, NULL, 0 ) == NULL );
+
+	def.vertices = vertices;
+
+	// Smaller than one vertex
+	def.stride = sizeof( b3Vec3 ) - 8;
+	ENSURE( b3CreateMesh( &def, NULL, 0 ) == NULL );
+
+	// Beyond the sanity ceiling, which usually means uninitialized memory
+	def.stride = 8192;
+	ENSURE( b3CreateMesh( &def, NULL, 0 ) == NULL );
+
+	return 0;
+}
+
+// Welding reads the source vertices through the stride as well
+static int MeshStrideWeld( void )
+{
+	b3Vec3 vertices[VALLEY_VERTEX_COUNT];
+	int32_t indices[3 * VALLEY_TRIANGLE_COUNT];
+	MakeValley( vertices, indices );
+
+	// Split the crease so each quad owns a copy of the shared edge
+	b3Vec3 splitVertices[8];
+	memcpy( splitVertices, vertices, sizeof( vertices ) );
+	splitVertices[6] = vertices[1];
+	splitVertices[7] = vertices[4];
+
+	// Point the right quad at the copies
+	int32_t splitIndices[3 * VALLEY_TRIANGLE_COUNT];
+	memcpy( splitIndices, indices, sizeof( indices ) );
+	splitIndices[6] = 6;
+	splitIndices[7] = 7;
+	splitIndices[9] = 7;
+
+	FatVertex fat[8];
+	MakeFatVertices( fat, splitVertices, 8 );
+
+	b3MeshDef def = MakeValleyDef( &fat[0].position, splitIndices );
+	def.stride = sizeof( FatVertex );
+	def.vertexCount = 8;
+	def.weldVertices = true;
+	def.weldTolerance = B3_FIX( 0.01f );
+
+	b3MeshData* mesh = b3CreateMesh( &def, NULL, 0 );
+	ENSURE( mesh != NULL );
+
+	ENSURE( mesh->vertexCount == VALLEY_VERTEX_COUNT );
+	ENSURE( mesh->triangleCount == VALLEY_TRIANGLE_COUNT );
+	ENSURE( VerticesMatch( mesh, vertices, VALLEY_VERTEX_COUNT ) );
+	ENSURE( FacesUp( mesh ) );
+	ENSURE( HasConcaveEdge( mesh ) );
+
+	b3DestroyMesh( mesh );
+	return 0;
+}
+
+// Clockwise input plus the flag must bake to the same mesh as counter clockwise input
+static int MeshClockWise( void )
+{
+	b3Vec3 vertices[VALLEY_VERTEX_COUNT];
+	int32_t indices[3 * VALLEY_TRIANGLE_COUNT];
+	MakeValley( vertices, indices );
+
+	b3MeshDef ccwDef = MakeValleyDef( vertices, indices );
+	b3MeshData* ccwMesh = b3CreateMesh( &ccwDef, NULL, 0 );
+	ENSURE( ccwMesh != NULL );
+
+	int32_t reversed[3 * VALLEY_TRIANGLE_COUNT];
+	memcpy( reversed, indices, sizeof( indices ) );
+	ReverseWinding( reversed, VALLEY_TRIANGLE_COUNT );
+
+	b3MeshDef cwDef = MakeValleyDef( vertices, reversed );
+	cwDef.clockWiseWinding = true;
+	b3MeshData* cwMesh = b3CreateMesh( &cwDef, NULL, 0 );
+	ENSURE( cwMesh != NULL );
+
+	ENSURE( FacesUp( cwMesh ) );
+	ENSURE( HasConcaveEdge( cwMesh ) );
+	ENSURE( MeshesMatch( ccwMesh, cwMesh ) );
+
+	b3DestroyMesh( cwMesh );
+	b3DestroyMesh( ccwMesh );
+	return 0;
+}
+
+// Without the flag the same clockwise input must bake inside out
+static int MeshClockWiseIgnored( void )
+{
+	b3Vec3 vertices[VALLEY_VERTEX_COUNT];
+	int32_t indices[3 * VALLEY_TRIANGLE_COUNT];
+	MakeValley( vertices, indices );
+	ReverseWinding( indices, VALLEY_TRIANGLE_COUNT );
+
+	b3MeshDef def = MakeValleyDef( vertices, indices );
+	b3MeshData* mesh = b3CreateMesh( &def, NULL, 0 );
+	ENSURE( mesh != NULL );
+
+	ENSURE( FacesUp( mesh ) == false );
+
+	b3DestroyMesh( mesh );
+	return 0;
+}
+
+// Winding, stride and welding have to compose
+static int MeshClockWiseStrideWeld( void )
+{
+	b3Vec3 vertices[VALLEY_VERTEX_COUNT];
+	int32_t indices[3 * VALLEY_TRIANGLE_COUNT];
+	MakeValley( vertices, indices );
+
+	b3MeshDef ccwDef = MakeValleyDef( vertices, indices );
+	ccwDef.weldVertices = true;
+	ccwDef.weldTolerance = B3_FIX( 0.01f );
+	b3MeshData* ccwMesh = b3CreateMesh( &ccwDef, NULL, 0 );
+	ENSURE( ccwMesh != NULL );
+
+	int32_t reversed[3 * VALLEY_TRIANGLE_COUNT];
+	memcpy( reversed, indices, sizeof( indices ) );
+	ReverseWinding( reversed, VALLEY_TRIANGLE_COUNT );
+
+	FatVertex fat[VALLEY_VERTEX_COUNT];
+	MakeFatVertices( fat, vertices, VALLEY_VERTEX_COUNT );
+
+	b3MeshDef cwDef = MakeValleyDef( &fat[0].position, reversed );
+	cwDef.stride = sizeof( FatVertex );
+	cwDef.clockWiseWinding = true;
+	cwDef.weldVertices = true;
+	cwDef.weldTolerance = B3_FIX( 0.01f );
+	b3MeshData* cwMesh = b3CreateMesh( &cwDef, NULL, 0 );
+	ENSURE( cwMesh != NULL );
+
+	ENSURE( FacesUp( cwMesh ) );
+	ENSURE( MeshesMatch( ccwMesh, cwMesh ) );
+
+	b3DestroyMesh( cwMesh );
+	b3DestroyMesh( ccwMesh );
+	return 0;
+}
+
+// The degenerate report is written before the count is bumped, so the first slot is
+// filled and the last slot in the caller's buffer is usable.
+static int MeshDegenerateReport( void )
+{
+	// A square split into two triangles, plus two zero-area slivers with distinct indices
+	b3Vec3 vertices[6] = {
+		{ B3_FIX( 0.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) },
+		{ B3_FIX( 1.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) },
+		{ B3_FIX( 1.0f ), B3_FIX( 0.0f ), B3_FIX( 1.0f ) },
+		{ B3_FIX( 0.0f ), B3_FIX( 0.0f ), B3_FIX( 1.0f ) },
+		{ B3_FIX( 2.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) },
+		{ B3_FIX( 3.0f ), B3_FIX( 0.0f ), B3_FIX( 0.0f ) },
+	};
+
+	int32_t indices[12] = {
+		0, 2, 1, // real
+		1, 4, 5, // collinear, zero area, distinct indices
+		0, 3, 2, // real
+		0, 4, 5, // collinear, zero area, distinct indices
+	};
+
+	b3MeshDef def = { 0 };
+	def.vertices = vertices;
+	def.indices = indices;
+	def.vertexCount = 6;
+	def.triangleCount = 4;
+
+	int reported[2] = { -1, -1 };
+	b3MeshData* mesh = b3CreateMesh( &def, reported, 2 );
+	ENSURE( mesh != NULL );
+
+	ENSURE( mesh->degenerateCount == 2 );
+	ENSURE( mesh->triangleCount == 2 );
+
+	// Both degenerates fit in the caller's buffer. Slot 0 alone does not discriminate --
+	// the old ordering incremented first and then wrote [count - 1], which lands on 0 too.
+	// What it never wrote is the LAST slot, because the guard had already consumed the
+	// increment, so it filled capacity - 1 entries and reported capacity of them.
+	ENSURE( reported[0] == 1 );
+	ENSURE( reported[1] == 3 );
+
+	b3DestroyMesh( mesh );
+	return 0;
+}
+
+// The built in creators fill their own def, so a missed stride shows up here
+static int MeshCreators( void )
+{
+	b3Vec3 center = { B3_FIX( 1.0f ), B3_FIX( 2.0f ), B3_FIX( 3.0f ) };
+	b3Vec3 extent = { B3_FIX( 0.5f ), B3_FIX( 1.0f ), B3_FIX( 1.5f ) };
+
+	b3MeshData* meshes[] = {
+		b3CreateGridMesh( 4, 4, B3_FIX( 1.0f ), 2, true ),
+		b3CreateWaveMesh( 4, 4, B3_FIX( 1.0f ), B3_FIX( 0.5f ), B3_FIX( 1.0f ), B3_FIX( 1.0f ) ),
+		b3CreateTorusMesh( 8, 6, B3_FIX( 2.0f ), B3_FIX( 0.5f ) ),
+		b3CreateBoxMesh( center, extent, true ),
+		b3CreateHollowBoxMesh( center, extent ),
+		b3CreatePlatformMesh( center, B3_FIX( 2.0f ), B3_FIX( 1.0f ), B3_FIX( 2.0f ) ),
+	};
+
+	for ( int i = 0; i < ARRAY_COUNT( meshes ); ++i )
+	{
+		ENSURE( meshes[i] != NULL );
+		ENSURE( meshes[i]->vertexCount >= 3 );
+		ENSURE( meshes[i]->triangleCount >= 1 );
+		ENSURE( b3IsSaneAABB( meshes[i]->bounds ) );
+
+		b3DestroyMesh( meshes[i] );
+	}
+
+	return 0;
+}
+
+int MeshTest( void )
+{
+	RUN_SUBTEST( MeshDenseStride );
+	RUN_SUBTEST( MeshZeroStride );
+	RUN_SUBTEST( MeshFatStride );
+	RUN_SUBTEST( MeshBadStride );
+	RUN_SUBTEST( MeshStrideWeld );
+	RUN_SUBTEST( MeshClockWise );
+	RUN_SUBTEST( MeshClockWiseIgnored );
+	RUN_SUBTEST( MeshClockWiseStrideWeld );
+	RUN_SUBTEST( MeshDegenerateReport );
+	RUN_SUBTEST( MeshCreators );
+
+	return 0;
+}

--- a/test/test_mesh.c
+++ b/test/test_mesh.c
@@ -444,6 +444,93 @@ static int MeshDegenerateReport( void )
 	return 0;
 }
 
+// Winding under a scaled mesh. b3QueryMesh reports each triangle in winding order, so the
+// sign of the reported normal is a direct read of the winding decision -- no culling, no
+// solver, nothing else in the way.
+typedef struct WindingContext
+{
+	int triangleCount;
+	int upCount;
+} WindingContext;
+
+static bool CountWinding( b3Vec3 a, b3Vec3 b, b3Vec3 c, int triangleIndex, void* context )
+{
+	(void)triangleIndex;
+	WindingContext* wc = (WindingContext*)context;
+	b3Vec3 normal = b3Cross( b3Sub( b, a ), b3Sub( c, a ) );
+	wc->triangleCount += 1;
+	if ( normal.y > B3_FIX( 0.0f ) )
+	{
+		wc->upCount += 1;
+	}
+
+	return true;
+}
+
+static int QueryWindingUpCount( b3MeshData* data, b3Vec3 scale, int* triangleCount )
+{
+	b3Mesh mesh = { data, scale };
+	b3AABB bounds = {
+		{ -B3_FIX( 1000.0f ), -B3_FIX( 1000.0f ), -B3_FIX( 1000.0f ) },
+		{ B3_FIX( 1000.0f ), B3_FIX( 1000.0f ), B3_FIX( 1000.0f ) },
+	};
+
+	WindingContext wc = { 0, 0 };
+	b3QueryMesh( &mesh, bounds, CountWinding, &wc );
+	*triangleCount = wc.triangleCount;
+	return wc.upCount;
+}
+
+// THE INVARIANT: a scale changes a mesh's size and handedness, never which way its surface
+// faces. A mirroring scale flips the geometric normal, and the winding swap exists to undo
+// exactly that -- so an upward facing valley must report upward facing triangles under
+// every legal scale, positive or reflected, large or small.
+//
+// The decision is the SIGN of the scale determinant, and forming that determinant with
+// b3FixMul quantizes to zero for legal small scales. Measured in Q48.16: the product of
+// (0.01, 0.01, 0.01) is exactly 0, and so is the product of (0.01, 0.01, -0.01). A test on
+// the product then answers wrongly for both, in opposite directions.
+static int MeshScaledWinding( void )
+{
+	b3Vec3 vertices[VALLEY_VERTEX_COUNT];
+	int32_t indices[3 * VALLEY_TRIANGLE_COUNT];
+	MakeValley( vertices, indices );
+
+	b3MeshDef def = MakeValleyDef( vertices, indices );
+	b3MeshData* data = b3CreateMesh( &def, NULL, 0 );
+	ENSURE( data != NULL );
+
+	b3Vec3 scales[] = {
+		// Determinant safely positive: holds under any spelling, so it is the reference
+		{ B3_FIX( 1.0f ), B3_FIX( 1.0f ), B3_FIX( 1.0f ) },
+
+		// Determinant safely negative: also holds under any spelling
+		{ B3_FIX( 1.0f ), B3_FIX( 1.0f ), -B3_FIX( 1.0f ) },
+
+		// Determinant positive, product quantizes to zero. Upstream's `product > 0` reads
+		// this as clockwise and swaps every triangle.
+		{ B3_FIX( 0.01f ), B3_FIX( 0.01f ), B3_FIX( 0.01f ) },
+
+		// Determinant negative, product quantizes to zero. The older `product < 0` reads
+		// this as counter clockwise and fails to swap.
+		{ B3_FIX( 0.01f ), B3_FIX( 0.01f ), -B3_FIX( 0.01f ) },
+
+		// Non-uniform, two reflected axes, determinant positive and small
+		{ -B3_FIX( 0.02f ), B3_FIX( 0.01f ), -B3_FIX( 0.05f ) },
+	};
+
+	for ( int i = 0; i < ARRAY_COUNT( scales ); ++i )
+	{
+		int count = 0;
+		int up = QueryWindingUpCount( data, scales[i], &count );
+		ENSURE( count == VALLEY_TRIANGLE_COUNT );
+		ENSURE( up == VALLEY_TRIANGLE_COUNT );
+	}
+
+	b3DestroyMesh( data );
+	return 0;
+}
+
 // The built in creators fill their own def, so a missed stride shows up here
 static int MeshCreators( void )
 {
@@ -483,6 +570,7 @@ int MeshTest( void )
 	RUN_SUBTEST( MeshClockWiseIgnored );
 	RUN_SUBTEST( MeshClockWiseStrideWeld );
 	RUN_SUBTEST( MeshDegenerateReport );
+	RUN_SUBTEST( MeshScaledWinding );
 	RUN_SUBTEST( MeshCreators );
 
 	return 0;

--- a/test/test_mover.c
+++ b/test/test_mover.c
@@ -233,6 +233,76 @@ static int MoverHullDeepOverlap( void )
 	return 0;
 }
 
+// Back-side culling on the MOVER paths. The shape-cast cull has MeshBackSideCull in
+// test_mesh.c; instrumenting every cull site across the whole suite showed the two
+// b3CollideMoverAnd* sites reached and never fired, so until these two subtests existed
+// the highest consequence cull in the change -- a character mover's contact planes --
+// was carried by inspection alone. A wrong sign here is a character falling through a
+// floor, and no determinism golden can see it because nothing in the corpus is culled.
+
+#define MOVER_PLATE_VERTEX_COUNT 4
+#define MOVER_PLATE_TRIANGLE_COUNT 2
+
+// A flat plate in the y = 0 plane, wound CCW seen from above, so its front face is +Y.
+static b3MeshData* MakeMoverPlate( void )
+{
+	static b3Vec3 vertices[MOVER_PLATE_VERTEX_COUNT] = {
+		{ -B3_FIX( 2.0f ), B3_FIX( 0.0f ), -B3_FIX( 2.0f ) },
+		{ B3_FIX( 2.0f ), B3_FIX( 0.0f ), -B3_FIX( 2.0f ) },
+		{ B3_FIX( 2.0f ), B3_FIX( 0.0f ), B3_FIX( 2.0f ) },
+		{ -B3_FIX( 2.0f ), B3_FIX( 0.0f ), B3_FIX( 2.0f ) },
+	};
+
+	static int32_t indices[3 * MOVER_PLATE_TRIANGLE_COUNT] = { 0, 3, 1, 1, 3, 2 };
+
+	b3MeshDef def = { 0 };
+	def.vertices = vertices;
+	def.indices = indices;
+	def.vertexCount = MOVER_PLATE_VERTEX_COUNT;
+	def.triangleCount = MOVER_PLATE_TRIANGLE_COUNT;
+	return b3CreateMesh( &def, NULL, 0 );
+}
+
+// Collide a short vertical mover centred at height y against the plate, and report how
+// many contact planes come back.
+static int CollideMoverAtHeight( b3MeshData* data, b3Fixed y )
+{
+	b3Mesh mesh = { data, { B3_FIX( 1.0f ), B3_FIX( 1.0f ), B3_FIX( 1.0f ) } };
+
+	b3Capsule mover = {
+		{ B3_FIX( 0.0f ), y - B3_FIX( 0.05f ), B3_FIX( 0.0f ) },
+		{ B3_FIX( 0.0f ), y + B3_FIX( 0.05f ), B3_FIX( 0.0f ) },
+		B3_FIX( 0.25f ),
+	};
+
+	b3PlaneResult planes[8] = { 0 };
+	return b3CollideMoverAndMesh( planes, ARRAY_COUNT( planes ), &mesh, &mover );
+}
+
+static int MoverMeshBackSideCull( void )
+{
+	b3MeshData* plate = MakeMoverPlate();
+	ENSURE( plate != NULL );
+
+	// Above the plate and within the mover radius: the front side, so a plane is reported.
+	ENSURE( CollideMoverAtHeight( plate, B3_FIX( 0.2f ) ) > 0 );
+
+	// Below the plate, the same distance away: the back side, so the cull drops it.
+	ENSURE( CollideMoverAtHeight( plate, -B3_FIX( 0.2f ) ) == 0 );
+
+	// Far below, out of range either way. Without this the case above could pass merely
+	// by being too far from the plate to touch it, which would make the cull untested
+	// while looking green.
+	ENSURE( CollideMoverAtHeight( plate, -B3_FIX( 3.0f ) ) == 0 );
+
+	// And far above, out of range on the front side, so the in-range case above is
+	// reporting contact rather than reporting everything.
+	ENSURE( CollideMoverAtHeight( plate, B3_FIX( 3.0f ) ) == 0 );
+
+	b3DestroyMesh( plate );
+	return 0;
+}
+
 int MoverTest( void )
 {
 	RUN_SUBTEST( GamePlanes );
@@ -250,6 +320,8 @@ int MoverTest( void )
 	RUN_SUBTEST( MoverHullSeparated );
 	RUN_SUBTEST( MoverHullTouching );
 	RUN_SUBTEST( MoverHullDeepOverlap );
+
+	RUN_SUBTEST( MoverMeshBackSideCull );
 
 	return 0;
 }


### PR DESCRIPTION
Carries upstream `erincatto/box3d@47d7f7c` "clockwise option, joint is awake (#130)"
across to Fixed3D. 2,466 upstream insertions; the whole engine half is here, in seven
steps, each built and run under narrow, ludicrous and Debug+VALIDATE+ASan before the
next began.

## The two fixed-point decisions

**1. Mesh winding must not use the scale product — porting upstream verbatim would have
been a regression.**

Upstream renames its winding boolean from `clockwise = sx*sy*sz < 0` to
`ccw = sx*sy*sz > 0` and swaps the branch bodies. In single precision those differ only
when a scale component is exactly zero. Here `b3FixMul` of three legal scales quantizes
to zero far earlier. Measured raw product values in Q48.16:

| scale | raw product | product test correct? |
|---|---|---|
| (1, 1, 1) | 65536 | yes |
| (1, 1, -1) | -65536 | yes |
| (0.2, 0.2, -0.2) | -524 | yes |
| (0.05, 0.05, -0.05) | -8 | yes |
| (0.01, 0.01, -0.01) | **0** | **no** |
| (0.01, 0.01, 0.01) | **0** | **no** |

A plain uniform 1 cm scale has a determinant product of exactly zero, and upstream's new
spelling reads that as clockwise and swaps the winding of every triangle in every ray
cast, shape cast and query. The older `< 0` spelling is wrong the other way, on small
reflected scales. Neither goes red on its own.

`b3IsScaleCounterClockwise` compares signs and never forms the product — the sign of a
product is the parity of its negative factors — and equals upstream's `product > 0` in
exact arithmetic, zero-component case included. Applied at all three sites, which also
resolves a pre-existing inconsistency where two used `< 0` and the third used `> 0`.

**2. Mesh vertex stride alignment is 8 here, not 4.**

Upstream rejects a stride that is not a multiple of 4, the alignment of a single
precision `b3Vec3`. Measured by compiling a sizeof/alignof program in both configs,
`b3Vec3` is 24 bytes with alignment 8 in narrow and under `LUDICROUS_MODE`. Upstream's
check would accept a stride of 28 and load every vertex misaligned, so the check is
spelled against `_Alignof( b3Vec3 )` and follows the type.

## Back-side culling fails open, deliberately

`b3SignedVolume` is a `b3Cross` fed to a `b3Dot`. `b3Dot` is a fused raw-128 reduction,
but `b3Cross` is on this tree's do-not-fuse list, so each cross component rounds and a
small enough triangle quantizes the whole signed volume to zero. Upstream's comparison
already puts zero on the front side, so the degenerate case stops culling rather than
silently dropping contacts on tiny geometry. The upstream spelling is kept exactly rather
than tightened.

## Recording format

`B3_REC_VERSION_MAJOR` 7 to 8. The mover plane batches gain three int32 fields per hit,
so a v7 reader walking a v8 stream desynchronises at the first plane and every op after
it. Upstream made the same widening its own major bump, 4 to 5; ours is 8 because this
fork's counter is ahead.

## Goldens

None moved — and for back-side culling that was not evidence until it was measured.
Instrumenting every cull site and running the whole suite, the branch was reached
**1992 times and fired 0 times**: every golden held for the uninteresting reason that
nothing in the corpus is ever culled. `MeshBackSideCull` is the test that makes it fire,
after which the counters read 1996 tested and 2 fired.

Winding and stride move no golden because both new `b3MeshDef` fields default to the old
behavior. Extents bound behavior rather than producing it.

## Red first

Every new claim was seen failing by neutering the code it tests, one at a time, with the
neuter asserted to have matched the source rather than assumed. Twelve controls in all,
covering stride, the welder, clockwise winding, the degenerate report, stride alignment,
the winding sign test under both product spellings, mesh and height field culling, and
the three shape extent bugs.

**Two of those controls were green on the first attempt, which is the finding rather than
a detail.** `MeshDegenerateReport` asserted only slot 0, which the old ordering also
fills — the difference is the last slot. `MeshBadStride` returned NULL under the neutered
build for the wrong reason: the bad stride overran its buffer and collapsed the mesh
instead of being refused. Both were rewritten until the control actually went red. A pass
never seen failing is evidence about the runner, not the job.

## Also carried

`b3PlaneResult` gains triangle, child and material indices; `b3Body_TimeOfImpactMover`
and `b3BodyTOIResult` (fraction as `b3Fixed`); `b3Joint_IsAwake`; the three body extent
getters; three real extent bugs (capsule max without `b3Abs`, sphere subtracting the
local center twice, mesh measuring from the body origin); complete `b3ShapeDistance`
output on every return; the TOI overlapped hit point; the degenerate-report off-by-one;
two `b3Array` leaks; `B3_MAX_MESH_CONTACT_TRIANGLES` as a public tunable.

`test/test_mesh.c` is new — upstream's, in Q48.16, plus five cases of our own. 24 suites.

## Held, and named rather than skipped

- **The samples half** — `sample_character.cpp`, `sample_issues.cpp`, `sample_joint.cpp`,
  `samples/mover.*`. Same ground as fixed3d#20: sample-app content, no simulation
  content. The samples tree still builds clean against the new API, verified after a
  forced header rebuild.
- **The remainder of upstream's test additions** — the `test_mover.c` block and three
  further `test_body_query.c` TOI cases. These are additional coverage of engine changes
  that already carry tests of their own.

The port cursor in `CLAUDE.md` says "carried across" and names this branch as the thing
that has to merge before it is true, striking itself on merge.

## Verified

All four configs green: `build-port`, `build-ludicrous`, `build-debug`
(Debug + VALIDATE + ASan), `build-samples`.
