### PR TITLE
Fix fixed-point scale errors and add Box3D visual comparisons

### DIFF
--- a/samples/main.cpp
+++ b/samples/main.cpp
@@ -51,6 +51,7 @@ static int s_frame = 0;
 static int s_frameLimit = -1;
 static char s_capturePath[1024];
 static bool s_headless = false;
+static bool s_captureNoAxes = false;
 static int s_sampleOverride = -1;
 static int s_exitCode = 0;
 
@@ -624,6 +625,13 @@ static int RunHeadlessCapture()
 		double gridPeriod = 10.0 * BOX3D_GROUND_GRID_CELL_SIZE;
 		fi.gridWrap.x = (float)fmod( b3FixToDouble( drawOrigin.x ), gridPeriod );
 		fi.gridWrap.y = (float)fmod( b3FixToDouble( drawOrigin.z ), gridPeriod );
+		// Absolute world-axis lines differ when the same scene is translated.
+		// This capture-only option hides them without changing the repeating grid.
+		if ( s_captureNoAxes )
+		{
+			fi.drawOrigin.x = 1.0e20f;
+			fi.drawOrigin.z = 1.0e20f;
+		}
 		fi.time = (float)frame / 60.0f;
 		fi.debugMode = s_context.debugView;
 		fi.disableShadows = !s_context.enableShadows;
@@ -696,6 +704,10 @@ static sapp_desc BuildAppDesc( int argc, char** argv )
 			// End-state screenshot: at --frames N, freeze the sim, render the
 			// final state offscreen, and write it to this PNG path (macOS only).
 			snprintf( s_capturePath, sizeof( s_capturePath ), "%s", argv[++i] );
+		}
+		else if ( strcmp( argv[i], "--capture-no-axes" ) == 0 )
+		{
+			s_captureNoAxes = true;
 		}
 		else if ( strcmp( argv[i], "--headless" ) == 0 )
 		{

--- a/src/body.c
+++ b/src/body.c
@@ -1555,7 +1555,7 @@ void b3Body_ApplyAngularImpulse( b3BodyId bodyId, b3Vec3 impulse, bool wake )
 		b3BodySim* bodySim = b3Array_Get( set->bodySims, localIndex );
 
 		b3Vec3 localImpulse = b3InvRotateVector( bodySim->transform.q, impulse );
-		b3Vec3 localAngularVelocityDelta = b3MulMV( bodySim->invInertiaLocal, localImpulse );
+		b3Vec3 localAngularVelocityDelta = b3InvMulMV( bodySim->invInertiaLocal, localImpulse );
 		state->angularVelocity =
 			b3Add( state->angularVelocity, b3RotateVector( bodySim->transform.q, localAngularVelocityDelta ) );
 	}

--- a/src/distance.c
+++ b/src/distance.c
@@ -219,10 +219,13 @@ static bool b3SolveSimplex2( b3Simplex* simplex )
 		return false;
 	}
 
-	// VR( AB )
-	b3Fixed denominator = b3FixDiv( B3_FIX( 1.0f ) , divisor );
-	vs[0].a = b3FixMul( denominator , u );
-	vs[1].a = b3FixMul( denominator , v );
+	// VR( AB ). Form the ratio directly: 1 / |AB|^2 rounds to zero for
+	// edges longer than 256. Normalize the rounded numerators and derive the
+	// other weight by subtraction so the witnesses remain affine combinations.
+	// u and v are positive here; their unsigned sum cannot overflow uint64.
+	uint64_t sum = (uint64_t)u + (uint64_t)v;
+	vs[1].a = (b3Fixed)( ( (b3UInt128)(uint64_t)v << B3_FIXED_FRACTION_BITS ) / sum );
+	vs[0].a = B3_FIXED_ONE - vs[1].a;
 
 	return true;
 }

--- a/src/math_internal.h
+++ b/src/math_internal.h
@@ -405,6 +405,31 @@ static inline b3Vec2 b3Solve2( b3Matrix2 m, b3Vec2 b )
 	return B3_LITERAL( b3Vec2 ){ B3_FIX( 0.0f ), B3_FIX( 0.0f ) };
 }
 
+// Solve K*x = b with inverse-scaled K and ordinary b/x. The numerator has
+// 40+16 fractional bits and the determinant has 80, so shift by 40, not 16.
+// Two int64 products and their difference fit in int128; the additional shift
+// need not. Keep ordinary solves in int128 and widen only that overflow case.
+static inline b3Vec2 b3Solve2AcrossScales( b3Matrix2 m, b3Vec2 b )
+{
+	b3Int128 det = b3Cofactor128( m.cx.x, m.cy.y, m.cx.y, m.cy.x );
+	if ( fixInt128Le( det, FIX_INT128_ZERO ) )
+	{
+		return B3_LITERAL( b3Vec2 ){ 0, 0 };
+	}
+
+	b3Int128 nx = b3Cofactor128( m.cy.y, b.x, m.cy.x, b.y );
+	b3Int128 ny = b3Cofactor128( m.cx.x, b.y, m.cx.y, b.x );
+	const int shift = B3_INVERSE_FRACTION_BITS;
+	b3Int128 limit = b3Int128ShiftLeft( fixInt128FromI64( 1 ), 127 - shift );
+	if ( fixInt128InRange( nx, limit ) && fixInt128InRange( ny, limit ) )
+	{
+		return B3_LITERAL( b3Vec2 ){ fixDivShifted( nx, shift, det ), fixDivShifted( ny, shift, det ) };
+	}
+
+	fixUInt256 wideDet = fixUInt256FromU128( fixInt128ToUnsigned( det ) );
+	return B3_LITERAL( b3Vec2 ){ fixDivShiftedWide( nx, shift, wideDet, false ), fixDivShiftedWide( ny, shift, wideDet, false ) };
+}
+
 // Convenience function: s * a + t * b + u * c
 static inline b3Vec3 b3Blend3( b3Fixed s, b3Vec3 a, b3Fixed t, b3Vec3 b, b3Fixed u, b3Vec3 c )
 {

--- a/src/parallel_joint.c
+++ b/src/parallel_joint.c
@@ -209,7 +209,7 @@ void b3SolveParallelJoint( b3JointSim* base, b3StepContext* context )
 		b3Fixed maxImpulse = b3FixMul( context->h , joint->maxTorque );
 		b3Vec2 oldImpulse = joint->perpImpulse;
 		b3Vec2 cdotPlusBias = { cdot.x + bias.x, cdot.y + bias.y };
-		b3Vec2 sol = b3Solve2( k, cdotPlusBias );
+		b3Vec2 sol = b3Solve2AcrossScales( k, cdotPlusBias );
 		b3Vec2 deltaImpulse = {
 			b3FixMul( -massScale , sol.x ) - b3FixMul( impulseScale , oldImpulse.x ),
 			b3FixMul( -massScale , sol.y ) - b3FixMul( impulseScale , oldImpulse.y ),

--- a/src/prismatic_joint.c
+++ b/src/prismatic_joint.c
@@ -661,7 +661,7 @@ void b3SolvePrismaticJoint( b3JointSim* base, b3StepContext* context, bool useBi
 		b3Matrix2 K = { { kyy, kyz }, { kyz, kzz } };
 
 		b3Vec2 oldImpulse = joint->perpImpulse;
-		b3Vec2 sol = b3Solve2( K, b3Add2( cdot, bias ) );
+		b3Vec2 sol = b3Solve2AcrossScales( K, b3Add2( cdot, bias ) );
 		b3Vec2 deltaImpulse = b3Sub2( b3MulSV2( -massScale, sol ), b3MulSV2( impulseScale, oldImpulse ) );
 		joint->perpImpulse = b3Add2( oldImpulse, deltaImpulse );
 

--- a/src/revolute_joint.c
+++ b/src/revolute_joint.c
@@ -546,7 +546,7 @@ void b3SolveRevoluteJoint( b3JointSim* base, b3StepContext* context, bool useBia
 		b3Vec3 wRel = b3Sub( wB, wA );
 		b3Vec2 cdot = { b3Dot( wRel, perpAxisX ), b3Dot( wRel, perpAxisY ) };
 		b3Vec2 oldImpulse = joint->perpImpulse;
-		b3Vec2 sol = b3Solve2( k, b3Add2( cdot, bias ) );
+		b3Vec2 sol = b3Solve2AcrossScales( k, b3Add2( cdot, bias ) );
 		b3Vec2 deltaImpulse = b3Sub2( b3MulSV2( -massScale, sol ), b3MulSV2( impulseScale, oldImpulse ) );
 		joint->perpImpulse = b3Add2( joint->perpImpulse, deltaImpulse );
 

--- a/src/wheel_joint.c
+++ b/src/wheel_joint.c
@@ -923,7 +923,7 @@ void b3SolveWheelJoint( b3JointSim* base, b3StepContext* context, bool useBias )
 			b3Vec2 cdot = { b3Dot( wRel, perpAxisX ), b3Dot( wRel, perpAxisY ) };
 			b3Vec2 oldImpulse = joint->angularImpulse;
 			b3Vec2 cdotPlusBias = { cdot.x + bias.x, cdot.y + bias.y };
-			b3Vec2 sol = b3Solve2( k, cdotPlusBias );
+			b3Vec2 sol = b3Solve2AcrossScales( k, cdotPlusBias );
 			b3Vec2 deltaImpulse = {
 				b3FixMul( -massScale , sol.x ) - b3FixMul( impulseScale , oldImpulse.x ),
 				b3FixMul( -massScale , sol.y ) - b3FixMul( impulseScale , oldImpulse.y ),
@@ -966,7 +966,7 @@ void b3SolveWheelJoint( b3JointSim* base, b3StepContext* context, bool useBias )
 
 		b3Vec2 oldImpulse = joint->linearImpulse;
 		b3Vec2 cdotPlusBias = { cdot.x + bias.x, cdot.y + bias.y };
-		b3Vec2 sol = b3Solve2( k, cdotPlusBias );
+		b3Vec2 sol = b3Solve2AcrossScales( k, cdotPlusBias );
 		b3Vec2 deltaImpulse = {
 			b3FixMul( -massScale , sol.x ) - b3FixMul( impulseScale , oldImpulse.x ),
 			b3FixMul( -massScale , sol.y ) - b3FixMul( impulseScale , oldImpulse.y ),

--- a/test/test_body.c
+++ b/test/test_body.c
@@ -718,8 +718,37 @@ static int ShapeExtents( void )
 	return 0;
 }
 
+// An angular impulse changes velocity by inverse inertia times impulse. Use
+// anisotropic inertia and a rotated body to check the local/world conversion too.
+static int AngularImpulseInverseScale( void )
+{
+	b3WorldDef worldDef = b3DefaultWorldDef();
+	b3WorldId worldId = b3CreateWorld( &worldDef );
+	b3BodyDef bodyDef = b3DefaultBodyDef();
+	bodyDef.type = b3_dynamicBody;
+	bodyDef.rotation = b3MakeQuatFromAxisAngle( b3Vec3_axisZ, B3_FIX( 0.5f ) );
+	b3BodyId bodyId = b3CreateBody( worldId, &bodyDef );
+	b3MassData mass = { 0 };
+	mass.mass = B3_FIX( 1.0f );
+	mass.inertia = (b3Matrix3){ { B3_FIX( 2.0f ), 0, 0 }, { 0, B3_FIX( 4.0f ), 0 }, { 0, 0, B3_FIX( 8.0f ) } };
+	b3Body_SetMassData( bodyId, mass );
+	b3Vec3 localImpulse = { B3_FIX( 1.0f ), B3_FIX( -2.0f ), B3_FIX( 2.0f ) };
+	b3Vec3 initial = { B3_FIX( 0.25f ), B3_FIX( 0.5f ), B3_FIX( -0.25f ) };
+	b3Body_SetAngularVelocity( bodyId, initial );
+	b3Body_ApplyAngularImpulse( bodyId, b3RotateVector( bodyDef.rotation, localImpulse ), true );
+	b3Vec3 expected =
+		b3Add( initial, b3RotateVector( bodyDef.rotation, (b3Vec3){ B3_FIX( 0.5f ), B3_FIX( -0.5f ), B3_FIX( 0.25f ) } ) );
+	b3Vec3 actual = b3Body_GetAngularVelocity( bodyId );
+	b3DestroyWorld( worldId );
+	ENSURE_SMALL( actual.x - expected.x, B3_FIX( 0.001f ) );
+	ENSURE_SMALL( actual.y - expected.y, B3_FIX( 0.001f ) );
+	ENSURE_SMALL( actual.z - expected.z, B3_FIX( 0.001f ) );
+	return 0;
+}
+
 int BodyTest( void )
 {
+	RUN_SUBTEST( AngularImpulseInverseScale );
 	RUN_SUBTEST( InverseMassQuantumFloor );
 	RUN_SUBTEST( InverseInertiaScaleEnvelope );
 	RUN_SUBTEST( InverseMassQuantumFloorFromShapes );

--- a/test/test_determinism.c
+++ b/test/test_determinism.c
@@ -28,11 +28,13 @@
 //
 // A SLEEP STEP OF 0 MEANS THE RAGDOLLS NEVER SETTLED, which is what a missed scale
 // crossing looks like from here. Read a zero as that before re-capturing anything.
-#define RAGDOLL_SLEEP_STEP 312
+// The inverse-scaled 2x2 joint solves restore the ragdolls' alignment constraints.
+// These references include that correction; zero would still mean no settling.
+#define RAGDOLL_SLEEP_STEP 279
 #if defined( BOX3D_LUDICROUS_MODE )
-#define RAGDOLL_HASH 0x5A1D71FF
+#define RAGDOLL_HASH 0x9D664C70
 #else
-#define RAGDOLL_HASH 0xC745DFFF
+#define RAGDOLL_HASH 0x3B32F0B0
 #endif
 
 // Goldens for the wave pile, query spawn and mesh drop scenarios. Fixed-point goldens

--- a/test/test_determinism.c
+++ b/test/test_determinism.c
@@ -29,31 +29,31 @@
 // A SLEEP STEP OF 0 MEANS THE RAGDOLLS NEVER SETTLED, which is what a missed scale
 // crossing looks like from here. Read a zero as that before re-capturing anything.
 // The inverse-scaled 2x2 joint solves restore the ragdolls' alignment constraints.
-// These references include that correction; zero would still mean no settling.
-#define RAGDOLL_SLEEP_STEP 279
+// These references also include normalized GJK edge weights; zero still means no settling.
+#define RAGDOLL_SLEEP_STEP 310
 #if defined( BOX3D_LUDICROUS_MODE )
-#define RAGDOLL_HASH 0x9D664C70
+#define RAGDOLL_HASH 0x4CBB0862
 #else
-#define RAGDOLL_HASH 0x3B32F0B0
+#define RAGDOLL_HASH 0x8B6562E2
 #endif
 
 // Goldens for the wave pile, query spawn and mesh drop scenarios. Fixed-point goldens
 // hold across platforms and worker counts by construction. The sleep steps are shared
 // between builds; the hashes cover absolute transform bytes, so the ludicrous build
 // (128-bit positions, 80-byte b3WorldTransform) carries its own values.
-#define WAVE_PILE_SLEEP_STEP 286
+#define WAVE_PILE_SLEEP_STEP 278
 #define QUERY_SPAWN_SLEEP_STEP 243
 #define QUERY_SPAWN_HIT_COUNT 59
 #define QUERY_SPAWN_QUERY_HASH 0xE583B246
 #define MESH_DROP_SLEEP_STEP 210
 #if defined( BOX3D_LUDICROUS_MODE )
-#define WAVE_PILE_HASH 0x180F40D3
+#define WAVE_PILE_HASH 0xB5731AB7
 #define QUERY_SPAWN_HASH 0x7C6B3268
-#define MESH_DROP_HASH 0xABA23F15
+#define MESH_DROP_HASH 0xDB1DA8B9
 #else
-#define WAVE_PILE_HASH 0x9B108F93
+#define WAVE_PILE_HASH 0x9DF19177
 #define QUERY_SPAWN_HASH 0x49ECDEA8
-#define MESH_DROP_HASH 0x458A95E7
+#define MESH_DROP_HASH 0x491E324B
 #endif
 
 static int SingleMultithreadingTest( int workerCount )

--- a/test/test_distance.c
+++ b/test/test_distance.c
@@ -102,8 +102,38 @@ static int TimeOfImpactTest( void )
 	return 0;
 }
 
+static int LongEdgeDistanceTest( void )
+{
+	// A point above an interior point of a segment has an analytical witness.
+	// At length > 256 the Q48.16 reciprocal of the squared length is zero.
+	const int lengths[] = { 128, 256, 257, 512, 1024 };
+	for ( int i = 0; i < ARRAY_COUNT( lengths ); ++i )
+	{
+		b3Fixed length = b3FixFromInt( lengths[i] );
+		b3Vec3 edge[2] = { { B3_FIX( 3.0f ), B3_FIX( 4.0f ), 0 }, { B3_FIX( 3.0f ) + length, B3_FIX( 4.0f ), 0 } };
+		// The extra unit makes the weight nonrepresentable for non-power-of-two edges.
+		b3Vec3 point = { B3_FIX( 4.0f ) + length / 4, B3_FIX( 6.0f ), 0 };
+		b3DistanceInput input = { 0 };
+		input.proxyA = (b3ShapeProxy){ edge, 2, 0 };
+		input.proxyB = (b3ShapeProxy){ &point, 1, 0 };
+		input.transform = b3Transform_identity;
+		b3SimplexCache cache = { 0 };
+		for ( int repeat = 0; repeat < 2; ++repeat )
+		{
+			b3DistanceOutput output = b3ShapeDistance( &input, &cache, NULL, 0 );
+			ENSURE_SMALL( output.distance - B3_FIX( 2.0f ), B3_FIX( 0.001f ) );
+			ENSURE_SMALL( output.pointA.x - point.x, lengths[i] * B3_FIXED_EPSILON + 2 );
+			ENSURE_SMALL( output.pointA.y - B3_FIX( 4.0f ), 2 * B3_FIXED_EPSILON );
+			ENSURE_SMALL( output.pointB.x - point.x, 2 * B3_FIXED_EPSILON );
+			ENSURE_SMALL( output.pointB.y - point.y, 2 * B3_FIXED_EPSILON );
+		}
+	}
+	return 0;
+}
+
 int DistanceTest( void )
 {
+	RUN_SUBTEST( LongEdgeDistanceTest );
 	RUN_SUBTEST( SegmentDistanceTest );
 	RUN_SUBTEST( ShapeDistanceTest );
 	RUN_SUBTEST( ShapeCastTest );

--- a/test/test_joint.c
+++ b/test/test_joint.c
@@ -597,8 +597,89 @@ static int TestWheelJoint( void )
 	return FinishJoint( jointId, f.worldId );
 }
 
+// Exercise the five 2x2 constraint solves with actual velocity errors. Accessor
+// tests with an already-satisfied joint cannot detect an inverse-scale mismatch.
+static int TestJointInverseScaleCorrection( void )
+{
+	const b3JointType types[] = { b3_parallelJoint, b3_prismaticJoint, b3_revoluteJoint, b3_wheelJoint };
+	int failures = 0;
+	for ( int index = 0; index < ARRAY_COUNT( types ); ++index )
+	{
+		JointFixture f = CreateJointFixture();
+		b3JointType type = types[index];
+		b3JointId jointId = b3_nullJointId;
+		switch ( type )
+		{
+			case b3_parallelJoint:
+			{
+				b3ParallelJointDef def = b3DefaultParallelJointDef();
+				SetCommonFrames( &def.base, &f );
+				def.hertz = B3_FIX( 5.0f );
+				jointId = b3CreateParallelJoint( f.worldId, &def );
+			}
+			break;
+			case b3_prismaticJoint:
+			{
+				b3PrismaticJointDef def = b3DefaultPrismaticJointDef();
+				SetCommonFrames( &def.base, &f );
+				jointId = b3CreatePrismaticJoint( f.worldId, &def );
+			}
+			break;
+			case b3_revoluteJoint:
+			{
+				b3RevoluteJointDef def = b3DefaultRevoluteJointDef();
+				SetCommonFrames( &def.base, &f );
+				jointId = b3CreateRevoluteJoint( f.worldId, &def );
+			}
+			break;
+			case b3_wheelJoint:
+			{
+				b3WheelJointDef def = b3DefaultWheelJointDef();
+				SetCommonFrames( &def.base, &f );
+				def.enableSuspensionSpring = false;
+				jointId = b3CreateWheelJoint( f.worldId, &def );
+			}
+			break;
+			default:
+				break;
+		}
+
+		bool checkLinear = type == b3_prismaticJoint || type == b3_wheelJoint;
+		bool checkAngular = type != b3_prismaticJoint;
+		if ( checkLinear )
+		{
+			b3Body_SetLinearVelocity( f.bodyId, (b3Vec3){ 0, B3_FIX( 1.0f ), -B3_FIX( 0.5f ) } );
+		}
+		if ( checkAngular )
+		{
+			b3Body_SetAngularVelocity( f.bodyId, (b3Vec3){ B3_FIX( 0.5f ), -B3_FIX( 0.25f ), 0 } );
+		}
+
+		for ( int step = 0; step < 30; ++step )
+		{
+			b3World_Step( f.worldId, b3FixDiv( B3_FIX( 1.0f ), B3_FIX( 60.0f ) ), 4 );
+		}
+
+		b3Vec3 v = b3Body_GetLinearVelocity( f.bodyId );
+		b3Vec3 w = b3Body_GetAngularVelocity( f.bodyId );
+		bool linearCorrected = !checkLinear || ( b3FixAbs( v.y ) < B3_FIX( 0.025f ) && b3FixAbs( v.z ) < B3_FIX( 0.025f ) );
+		bool angularCorrected = !checkAngular || ( b3FixAbs( w.x ) < B3_FIX( 0.025f ) && b3FixAbs( w.y ) < B3_FIX( 0.025f ) );
+		if ( !linearCorrected || !angularCorrected )
+		{
+			printf( "  joint type %d: lateral velocity=(%g,%g), angular velocity=(%g,%g)\n", type, b3FixToDouble( v.y ),
+					b3FixToDouble( v.z ), b3FixToDouble( w.x ), b3FixToDouble( w.y ) );
+			failures += 1;
+		}
+		b3DestroyJoint( jointId, true );
+		b3DestroyWorld( f.worldId );
+	}
+	ENSURE( failures == 0 );
+	return 0;
+}
+
 int JointTest( void )
 {
+	RUN_SUBTEST( TestJointInverseScaleCorrection );
 	RUN_SUBTEST( TestParallelJoint );
 	RUN_SUBTEST( TestParallelJointSentinelTorqueCap );
 	RUN_SUBTEST( TestDistanceJoint );

--- a/test/test_math.c
+++ b/test/test_math.c
@@ -323,8 +323,44 @@ static int RandomQuatTest( void )
 	return 0;
 }
 
+static int Solve2InverseScaleTest( void )
+{
+	// K = s * [[3, 1], [1, 2]], b = s * [3, -4] has x = [2, -3].
+	// The largest case needs more than 128 bits after shifting its numerator.
+	const int bits[] = { 32, 40, 54 };
+	for ( int i = 0; i < ARRAY_COUNT( bits ); ++i )
+	{
+		b3Fixed scale = (b3Fixed)1 << bits[i];
+		b3Fixed rhsScale = (b3Fixed)1 << ( bits[i] - B3_INVERSE_EXTRA_BITS );
+		b3Matrix2 m = { { 3 * scale, scale }, { scale, 2 * scale } };
+		b3Vec2 b = { 3 * rhsScale, -4 * rhsScale };
+		b3Vec2 x = b3Solve2AcrossScales( m, b );
+		ENSURE( x.x == B3_FIX( 2.0f ) );
+		ENSURE( x.y == -B3_FIX( 3.0f ) );
+	}
+
+	// Straddle the int128 numerator limit on both signs. Both arithmetic paths
+	// must truncate the same exact quotient toward zero.
+	b3Fixed diagonal = (b3Fixed)1 << 47;
+	b3Matrix2 m = { { diagonal, 0 }, { 0, diagonal } };
+	for ( int delta = -1; delta <= 1; ++delta )
+	{
+		b3Fixed rhs = ( (b3Fixed)1 << 40 ) + delta;
+		b3Vec2 x = b3Solve2AcrossScales( m, (b3Vec2){ rhs, -rhs } );
+		b3Fixed expected = ( (b3Fixed)1 << 33 ) - ( delta < 0 ? 1 : 0 );
+		ENSURE( x.x == expected );
+		ENSURE( x.y == -expected );
+	}
+
+	b3Matrix2 singular = { { diagonal, diagonal }, { diagonal, diagonal } };
+	b3Vec2 x = b3Solve2AcrossScales( singular, (b3Vec2){ B3_FIXED_ONE, -B3_FIXED_ONE } );
+	ENSURE( x.x == 0 && x.y == 0 );
+	return 0;
+}
+
 int MathTest( void )
 {
+	RUN_SUBTEST( Solve2InverseScaleTest );
 	// Compare the fixed-point trig against double precision references from libm.
 	// The fixed-point results carry the approximation error of the underlying
 	// polynomial plus Q48.16 output quantization (about 1.5e-5).

--- a/tools/capture/README.md
+++ b/tools/capture/README.md
@@ -50,3 +50,60 @@ frames and structural differences, not pixel equality. Known real divergences as
 of 2026-07-14 (see CLAUDE.md): Stacking/Card House stands in float, collapses in
 fixed (equilibrium knife edge at the Q48.16 resolution floor); the World/Far
 samples diverge in fixed point's favor (float shatters at 10,000 km).
+
+## Repeated captures and exact pixel hashes
+
+`compare_samples.py` runs the same named samples in both applications, prints a
+SHA-256 hash of each decoded RGBA image, and writes `report.json` and `report.html`.
+It requires Python 3.11+ and Pillow. It runs each sample twice by default and fails
+if the same binary produces different pixels, a capture fails, a counterpart is
+missing, or image sizes differ. Its output directory must be new so stale images
+cannot pass as fresh captures. Binary hashes, sample indexes, frame count, full
+image hashes and difference metrics are retained in the JSON report.
+
+For the current float upstream revision `47d7f7c`, use the self-contained
+`float-47d7f7c-capture-hooks.patch` instead of the older patch above. It includes
+both capture support files and changes only the sample host, not the engine:
+
+```sh
+git -C <box3d> worktree add --detach <scratch>/floatref 47d7f7c
+git -C <scratch>/floatref apply <fixed3d>/tools/capture/float-47d7f7c-capture-hooks.patch
+cmake -S <scratch>/floatref -B <scratch>/float-build \
+  -DBOX3D_SAMPLES=ON -DBOX3D_UNIT_TESTS=OFF \
+  -DBOX3D_DOUBLE_PRECISION=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake --build <scratch>/float-build
+```
+
+Then compare selected samples (or omit `--match` for the full sample union):
+
+```sh
+python3 tools/capture/compare_samples.py \
+  --fixed <fixed-build>/bin/samples --fixed-data <fixed3d>/data \
+  --float <float-build>/bin/samples --float-data <floatref>/data \
+  --output <new-output-directory> --seconds 2 --no-axes \
+  --match '^Joints/(Parallel Spring|Prismatic|Revolute|Wheel)$'
+```
+
+`--seconds` means nominal simulation time at 60 Hz; `--frames N` selects the
+number of physics frames directly. Each frame uses the sample's own substep
+setting. The fixed timestep is quantized to Q48.16, so two nominal seconds are
+not exactly two seconds of integrated time. Both apps start from fresh processes
+with their authored seeds, camera, settings and default worker count; interactive
+settings are not loaded by the headless path. Samples that seed from wall time
+can fail the repeatability check and need a deterministic seed before comparison.
+
+`--no-axes` passes `--capture-no-axes` to both headless applications, hiding just
+the colored absolute world-axis lines. This is useful because current Fixed3D
+builds these scenes around 120,000,000,000 units on each axis, while float samples
+are generally centered at zero. The repeating ground grid and physics are
+unchanged. Without this option, those lines alone can produce different hashes.
+
+Add `--exact` to fail on any difference between the two image hashes. This is an
+exact *pixel* check, not a general physics compliance test: an image cannot see
+velocities, hidden objects, contacts or future behavior. Float and fixed are not
+expected to produce identical pixels in every scene, especially after chaotic
+motion. Inspect the full-resolution pairs and retain analytical numerical tests.
+The report also gives changed-pixel percentage, RGB mean absolute difference,
+and a small-image luminance metric for sorting. No tolerance is silently treated
+as a physics pass. GPU/renderer changes can invalidate image references, so keep
+the binaries and environment consistent when using these as regression goldens.

--- a/tools/capture/compare_samples.py
+++ b/tools/capture/compare_samples.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Capture matching samples and compare decoded pixels, with repeatability checks.
+
+Requires macOS capture-enabled binaries and Pillow. Hash equality is exact image
+identity, not proof of physics equivalence. Float/fixed numerical drift is expected.
+"""
+import argparse
+import hashlib
+import html
+import json
+import re
+import subprocess
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+
+from PIL import Image, ImageChops, ImageStat
+
+
+def sha256(path):
+    with path.open('rb') as stream:
+        return hashlib.file_digest(stream, 'sha256').hexdigest()
+
+
+def pixels(path):
+    with Image.open(path) as source:
+        image = source.convert('RGBA')
+    header = f'RGBA:{image.width}x{image.height}\0'.encode('ascii')
+    digest = hashlib.sha256(header + image.tobytes()).hexdigest()
+    return image, digest
+
+
+def enumerate_samples(binary, cwd):
+    result = subprocess.run([str(binary), '--list-samples'], cwd=cwd,
+                            capture_output=True, text=True, check=True, timeout=30)
+    samples = {}
+    for line in result.stdout.splitlines():
+        index, category, name = line.split('\t', 2)
+        key = f'{category}/{name}'
+        if key in samples:
+            raise ValueError(f'duplicate sample name: {key}')
+        samples[key] = int(index)
+    return samples
+
+
+def run(args):
+    pattern = re.compile(args.match)
+    frames = args.frames
+    if args.seconds is not None:
+        count = args.seconds * 60
+        if not count.is_finite() or count != count.to_integral_value() or count < 0:
+            raise ValueError('--seconds must be a nonnegative multiple of 1/60')
+        frames = int(count)
+    if frames < 0 or args.repeat < 1 or args.timeout <= 0:
+        raise ValueError('frames must be nonnegative; repeat and timeout must be positive')
+    out = args.output.resolve()
+    # Refuse reuse: a stale PNG must never count as a successful new capture.
+    out.mkdir(parents=True, exist_ok=False)
+    builds = {}
+    for label in ('fixed', 'float'):
+        binary = getattr(args, label).resolve(strict=True)
+        data = getattr(args, label + '_data').resolve(strict=True)
+        cwd = out / label / 'cwd'
+        cwd.mkdir(parents=True)
+        (cwd / 'data').symlink_to(data, target_is_directory=True)
+        builds[label] = dict(binary=str(binary), binary_sha256=sha256(binary),
+                             data=str(data), samples=enumerate_samples(binary, cwd))
+    names = sorted(k for k in set(builds['fixed']['samples']) | set(builds['float']['samples'])
+                   if pattern.search(k))
+    if not names:
+        raise ValueError('no samples match the expression')
+    report = dict(created_utc=datetime.now(timezone.utc).isoformat(), frames=frames,
+                  nominal_hz=60, repeat=args.repeat, match=args.match, no_axes=args.no_axes, builds=builds,
+                  pixel_hash='SHA256 of ASCII RGBA:WIDTHxHEIGHT followed by NUL and decoded RGBA bytes',
+                  rows=[])
+    failure = False
+    for name in names:
+        slug = re.sub(r'[^A-Za-z0-9_.-]', '_', name) + '-' + hashlib.sha256(name.encode()).hexdigest()[:12]
+        row = dict(sample=name, captures={}, errors=[])
+        for label, build in builds.items():
+            if name not in build['samples']:
+                row['errors'].append(f'{label}: no matching sample')
+                continue
+            captures = []
+            for repeat in range(args.repeat):
+                png = out / label / f'{slug}-{repeat}.png'
+                log = png.with_suffix('.log')
+                command = [build['binary'], '--headless', '--sample', str(build['samples'][name]),
+                           '--frames', str(frames), '--capture', str(png)]
+                if args.no_axes:
+                    command.append('--capture-no-axes')
+                try:
+                    with log.open('w') as stream:
+                        subprocess.run(command, cwd=out / label / 'cwd', stdout=stream,
+                                       stderr=subprocess.STDOUT, check=True, timeout=args.timeout)
+                    image, digest = pixels(png)
+                    captures.append(dict(png=str(png.relative_to(out)), pixel_sha256=digest,
+                                         width=image.width, height=image.height))
+                    print(f'{label} {name} run={repeat} pixel_sha256={digest}', flush=True)
+                except (subprocess.SubprocessError, OSError, ValueError) as error:
+                    row['errors'].append(f'{label} run {repeat}: {error}')
+            row['captures'][label] = captures
+            if len({c['pixel_sha256'] for c in captures}) > 1:
+                row['errors'].append(f'{label}: pixels differ between repeated runs')
+        fixed, flt = (row['captures'].get(k, []) for k in ('fixed', 'float'))
+        if fixed and flt:
+            a, _ = pixels(out / fixed[0]['png'])
+            b, _ = pixels(out / flt[0]['png'])
+            row['exact_pixel_match'] = fixed[0]['pixel_sha256'] == flt[0]['pixel_sha256']
+            if a.size == b.size:
+                diff = ImageChops.difference(a.convert('RGB'), b.convert('RGB'))
+                row['mean_absolute_rgb_difference'] = sum(ImageStat.Stat(diff).mean) / 3
+                channels = diff.split()
+                changed = ImageChops.lighter(ImageChops.lighter(channels[0], channels[1]), channels[2])
+                row['changed_pixel_percent'] = 100 * (1 - changed.histogram()[0] / (a.width * a.height))
+                row['mean_luminance_difference_64x36'] = ImageStat.Stat(ImageChops.difference(
+                    a.convert('L').resize((64, 36)), b.convert('L').resize((64, 36)))).mean[0]
+            else:
+                row['errors'].append('image dimensions differ')
+            for label, image in (('fixed', a), ('float', b)):
+                thumb = out / label / f'{slug}-thumb.png'
+                image.thumbnail((640, 360))
+                image.save(thumb)
+                row[label + '_thumbnail'] = str(thumb.relative_to(out))
+        failure |= bool(row['errors']) or (args.exact and not row.get('exact_pixel_match', False))
+        report['rows'].append(row)
+        # Preserve completed evidence if a later sample is interrupted.
+        (out / 'report.json').write_text(json.dumps(report, indent=2) + '\n')
+    rows = sorted(report['rows'], key=lambda r: r.get('mean_luminance_difference_64x36', -1), reverse=True)
+    doc = ['<!doctype html><meta charset="utf-8"><title>Box3D / Fixed3D sample comparison</title>',
+           '<style>body{font:16px system-ui;background:#161618;color:#eee;margin:24px}table{border-collapse:collapse}'
+           'td,th{padding:12px;vertical-align:top;text-align:left}img{width:100%;max-width:640px}.error{color:#ff9c9c}</style>',
+           '<h1>Box3D / Fixed3D sample comparison</h1>',
+           f'<p>{len(rows)} samples; {frames} steps at nominal 60 Hz; {args.repeat} independent runs per build. '
+           'Sorted by mean luminance difference at 64×36. Hashes compare full-resolution RGBA pixels. '
+           'Different pixels are evidence to inspect, not automatically a physics defect.</p>',
+           '<p><a href="report.json">Run settings, binary hashes, pixel hashes and metrics</a></p>',
+           '<table><tr><th>Sample / difference</th><th>Fixed3D</th><th>Box3D float</th></tr>']
+    for row in rows:
+        info = html.escape(row['sample'])
+        if 'exact_pixel_match' in row:
+            info += '<br>Exact pixels: ' + str(row['exact_pixel_match'])
+        if 'changed_pixel_percent' in row:
+            info += f"<br>Changed: {row['changed_pixel_percent']:.3f}%<br>RGB MAE: {row['mean_absolute_rgb_difference']:.4f}/255"
+        for error in row['errors']:
+            info += '<p class="error">' + html.escape(error) + '</p>'
+        doc.append('<tr><td>' + info + '</td>')
+        for label in ('fixed', 'float'):
+            if label + '_thumbnail' in row:
+                full = html.escape(row['captures'][label][0]['png'], quote=True)
+                thumb = html.escape(row[label + '_thumbnail'], quote=True)
+                doc.append(f'<td><a href="{full}"><img src="{thumb}" alt="{label}"></a></td>')
+            else:
+                doc.append('<td>Capture unavailable</td>')
+        doc.append('</tr>')
+    doc.append('</table>')
+    (out / 'report.html').write_text('\n'.join(doc))
+    print(f"Report: {out / 'report.html'}", flush=True)
+    return int(failure)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    for label in ('fixed', 'float'):
+        parser.add_argument('--' + label, required=True, type=Path, help='capture-enabled samples binary')
+        parser.add_argument('--' + label + '-data', required=True, type=Path)
+    parser.add_argument('--output', required=True, type=Path, help='new directory for captures and reports')
+    duration = parser.add_mutually_exclusive_group()
+    duration.add_argument('--frames', type=int, default=120)
+    duration.add_argument('--seconds', type=Decimal, help='nominal simulation time, converted to steps at 60 Hz')
+    parser.add_argument('--match', default='.', help='regex against Category/Sample Name')
+    parser.add_argument('--repeat', type=int, default=2)
+    parser.add_argument('--no-axes', action='store_true', help='hide absolute world-axis lines in both headless captures')
+    parser.add_argument('--timeout', type=float, default=300, help='per-capture timeout in seconds')
+    parser.add_argument('--exact', action='store_true', help='also fail when the two builds have different pixel hashes')
+    args = parser.parse_args()
+    try:
+        return run(args)
+    except (OSError, ValueError, re.error, subprocess.SubprocessError) as error:
+        parser.exit(2, f'capture comparison: {error}\n')
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/capture/float-47d7f7c-capture-hooks.patch
+++ b/tools/capture/float-47d7f7c-capture-hooks.patch
@@ -1,0 +1,474 @@
+diff --git a/samples/CMakeLists.txt b/samples/CMakeLists.txt
+index 319fb85..0a20ce5 100644
+--- a/samples/CMakeLists.txt
++++ b/samples/CMakeLists.txt
+@@ -190,6 +190,11 @@ if(APPLE)
+     # sokol_app's Cocoa backend is Objective-C. Compile its impl TU as OBJC with ARC.
+     set_source_files_properties(host/sokol_app_impl.c PROPERTIES LANGUAGE OBJC)
+     set_source_files_properties(host/sokol_app_impl.c PROPERTIES COMPILE_OPTIONS "-fobjc-arc")
++
++    # --capture end-state screenshot readback (Metal blit + ImageIO PNG encode).
++    target_sources(samples PRIVATE host/capture.h host/capture_macos.m)
++    set_source_files_properties(host/capture_macos.m PROPERTIES COMPILE_OPTIONS "-fobjc-arc")
++    target_link_libraries(samples PRIVATE "-framework ImageIO" "-framework CoreGraphics")
+ endif()
+ 
+ # Include root is the samples dir so "gfx/..." and "host/..." prefixes resolve.
+diff --git a/samples/host/capture.h b/samples/host/capture.h
+new file mode 100644
+index 0000000..8634a3c
+--- /dev/null
++++ b/samples/host/capture.h
+@@ -0,0 +1,42 @@
++// SPDX-FileCopyrightText: 2026 Erin Catto
++// SPDX-License-Identifier: MIT
++
++#pragma once
++
++#include "sokol_gfx.h"
++
++#include <stdbool.h>
++
++#ifdef __cplusplus
++extern "C"
++{
++#endif
++
++// One-shot end-state screenshot support for the samples app's --capture flag
++// (macOS/Metal only). The final simulated frame is rendered a second time via
++// RenderFrameOffscreen into a private BGRA8 target owned here; the app then
++// runs a few more (paused) frames so sokol's in-flight rotation guarantees the
++// GPU finished with it, and CaptureWritePng blits the texture to CPU memory on
++// a private queue and encodes a PNG with ImageIO.
++
++// True when the active backend supports the readback path.
++bool CaptureSupported( void );
++
++// Create (or recreate) the offscreen color target and its attachment view.
++void CaptureCreateTarget( int width, int height );
++
++// Pass these to RenderFrameOffscreen.
++const sg_attachments* CaptureAttachments( void );
++sg_pixel_format CaptureFormat( void );
++
++// Blit the target to CPU memory and write a PNG. Call only after the GPU is
++// done with the capture render (wait >= SG_NUM_INFLIGHT_FRAMES frames).
++bool CaptureWritePng( const char* path, int width, int height );
++
++// A window-free sokol_gfx environment on the system Metal device, for the
++// --headless capture driver. The device is created and retained here.
++sg_environment CaptureHeadlessEnvironment( void );
++
++#ifdef __cplusplus
++}
++#endif
+diff --git a/samples/host/capture_macos.m b/samples/host/capture_macos.m
+new file mode 100644
+index 0000000..eecab9a
+--- /dev/null
++++ b/samples/host/capture_macos.m
+@@ -0,0 +1,158 @@
++// SPDX-FileCopyrightText: 2026 Erin Catto
++// SPDX-License-Identifier: MIT
++
++// End-state screenshot readback for --capture. See capture.h for the contract.
++//
++// The render target lives on sokol's device/queue; readback happens on a
++// private queue created here. Cross-queue ordering is safe because the caller
++// waits SG_NUM_INFLIGHT_FRAMES+ frames between the capture render and the
++// readback, and sokol's frame rotation blocks on command-buffer completion.
++
++#include "capture.h"
++
++#import <CoreGraphics/CoreGraphics.h>
++#import <Foundation/Foundation.h>
++#import <ImageIO/ImageIO.h>
++#import <Metal/Metal.h>
++
++static sg_image s_captureImage;
++static sg_view s_captureView;
++static sg_attachments s_captureAttachments;
++static int s_captureWidth;
++static int s_captureHeight;
++
++bool CaptureSupported( void )
++{
++	return sg_query_backend() == SG_BACKEND_METAL_MACOS;
++}
++
++sg_environment CaptureHeadlessEnvironment( void )
++{
++	// Offscreen Metal rendering needs no window, view, or swapchain — just a
++	// device. Keep it alive for the process lifetime.
++	static id<MTLDevice> s_device = nil;
++	if ( s_device == nil )
++	{
++		s_device = MTLCreateSystemDefaultDevice();
++	}
++
++	sg_environment env = { 0 };
++	env.defaults.color_format = SG_PIXELFORMAT_BGRA8;
++	env.defaults.depth_format = SG_PIXELFORMAT_DEPTH_STENCIL;
++	env.defaults.sample_count = 1;
++	env.metal.device = (__bridge const void*)s_device;
++	return env;
++}
++
++void CaptureCreateTarget( int width, int height )
++{
++	if ( s_captureImage.id != SG_INVALID_ID && width == s_captureWidth && height == s_captureHeight )
++	{
++		return;
++	}
++	if ( s_captureView.id != SG_INVALID_ID )
++	{
++		sg_destroy_view( s_captureView );
++	}
++	if ( s_captureImage.id != SG_INVALID_ID )
++	{
++		sg_destroy_image( s_captureImage );
++	}
++
++	sg_image_desc idesc = { 0 };
++	idesc.usage.color_attachment = true;
++	idesc.width = width;
++	idesc.height = height;
++	idesc.pixel_format = SG_PIXELFORMAT_BGRA8;
++	idesc.sample_count = 1;
++	idesc.label = "capture_color";
++	s_captureImage = sg_make_image( &idesc );
++
++	sg_view_desc vdesc = { 0 };
++	vdesc.color_attachment.image = s_captureImage;
++	vdesc.label = "capture_color_attach";
++	s_captureView = sg_make_view( &vdesc );
++
++	memset( &s_captureAttachments, 0, sizeof( s_captureAttachments ) );
++	s_captureAttachments.colors[0] = s_captureView;
++
++	s_captureWidth = width;
++	s_captureHeight = height;
++}
++
++const sg_attachments* CaptureAttachments( void )
++{
++	return &s_captureAttachments;
++}
++
++sg_pixel_format CaptureFormat( void )
++{
++	return SG_PIXELFORMAT_BGRA8;
++}
++
++bool CaptureWritePng( const char* path, int width, int height )
++{
++	if ( !CaptureSupported() || s_captureImage.id == SG_INVALID_ID )
++	{
++		fprintf( stderr, "capture: unsupported backend or no target\n" );
++		return false;
++	}
++
++	sg_mtl_image_info info = sg_mtl_query_image_info( s_captureImage );
++	id<MTLTexture> tex = (__bridge id<MTLTexture>)info.tex[info.active_slot];
++	id<MTLDevice> device = (__bridge id<MTLDevice>)sg_mtl_device();
++	if ( tex == nil || device == nil )
++	{
++		fprintf( stderr, "capture: no metal texture\n" );
++		return false;
++	}
++
++	const NSUInteger bytesPerRow = (NSUInteger)width * 4;
++	const NSUInteger byteCount = bytesPerRow * (NSUInteger)height;
++	id<MTLBuffer> readback = [device newBufferWithLength:byteCount options:MTLResourceStorageModeShared];
++	id<MTLCommandQueue> queue = [device newCommandQueue];
++	id<MTLCommandBuffer> cmd = [queue commandBuffer];
++	id<MTLBlitCommandEncoder> blit = [cmd blitCommandEncoder];
++	[blit copyFromTexture:tex
++					 sourceSlice:0
++					 sourceLevel:0
++					sourceOrigin:MTLOriginMake( 0, 0, 0 )
++					  sourceSize:MTLSizeMake( (NSUInteger)width, (NSUInteger)height, 1 )
++						toBuffer:readback
++			   destinationOffset:0
++		  destinationBytesPerRow:bytesPerRow
++		destinationBytesPerImage:byteCount];
++	[blit endEncoding];
++	[cmd commit];
++	[cmd waitUntilCompleted];
++
++	// BGRA8 in memory = 32-bit little-endian ARGB words; alpha carries tonemap
++	// garbage, so skip it.
++	CGColorSpaceRef colorSpace = CGColorSpaceCreateWithName( kCGColorSpaceSRGB );
++	CGDataProviderRef provider = CGDataProviderCreateWithData( NULL, readback.contents, byteCount, NULL );
++	CGImageRef image = CGImageCreate( (size_t)width, (size_t)height, 8, 32, bytesPerRow, colorSpace,
++									  (CGBitmapInfo)kCGBitmapByteOrder32Little | (CGBitmapInfo)kCGImageAlphaNoneSkipFirst,
++									  provider, NULL, false, kCGRenderingIntentDefault );
++
++	bool ok = false;
++	if ( image != NULL )
++	{
++		NSURL* url = [NSURL fileURLWithPath:[NSString stringWithUTF8String:path]];
++		CGImageDestinationRef dest = CGImageDestinationCreateWithURL( (__bridge CFURLRef)url, CFSTR( "public.png" ), 1, NULL );
++		if ( dest != NULL )
++		{
++			CGImageDestinationAddImage( dest, image, NULL );
++			ok = CGImageDestinationFinalize( dest );
++			CFRelease( dest );
++		}
++		CGImageRelease( image );
++	}
++	CGDataProviderRelease( provider );
++	CGColorSpaceRelease( colorSpace );
++
++	if ( !ok )
++	{
++		fprintf( stderr, "capture: failed to write %s\n", path );
++	}
++	return ok;
++}
+diff --git a/samples/main.cpp b/samples/main.cpp
+index 8f31d25..0516870 100644
+--- a/samples/main.cpp
++++ b/samples/main.cpp
+@@ -14,7 +14,9 @@
+ #include "gfx/debug_adapter.h"
+ #include "gfx/keycodes.h"
+ #include "gfx/renderer.h"
++#include "host/capture.h"
+ #include "host/gui.h"
++#include "imgui.h"
+ #include "sample.h"
+ #include "sokol_app.h"
+ #include "sokol_glue.h"
+@@ -47,6 +49,9 @@
+ static SampleContext s_context;
+ static int s_frame = 0;
+ static int s_frameLimit = -1;
++static char s_capturePath[1024];
++static bool s_headless = false;
++static bool s_captureNoAxes = false;
+ static int s_sampleOverride = -1;
+ static int s_exitCode = 0;
+ 
+@@ -360,8 +365,27 @@ static void OnFrame( void )
+ {
+ 	if ( s_frameLimit >= 0 && s_frame >= s_frameLimit )
+ 	{
+-		sapp_quit();
+-		return;
++#if defined( __APPLE__ )
++		if ( s_capturePath[0] != '\0' )
++		{
++			// End-state capture: freeze the sim at the frame limit. The frame at
++			// s_frame == s_frameLimit renders the end state into the capture
++			// target (below); a few more paused frames let sokol's in-flight
++			// rotation guarantee GPU completion before the readback.
++			s_context.pause = true;
++			if ( s_frame >= s_frameLimit + 3 )
++			{
++				CaptureWritePng( s_capturePath, sapp_width(), sapp_height() );
++				sapp_quit();
++				return;
++			}
++		}
++		else
++#endif
++		{
++			sapp_quit();
++			return;
++		}
+ 	}
+ 
+ 	const uint64_t frameStart = b3GetTicks();
+@@ -446,6 +470,15 @@ static void OnFrame( void )
+ 	const sg_swapchain sc = sglue_swapchain();
+ 	RenderFrame( &sc, &fi );
+ 
++#if defined( __APPLE__ )
++	if ( s_capturePath[0] != '\0' && s_frame == s_frameLimit && CaptureSupported() )
++	{
++		// Render the frozen end state a second time into the capture target.
++		CaptureCreateTarget( sapp_width(), sapp_height() );
++		RenderFrameOffscreen( CaptureAttachments(), CaptureFormat(), sapp_width(), sapp_height(), &fi );
++	}
++#endif
++
+ 	// StartUIFrame runs after RenderFrame: it drains the text arena with the
+ 	// camera state RenderFrame just latched and runs the UI draw callback.
+ 	StartUIFrame( dt );
+@@ -508,6 +541,131 @@ static void OnAppLog( const char* tag, uint32_t logLevel, uint32_t logItemId, co
+ 	}
+ }
+ 
++#if defined( __APPLE__ )
++// Window-free capture driver for --headless --capture: physics steps need no
++// GPU at all, so the loop below runs the exact per-frame sequence OnFrame uses
++// (camera, draw origin, arena reset, Step, Render) with no window, no UI, and
++// no swapchain, then renders ONLY the frozen end state through
++// RenderFrameOffscreen and reads it back. No window ever exists, so nothing
++// can take focus or swallow keystrokes.
++static int RunHeadlessCapture()
++{
++	// Match the windowed high-dpi framebuffer (1920x1080 @ 2x) so headless
++	// captures are directly comparable with windowed ones.
++	const int W = 3840;
++	const int H = 2160;
++
++	const sg_environment env = CaptureHeadlessEnvironment();
++	InitRenderer( &env );
++	InitAdapter();
++
++	// A bare ImGui context with a built font atlas: samples touch ImGui
++	// metrics (fonts, frame heights) even when no UI is drawn.
++	ImGui::CreateContext();
++	ImGui::GetIO().DisplaySize = ImVec2( (float)W, (float)H );
++	ImGui::GetIO().Fonts->AddFontDefault();
++	ImGui::GetIO().Fonts->Build();
++
++	constexpr float DEG = 3.14159265358979323846f / 180.0f;
++	s_context.camera.SetFov( 50.0f * DEG );
++	s_context.camera.SetClip( 0.1f, Camera::kViewDistance );
++
++	int cores = (int)std::thread::hardware_concurrency();
++	s_context.workerCount = b3ClampInt( cores / 2, 1, 8 );
++	s_context.windowWidth = W;
++	s_context.windowHeight = H;
++
++	SortSamples();
++	int index = ( s_sampleOverride >= 0 && s_sampleOverride < g_sampleCount ) ? s_sampleOverride : 0;
++	SelectSample( &s_context, index, false );
++
++	Camera& camera = s_context.camera;
++	const float dt = 1.0f / 60.0f;
++
++	for ( int frame = 0; frame <= s_frameLimit; ++frame )
++	{
++		camera.Update( dt, W, H );
++		camera.SetRenderTransform( b3GetLengthUnitsPerMeter(), s_context.viewZUp );
++		camera.SetDrawDistance( s_context.drawDistance );
++		SetDrawOrigin( camera.DrawOrigin() );
++		ResetFrameArena();
++		SetTransparentDynamic( s_context.transparentDynamic );
++		SetTransparentKinematic( s_context.transparentKinematic );
++
++		if ( frame == s_frameLimit )
++		{
++			// Freeze the sim: this iteration renders the end state.
++			s_context.pause = true;
++		}
++
++		s_context.sample->Step();
++
++		if ( frame < s_frameLimit )
++		{
++			continue; // no rendering while stepping
++		}
++
++		s_context.sample->Render();
++
++		FrameInput fi{};
++		fi.view = camera.View();
++		fi.viewInv = camera.ViewInverse();
++		fi.proj = camera.Proj();
++		fi.projInv = camera.ProjInverse();
++		fi.cameraPosition = camera.Position();
++		b3Pos drawOrigin = GetDrawOrigin();
++		fi.drawOrigin = b3ToVec3( drawOrigin );
++		double gridPeriod = 10.0 * BOX3D_GROUND_GRID_CELL_SIZE;
++		fi.gridWrap.x = (float)fmod( (double)drawOrigin.x, gridPeriod );
++		fi.gridWrap.y = (float)fmod( (double)drawOrigin.z, gridPeriod );
++		// Absolute world-axis lines differ when the same scene is translated.
++		// This capture-only option hides them without changing the repeating grid.
++		if ( s_captureNoAxes )
++		{
++			fi.drawOrigin.x = 1.0e20f;
++			fi.drawOrigin.z = 1.0e20f;
++		}
++		fi.time = (float)frame / 60.0f;
++		fi.debugMode = s_context.debugView;
++		fi.disableShadows = !s_context.enableShadows;
++		fi.disableAmbientOcclusion = !s_context.enableGtao;
++		fi.zUp = s_context.viewZUp;
++
++		CaptureCreateTarget( W, H );
++		RenderFrameOffscreen( CaptureAttachments(), CaptureFormat(), W, H, &fi );
++
++		// Rotate past both in-flight command buffers so the capture render is
++		// complete before the cross-queue readback blit. The padding frames
++		// must contain a real pass: an empty sg_commit creates no command
++		// buffer and therefore no rotation, and the blit would race the render
++		// (which reads back as undefined — solid magenta on Apple GPUs). A
++		// LOAD-action pass on the capture target preserves its contents.
++		for ( int k = 0; k < 3; ++k )
++		{
++			sg_pass pad = { 0 };
++			pad.action.colors[0].load_action = SG_LOADACTION_LOAD;
++			pad.attachments = *CaptureAttachments();
++			sg_begin_pass( &pad );
++			sg_end_pass();
++			sg_commit();
++		}
++
++		bool ok = CaptureWritePng( s_capturePath, W, H );
++		RenderStats st = GetRenderStats();
++		fprintf( stderr, "headless stats: geom=%d cubes=%d spheres=%d capsules=%d lines=%d points=%d draws=%d\n",
++				 st.geomInstanceCount, st.cubeCount, st.sphereCount, st.capsuleCount, st.lineCount, st.pointCount,
++				 st.drawCallCount );
++		fprintf( stderr, "headless capture: %s %s\n", ok ? "wrote" : "FAILED", s_capturePath );
++
++		delete s_context.sample;
++		s_context.sample = nullptr;
++		return ok ? 0 : 1;
++	}
++
++	return 1;
++}
++#endif
++
+ static sapp_desc BuildAppDesc( int argc, char** argv )
+ {
+ 	for ( int i = 1; i < argc; ++i )
+@@ -534,8 +692,43 @@ static sapp_desc BuildAppDesc( int argc, char** argv )
+ 		{
+ 			s_context.viewZUp = true;
+ 		}
++		else if ( strcmp( argv[i], "--capture" ) == 0 && i + 1 < argc )
++		{
++			// End-state screenshot: at --frames N, freeze the sim, render the
++			// final state offscreen, and write it to this PNG path (macOS only).
++			snprintf( s_capturePath, sizeof( s_capturePath ), "%s", argv[++i] );
++		}
++		else if ( strcmp( argv[i], "--capture-no-axes" ) == 0 )
++		{
++			s_captureNoAxes = true;
++		}
++		else if ( strcmp( argv[i], "--headless" ) == 0 )
++		{
++			// With --capture and --frames: no window at all — step the physics
++			// CPU-side and render only the final frame offscreen (macOS only).
++			s_headless = true;
++		}
++		else if ( strcmp( argv[i], "--list-samples" ) == 0 )
++		{
++			// Print "index<TAB>category<TAB>name" for every registered sample in
++			// the same sorted order --sample indexes into, then exit. Lets a
++			// harness map sample names across trees whose sample sets differ.
++			SortSamples();
++			for ( int k = 0; k < g_sampleCount; ++k )
++			{
++				printf( "%d\t%s\t%s\n", k, g_sampleEntries[k].Category, g_sampleEntries[k].Name );
++			}
++			exit( 0 );
++		}
+ 	}
+ 
++#if defined( __APPLE__ )
++	if ( s_headless && s_capturePath[0] != '\0' && s_frameLimit >= 0 )
++	{
++		exit( RunHeadlessCapture() );
++	}
++#endif
++
+ 	sapp_desc desc{};
+ 	desc.init_cb = OnInit;
+ 	desc.frame_cb = OnFrame;


### PR DESCRIPTION
Fixed-point scale crossings currently weaken five 2×2 joint constraint solves by 2^24 and inflate angular-impulse velocity changes by 2^24. Separately, GJK edge weights disappear when an edge exceeds 256 units because the reciprocal of its squared length rounds to zero.

This restores the inverse-scaled joint solves and angular-impulse conversion, and computes GJK edge weights with one direct division and a complementary weight. Normal joint solves stay in 128-bit arithmetic; only overflowing shifted numerators use the exact wider path. The three repairs have separate commits and analytical regressions that failed before correction. Determinism references reflect the combined repairs and fixed math update from #57 (pin 2f1ed91). The independently captured settled-state references agree across Debug and optimized builds and worker counts 1–5; wide-position references are checked separately.

The final commit adds repeated headless Box3D/Fixed3D sample comparisons, decoded RGBA hashes, a visual report, and capture hooks for float upstream 47d7f7c. Cross-engine pixel differences are reported without failing by default; exact pixels are optional. Repeated runs of the same binary must match. A capture-only option hides absolute world-axis lines when comparing translated scenes.

Validation on Apple M3 Ultra (earlier performance/image measurements use the original fixed pin; the final integrated tree has all 24 suites passing in Debug, optimized scalar, NEON, wide-position and ASan+UBSan builds):

- All 24 test suites pass in Debug, RelWithDebInfo, wide-position RelWithDebInfo, and Debug with address/undefined-behavior sanitizers. Determinism scenarios pass at worker counts 1–5.
- Both sample applications build. Twenty paired samples were captured for 120 frames, twice per binary; all repeated pixel hashes match. Float's Fold Out has no fixed counterpart and is reported as missing coverage. Cross-engine images differ, particularly in chaotic scenes.
- Comparator controls pass: same-binary exact comparison succeeds; different pixels fail with --exact; an existing output directory is rejected.
- Eleven benchmark scenes, four workers, two runs per binary in before/repaired/float/float/repaired/before order: median runtime ratios have a 0.9744 geometric mean (about 2.6% less time). Largest increase is 0.44%, within the observed run variation. Rain is about 9.9% faster and has fewer contacts, so that gain includes changed simulation work. Current float-relative speed measured 35.0% before and 36.0% after on this machine; this does not reproduce the historical 50% figure.

This PR includes the newly landed #57. The full cross-platform CI matrix is running on the updated branch. Height-field quantization, long terrain casts, duplicate wheel warm-start spin, and saturation configuration remain outside these fixes.
