### PR TITLE
Speed up bounded scalar hull-edge rejection

### DIFF
--- a/benchmark/2026-09-07-scalar-edge-reject.json
+++ b/benchmark/2026-09-07-scalar-edge-reject.json
@@ -1,426 +1,686 @@
 {
   "base_commit": "0b27fe38879e0dc45bddf447b92fb9c23c8e3db0",
-  "implementation_commit": "d010dd00a45b5d8661a77bb8c977cd51aa88d819",
+  "implementation_commit": "bb6f23cd5f5dd17023d03f257fdfa7097122e4b6",
   "fixed_pin": "a0fa624d739790844af34499381c55abaa65180f",
-  "caution": "Shared workstation noise affected the full sweep and short runs. Only the Convex Pile gain was consistent across all grouped before/after trials. Do not infer an overall speedup from the full-sweep geometric mean.",
-  "full_sweep": {
-    "method": "Before/after/after/before, four workers, default scalar RelWithDebInfo with thin LTO on Apple M3 Ultra",
-    "binaries": {
-      "before": {
-        "path": "/Users/glenn/Documents/ChatGPT/stella 2/work/fixed3d-review/_bench/benchmark-corrected",
-        "sha256": "e77837f4ff560df982bf9b7bd7cc621700955fba8620f79a9a82a96e24932c36"
-      },
-      "after": {
-        "path": "/Users/glenn/Documents/ChatGPT/stella 2/work/fixed3d-review/_bench/optimization/benchmark-int64",
-        "sha256": "c51aed76142ccb068a89cbbd57c1e37c28f338f825ddb10fb9c2ebda26c96cc2"
-      }
+  "configuration": "Apple M3 Ultra, arm64 Apple Clang, RelWithDebInfo, -O2, thin LTO, four workers, NEON off",
+  "caution": "This is a shared workstation. Only the Convex Pile gain was consistent across all grouped before/after trials. Smaller scene differences are inconclusive.",
+  "binaries": {
+    "before": {
+      "path": "/Users/glenn/Documents/ChatGPT/stella 2/work/fixed3d-review/_bench/benchmark-corrected",
+      "sha256": "e77837f4ff560df982bf9b7bd7cc621700955fba8620f79a9a82a96e24932c36"
     },
-    "rows": [
-      {
-        "scene": "convex_pile",
-        "times_ms": {
-          "before": [
-            14511.9,
-            14997.0
-          ],
-          "after": [
-            13037.2,
-            12944.7
-          ]
-        },
-        "medians_ms": {
-          "before": 14754.45,
-          "after": 12990.95
-        },
-        "runtime_change_percent": -11.952326247335554,
-        "counters_match": true
-      },
-      {
-        "scene": "joint_grid",
-        "times_ms": {
-          "before": [
-            932.465,
-            1003.53
-          ],
-          "after": [
-            938.935,
-            923.022
-          ]
-        },
-        "medians_ms": {
-          "before": 967.9975,
-          "after": 930.9784999999999
-        },
-        "runtime_change_percent": -3.8242867362777266,
-        "counters_match": true
-      },
-      {
-        "scene": "junkyard",
-        "times_ms": {
-          "before": [
-            10642.3,
-            12040.2
-          ],
-          "after": [
-            10780.1,
-            12420.1
-          ]
-        },
-        "medians_ms": {
-          "before": 11341.25,
-          "after": 11600.1
-        },
-        "runtime_change_percent": 2.2823762812741233,
-        "counters_match": true
-      },
-      {
-        "scene": "large_pyramid",
-        "times_ms": {
-          "before": [
-            1789.57,
-            1918.49
-          ],
-          "after": [
-            1782.08,
-            1882.1
-          ]
-        },
-        "medians_ms": {
-          "before": 1854.03,
-          "after": 1832.09
-        },
-        "runtime_change_percent": -1.1833681224144188,
-        "counters_match": true
-      },
-      {
-        "scene": "large_world",
-        "times_ms": {
-          "before": [
-            25.5235,
-            25.1156
-          ],
-          "after": [
-            25.2244,
-            28.6279
-          ]
-        },
-        "medians_ms": {
-          "before": 25.31955,
-          "after": 26.92615
-        },
-        "runtime_change_percent": 6.345294446386296,
-        "counters_match": true
-      },
-      {
-        "scene": "many_pyramids",
-        "times_ms": {
-          "before": [
-            1705.55,
-            1754.0
-          ],
-          "after": [
-            1726.73,
-            2068.21
-          ]
-        },
-        "medians_ms": {
-          "before": 1729.775,
-          "after": 1897.47
-        },
-        "runtime_change_percent": 9.694613461288304,
-        "counters_match": true
-      },
-      {
-        "scene": "rain",
-        "times_ms": {
-          "before": [
-            1477.62,
-            1464.43
-          ],
-          "after": [
-            1448.67,
-            1573.37
-          ]
-        },
-        "medians_ms": {
-          "before": 1471.025,
-          "after": 1511.02
-        },
-        "runtime_change_percent": 2.718852500807256,
-        "counters_match": true
-      },
-      {
-        "scene": "trees100",
-        "times_ms": {
-          "before": [
-            209.129,
-            390.479
-          ],
-          "after": [
-            197.922,
-            207.472
-          ]
-        },
-        "medians_ms": {
-          "before": 299.804,
-          "after": 202.697
-        },
-        "runtime_change_percent": -32.390161572227186,
-        "counters_match": true
-      },
-      {
-        "scene": "trees50",
-        "times_ms": {
-          "before": [
-            337.235,
-            435.955
-          ],
-          "after": [
-            326.55,
-            326.667
-          ]
-        },
-        "medians_ms": {
-          "before": 386.595,
-          "after": 326.6085
-        },
-        "runtime_change_percent": -15.516625926357053,
-        "counters_match": true
-      },
-      {
-        "scene": "trees25",
-        "times_ms": {
-          "before": [
-            697.386,
-            738.378
-          ],
-          "after": [
-            674.963,
-            676.439
-          ]
-        },
-        "medians_ms": {
-          "before": 717.8820000000001,
-          "after": 675.701
-        },
-        "runtime_change_percent": -5.87575673996562,
-        "counters_match": true
-      },
-      {
-        "scene": "washer",
-        "times_ms": {
-          "before": [
-            16286.4,
-            17641.1
-          ],
-          "after": [
-            16274.4,
-            16632.7
-          ]
-        },
-        "medians_ms": {
-          "before": 16963.75,
-          "after": 16453.55
-        },
-        "runtime_change_percent": -3.007589713359371,
-        "counters_match": true
-      }
-    ],
-    "geomean_runtime_ratio": 0.9446911460760578
+    "after": {
+      "path": "/Users/glenn/Documents/ChatGPT/stella 2/work/fixed3d-review/_bench/optimization/benchmark-final",
+      "sha256": "4a9da5c6f7f5d2bdd7a332f5ba6253aaf8ef5b8c9792d490154787da590f7c75"
+    }
   },
-  "grouped_recheck": {
+  "final_grouped_recheck": {
     "method": "Three per binary per scene, before/after/after/before/before/after, four workers",
     "rows": [
       {
         "scene": "convex_pile",
         "times_ms": {
           "before": [
-            14873.9,
-            14666.3,
-            14553.1
+            14382.9,
+            14274.2,
+            14203.2
           ],
           "after": [
-            13361.8,
-            13713.7,
-            12864.4
+            12631.0,
+            12684.7,
+            12655.6
           ]
         },
         "medians_ms": {
-          "before": 14666.3,
-          "after": 13361.8
+          "before": 14274.2,
+          "after": 12655.6
         },
-        "runtime_change_percent": -8.89454054533182,
+        "runtime_change_percent": -11.339339507643164,
         "counters_match": true
       },
       {
         "scene": "junkyard",
         "times_ms": {
           "before": [
-            10863.9,
-            10988.8,
-            11336.7
+            10353.1,
+            10289.8,
+            10142.5
           ],
           "after": [
-            11064.9,
-            10827.0,
-            12335.1
+            10121.1,
+            10167.6,
+            10189.6
           ]
         },
         "medians_ms": {
-          "before": 10988.8,
-          "after": 11064.9
+          "before": 10289.8,
+          "after": 10167.6
         },
-        "runtime_change_percent": 0.6925232964472894,
+        "runtime_change_percent": -1.187583820871141,
         "counters_match": true
       },
       {
         "scene": "many_pyramids",
         "times_ms": {
           "before": [
-            2241.6,
-            1948.24,
-            2010.75
+            1724.84,
+            1704.81,
+            1691.45
           ],
           "after": [
-            2052.4,
-            1980.81,
-            2063.83
+            1724.6,
+            1687.97,
+            1715.95
           ]
         },
         "medians_ms": {
-          "before": 2010.75,
-          "after": 2052.4
+          "before": 1704.81,
+          "after": 1715.95
         },
-        "runtime_change_percent": 2.071366405570063,
+        "runtime_change_percent": 0.6534452519635581,
         "counters_match": true
       },
       {
         "scene": "rain",
         "times_ms": {
           "before": [
-            1716.86,
-            1767.2,
-            1732.98
+            1367.63,
+            1385.23,
+            1414.33
           ],
           "after": [
-            1860.85,
-            1713.89,
-            1713.79
+            1372.94,
+            1381.57,
+            1402.9
           ]
         },
         "medians_ms": {
-          "before": 1732.98,
-          "after": 1713.89
+          "before": 1385.23,
+          "after": 1381.57
         },
-        "runtime_change_percent": -1.1015707047975165,
+        "runtime_change_percent": -0.26421605076414334,
         "counters_match": true
       },
       {
         "scene": "trees100",
         "times_ms": {
           "before": [
-            221.847,
-            245.925,
-            217.483
+            189.242,
+            206.846,
+            195.584
           ],
           "after": [
-            231.248,
-            295.395,
-            271.579
+            187.583,
+            190.757,
+            193.291
           ]
         },
         "medians_ms": {
-          "before": 221.847,
-          "after": 271.579
+          "before": 195.584,
+          "after": 190.757
         },
-        "runtime_change_percent": 22.41725152920706,
+        "runtime_change_percent": -2.467993291884818,
         "counters_match": true
       },
       {
         "scene": "large_world",
         "times_ms": {
           "before": [
-            31.5634,
-            44.7111,
-            28.2437
+            25.1679,
+            24.9671,
+            25.5735
           ],
           "after": [
-            61.79,
-            28.2471,
-            31.6187
+            25.3505,
+            25.2782,
+            25.8768
           ]
         },
         "medians_ms": {
-          "before": 31.5634,
-          "after": 31.6187
+          "before": 25.1679,
+          "after": 25.3505
         },
-        "runtime_change_percent": 0.1752029249066922,
+        "runtime_change_percent": 0.7255273582619237,
         "counters_match": true
       }
     ]
   },
-  "trees_longer_recheck": {
-    "scene": "trees100",
-    "method": "before/after/after/before, 10 repetitions per process, four workers",
-    "times_ms": {
-      "before": [
-        239.815,
-        240.126,
-        238.675,
-        236.294,
-        234.4,
-        235.176,
-        241.702,
-        235.636,
-        237.671,
-        233.393,
-        239.214,
-        240.497,
-        239.29,
-        236.13,
-        236.222,
-        232.608,
-        237.679,
-        234.302,
-        233.939,
-        232.707
+  "earlier_candidate_exploration": {
+    "base_commit": "0b27fe38879e0dc45bddf447b92fb9c23c8e3db0",
+    "implementation_commit": "d010dd00a45b5d8661a77bb8c977cd51aa88d819",
+    "fixed_pin": "a0fa624d739790844af34499381c55abaa65180f",
+    "caution": "Shared workstation noise affected the full sweep and short runs. Only the Convex Pile gain was consistent across all grouped before/after trials. Do not infer an overall speedup from the full-sweep geometric mean.",
+    "full_sweep": {
+      "method": "Before/after/after/before, four workers, default scalar RelWithDebInfo with thin LTO on Apple M3 Ultra",
+      "binaries": {
+        "before": {
+          "path": "/Users/glenn/Documents/ChatGPT/stella 2/work/fixed3d-review/_bench/benchmark-corrected",
+          "sha256": "e77837f4ff560df982bf9b7bd7cc621700955fba8620f79a9a82a96e24932c36"
+        },
+        "after": {
+          "path": "/Users/glenn/Documents/ChatGPT/stella 2/work/fixed3d-review/_bench/optimization/benchmark-int64",
+          "sha256": "c51aed76142ccb068a89cbbd57c1e37c28f338f825ddb10fb9c2ebda26c96cc2"
+        }
+      },
+      "rows": [
+        {
+          "scene": "convex_pile",
+          "times_ms": {
+            "before": [
+              14511.9,
+              14997.0
+            ],
+            "after": [
+              13037.2,
+              12944.7
+            ]
+          },
+          "medians_ms": {
+            "before": 14754.45,
+            "after": 12990.95
+          },
+          "runtime_change_percent": -11.952326247335554,
+          "counters_match": true
+        },
+        {
+          "scene": "joint_grid",
+          "times_ms": {
+            "before": [
+              932.465,
+              1003.53
+            ],
+            "after": [
+              938.935,
+              923.022
+            ]
+          },
+          "medians_ms": {
+            "before": 967.9975,
+            "after": 930.9784999999999
+          },
+          "runtime_change_percent": -3.8242867362777266,
+          "counters_match": true
+        },
+        {
+          "scene": "junkyard",
+          "times_ms": {
+            "before": [
+              10642.3,
+              12040.2
+            ],
+            "after": [
+              10780.1,
+              12420.1
+            ]
+          },
+          "medians_ms": {
+            "before": 11341.25,
+            "after": 11600.1
+          },
+          "runtime_change_percent": 2.2823762812741233,
+          "counters_match": true
+        },
+        {
+          "scene": "large_pyramid",
+          "times_ms": {
+            "before": [
+              1789.57,
+              1918.49
+            ],
+            "after": [
+              1782.08,
+              1882.1
+            ]
+          },
+          "medians_ms": {
+            "before": 1854.03,
+            "after": 1832.09
+          },
+          "runtime_change_percent": -1.1833681224144188,
+          "counters_match": true
+        },
+        {
+          "scene": "large_world",
+          "times_ms": {
+            "before": [
+              25.5235,
+              25.1156
+            ],
+            "after": [
+              25.2244,
+              28.6279
+            ]
+          },
+          "medians_ms": {
+            "before": 25.31955,
+            "after": 26.92615
+          },
+          "runtime_change_percent": 6.345294446386296,
+          "counters_match": true
+        },
+        {
+          "scene": "many_pyramids",
+          "times_ms": {
+            "before": [
+              1705.55,
+              1754.0
+            ],
+            "after": [
+              1726.73,
+              2068.21
+            ]
+          },
+          "medians_ms": {
+            "before": 1729.775,
+            "after": 1897.47
+          },
+          "runtime_change_percent": 9.694613461288304,
+          "counters_match": true
+        },
+        {
+          "scene": "rain",
+          "times_ms": {
+            "before": [
+              1477.62,
+              1464.43
+            ],
+            "after": [
+              1448.67,
+              1573.37
+            ]
+          },
+          "medians_ms": {
+            "before": 1471.025,
+            "after": 1511.02
+          },
+          "runtime_change_percent": 2.718852500807256,
+          "counters_match": true
+        },
+        {
+          "scene": "trees100",
+          "times_ms": {
+            "before": [
+              209.129,
+              390.479
+            ],
+            "after": [
+              197.922,
+              207.472
+            ]
+          },
+          "medians_ms": {
+            "before": 299.804,
+            "after": 202.697
+          },
+          "runtime_change_percent": -32.390161572227186,
+          "counters_match": true
+        },
+        {
+          "scene": "trees50",
+          "times_ms": {
+            "before": [
+              337.235,
+              435.955
+            ],
+            "after": [
+              326.55,
+              326.667
+            ]
+          },
+          "medians_ms": {
+            "before": 386.595,
+            "after": 326.6085
+          },
+          "runtime_change_percent": -15.516625926357053,
+          "counters_match": true
+        },
+        {
+          "scene": "trees25",
+          "times_ms": {
+            "before": [
+              697.386,
+              738.378
+            ],
+            "after": [
+              674.963,
+              676.439
+            ]
+          },
+          "medians_ms": {
+            "before": 717.8820000000001,
+            "after": 675.701
+          },
+          "runtime_change_percent": -5.87575673996562,
+          "counters_match": true
+        },
+        {
+          "scene": "washer",
+          "times_ms": {
+            "before": [
+              16286.4,
+              17641.1
+            ],
+            "after": [
+              16274.4,
+              16632.7
+            ]
+          },
+          "medians_ms": {
+            "before": 16963.75,
+            "after": 16453.55
+          },
+          "runtime_change_percent": -3.007589713359371,
+          "counters_match": true
+        }
       ],
-      "after": [
-        233.978,
-        235.439,
-        232.406,
-        240.582,
-        240.753,
-        239.401,
-        234.74,
-        238.636,
-        229.676,
-        231.601,
-        228.263,
-        228.418,
-        232.985,
-        232.974,
-        235.432,
-        234.991,
-        230.378,
-        233.415,
-        234.358,
-        236.546
+      "geomean_runtime_ratio": 0.9446911460760578
+    },
+    "grouped_recheck": {
+      "method": "Three per binary per scene, before/after/after/before/before/after, four workers",
+      "rows": [
+        {
+          "scene": "convex_pile",
+          "times_ms": {
+            "before": [
+              14873.9,
+              14666.3,
+              14553.1
+            ],
+            "after": [
+              13361.8,
+              13713.7,
+              12864.4
+            ]
+          },
+          "medians_ms": {
+            "before": 14666.3,
+            "after": 13361.8
+          },
+          "runtime_change_percent": -8.89454054533182,
+          "counters_match": true
+        },
+        {
+          "scene": "junkyard",
+          "times_ms": {
+            "before": [
+              10863.9,
+              10988.8,
+              11336.7
+            ],
+            "after": [
+              11064.9,
+              10827.0,
+              12335.1
+            ]
+          },
+          "medians_ms": {
+            "before": 10988.8,
+            "after": 11064.9
+          },
+          "runtime_change_percent": 0.6925232964472894,
+          "counters_match": true
+        },
+        {
+          "scene": "many_pyramids",
+          "times_ms": {
+            "before": [
+              2241.6,
+              1948.24,
+              2010.75
+            ],
+            "after": [
+              2052.4,
+              1980.81,
+              2063.83
+            ]
+          },
+          "medians_ms": {
+            "before": 2010.75,
+            "after": 2052.4
+          },
+          "runtime_change_percent": 2.071366405570063,
+          "counters_match": true
+        },
+        {
+          "scene": "rain",
+          "times_ms": {
+            "before": [
+              1716.86,
+              1767.2,
+              1732.98
+            ],
+            "after": [
+              1860.85,
+              1713.89,
+              1713.79
+            ]
+          },
+          "medians_ms": {
+            "before": 1732.98,
+            "after": 1713.89
+          },
+          "runtime_change_percent": -1.1015707047975165,
+          "counters_match": true
+        },
+        {
+          "scene": "trees100",
+          "times_ms": {
+            "before": [
+              221.847,
+              245.925,
+              217.483
+            ],
+            "after": [
+              231.248,
+              295.395,
+              271.579
+            ]
+          },
+          "medians_ms": {
+            "before": 221.847,
+            "after": 271.579
+          },
+          "runtime_change_percent": 22.41725152920706,
+          "counters_match": true
+        },
+        {
+          "scene": "large_world",
+          "times_ms": {
+            "before": [
+              31.5634,
+              44.7111,
+              28.2437
+            ],
+            "after": [
+              61.79,
+              28.2471,
+              31.6187
+            ]
+          },
+          "medians_ms": {
+            "before": 31.5634,
+            "after": 31.6187
+          },
+          "runtime_change_percent": 0.1752029249066922,
+          "counters_match": true
+        }
       ]
     },
-    "medians_ms": {
-      "before": 236.258,
-      "after": 234.168
+    "trees_longer_recheck": {
+      "scene": "trees100",
+      "method": "before/after/after/before, 10 repetitions per process, four workers",
+      "times_ms": {
+        "before": [
+          239.815,
+          240.126,
+          238.675,
+          236.294,
+          234.4,
+          235.176,
+          241.702,
+          235.636,
+          237.671,
+          233.393,
+          239.214,
+          240.497,
+          239.29,
+          236.13,
+          236.222,
+          232.608,
+          237.679,
+          234.302,
+          233.939,
+          232.707
+        ],
+        "after": [
+          233.978,
+          235.439,
+          232.406,
+          240.582,
+          240.753,
+          239.401,
+          234.74,
+          238.636,
+          229.676,
+          231.601,
+          228.263,
+          228.418,
+          232.985,
+          232.974,
+          235.432,
+          234.991,
+          230.378,
+          233.415,
+          234.358,
+          236.546
+        ]
+      },
+      "medians_ms": {
+        "before": 236.258,
+        "after": 234.168
+      },
+      "runtime_change_percent": -0.8846261290622937
     },
-    "runtime_change_percent": -0.8846261290622937
+    "visual_parity": {
+      "frames": 120,
+      "repeat_per_binary": 2,
+      "capture_count": 80,
+      "builds": {
+        "before": "c3e59992658bca8fd80850c9ca4354d1d93f2181b5ea5ebe5ff961b004a613eb",
+        "after": "413e4c4ef956725101232d5623b4c0ac188eaa2c98553bce2ecece06ff991872"
+      },
+      "pixel_hash": "SHA256 of ASCII RGBA:WIDTHxHEIGHT followed by NUL and decoded RGBA bytes",
+      "rows": [
+        {
+          "sample": "Collision/Distance Debug",
+          "pixel_sha256": "c2efb9df2a8a59212e25b2c48f2039cf0321e0a27168fbbddc0f0e3def136c6e",
+          "all_four_captures_identical": true
+        },
+        {
+          "sample": "Collision/Shape Distance",
+          "pixel_sha256": "163cefe5ee4bde624ec79301a89dd8fec266f59d7c793e228aecc0943bd93834",
+          "all_four_captures_identical": true
+        },
+        {
+          "sample": "Determinism/Falling Ragdolls",
+          "pixel_sha256": "b1b349f7bb13d8cb2dda8649b968e600f2b47557524b474c34c4a926b9657f1d",
+          "all_four_captures_identical": true
+        },
+        {
+          "sample": "Joints/Ball and Chain",
+          "pixel_sha256": "05414d397b19f3818b2b30e7150404d29e49fe679d1867077d14baf587fc6a89",
+          "all_four_captures_identical": true
+        },
+        {
+          "sample": "Joints/Bridge",
+          "pixel_sha256": "2f00f9b401f3788fe9cee5550e08e2ecf50c4f0d746c9e13fa369aa99750ecf9",
+          "all_four_captures_identical": true
+        },
+        {
+          "sample": "Joints/Distance Joint",
+          "pixel_sha256": "77961532f714e0538b52a22e1ad79ff77ad359b9ef58cb053c37d88a286440ff",
+          "all_four_captures_identical": true
+        },
+        {
+          "sample": "Joints/Door",
+          "pixel_sha256": "d9143295e53c2f76dc142f9bc0ea433892525e8dbec974ad299d16000f73df1c",
+          "all_four_captures_identical": true
+        },
+        {
+          "sample": "Joints/Driving",
+          "pixel_sha256": "4a8f5f97ea9093bf284f83f9002fa53036730f67d3e5c81e01ba058f71dbee9c",
+          "all_four_captures_identical": true
+        },
+        {
+          "sample": "Joints/Filter",
+          "pixel_sha256": "76aee13b7d45545dbcb260337f3bf72cba63cbffe4c3707fd3a37adaf14fc829",
+          "all_four_captures_identical": true
+        },
+        {
+          "sample": "Joints/Gear Lift",
+          "pixel_sha256": "9cf1ca53eec7d2e665cc8a67415949809956e96f2c86dbf0c61acfe2270ae092",
+          "all_four_captures_identical": true
+        },
+        {
+          "sample": "Joints/Motion Locks",
+          "pixel_sha256": "0e97c91e801cd1d011ffaad5c846920f869af58d0091aeb10f8356fe12d32a24",
+          "all_four_captures_identical": true
+        },
+        {
+          "sample": "Joints/Motor Joint",
+          "pixel_sha256": "e4094ab8ec57c6f0ef248d3e9efd0c955629b5d0c7e560a63f9e91609eef1477",
+          "all_four_captures_identical": true
+        },
+        {
+          "sample": "Joints/Parallel Spring",
+          "pixel_sha256": "62a15f34cea73b733b83cd71cd78ddbc3d5bb0d6eae292e6e7d20f420c004cc8",
+          "all_four_captures_identical": true
+        },
+        {
+          "sample": "Joints/Prismatic",
+          "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+          "all_four_captures_identical": true
+        },
+        {
+          "sample": "Joints/Revolute",
+          "pixel_sha256": "6f2e38375e1871d7d578062bc87b837f04a8dad102ab2fb1a8615a42b8140179",
+          "all_four_captures_identical": true
+        },
+        {
+          "sample": "Joints/Spherical",
+          "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+          "all_four_captures_identical": true
+        },
+        {
+          "sample": "Joints/Top Down Friction",
+          "pixel_sha256": "f80d6ee44e9d0d1ac6eca5ae3e3d1989d26d222b049033deb550e04520d69b7f",
+          "all_four_captures_identical": true
+        },
+        {
+          "sample": "Joints/Weld",
+          "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+          "all_four_captures_identical": true
+        },
+        {
+          "sample": "Joints/Wheel",
+          "pixel_sha256": "d37bc980055bb39a4a5a9904d06c32ddae16a8048b7e322ef7325bfab31a1be8",
+          "all_four_captures_identical": true
+        },
+        {
+          "sample": "Stacking/Box Stack",
+          "pixel_sha256": "28aaa8686b52e698ac18cb06ca8f08e380dfefb28d57b707cb972322f209ed86",
+          "all_four_captures_identical": true
+        }
+      ]
+    }
   },
   "visual_parity": {
     "frames": 120,
     "repeat_per_binary": 2,
     "capture_count": 80,
-    "builds": {
+    "build_sha256": {
       "before": "c3e59992658bca8fd80850c9ca4354d1d93f2181b5ea5ebe5ff961b004a613eb",
-      "after": "413e4c4ef956725101232d5623b4c0ac188eaa2c98553bce2ecece06ff991872"
+      "after": "c6a18279c5b201078901fcc5d71a6bab28a334ae8b573a2aab661e5ae841ef4d"
     },
     "pixel_hash": "SHA256 of ASCII RGBA:WIDTHxHEIGHT followed by NUL and decoded RGBA bytes",
     "rows": [

--- a/benchmark/2026-09-07-scalar-edge-reject.json
+++ b/benchmark/2026-09-07-scalar-edge-reject.json
@@ -1,0 +1,529 @@
+{
+  "base_commit": "0b27fe38879e0dc45bddf447b92fb9c23c8e3db0",
+  "implementation_commit": "d010dd00a45b5d8661a77bb8c977cd51aa88d819",
+  "fixed_pin": "a0fa624d739790844af34499381c55abaa65180f",
+  "caution": "Shared workstation noise affected the full sweep and short runs. Only the Convex Pile gain was consistent across all grouped before/after trials. Do not infer an overall speedup from the full-sweep geometric mean.",
+  "full_sweep": {
+    "method": "Before/after/after/before, four workers, default scalar RelWithDebInfo with thin LTO on Apple M3 Ultra",
+    "binaries": {
+      "before": {
+        "path": "/Users/glenn/Documents/ChatGPT/stella 2/work/fixed3d-review/_bench/benchmark-corrected",
+        "sha256": "e77837f4ff560df982bf9b7bd7cc621700955fba8620f79a9a82a96e24932c36"
+      },
+      "after": {
+        "path": "/Users/glenn/Documents/ChatGPT/stella 2/work/fixed3d-review/_bench/optimization/benchmark-int64",
+        "sha256": "c51aed76142ccb068a89cbbd57c1e37c28f338f825ddb10fb9c2ebda26c96cc2"
+      }
+    },
+    "rows": [
+      {
+        "scene": "convex_pile",
+        "times_ms": {
+          "before": [
+            14511.9,
+            14997.0
+          ],
+          "after": [
+            13037.2,
+            12944.7
+          ]
+        },
+        "medians_ms": {
+          "before": 14754.45,
+          "after": 12990.95
+        },
+        "runtime_change_percent": -11.952326247335554,
+        "counters_match": true
+      },
+      {
+        "scene": "joint_grid",
+        "times_ms": {
+          "before": [
+            932.465,
+            1003.53
+          ],
+          "after": [
+            938.935,
+            923.022
+          ]
+        },
+        "medians_ms": {
+          "before": 967.9975,
+          "after": 930.9784999999999
+        },
+        "runtime_change_percent": -3.8242867362777266,
+        "counters_match": true
+      },
+      {
+        "scene": "junkyard",
+        "times_ms": {
+          "before": [
+            10642.3,
+            12040.2
+          ],
+          "after": [
+            10780.1,
+            12420.1
+          ]
+        },
+        "medians_ms": {
+          "before": 11341.25,
+          "after": 11600.1
+        },
+        "runtime_change_percent": 2.2823762812741233,
+        "counters_match": true
+      },
+      {
+        "scene": "large_pyramid",
+        "times_ms": {
+          "before": [
+            1789.57,
+            1918.49
+          ],
+          "after": [
+            1782.08,
+            1882.1
+          ]
+        },
+        "medians_ms": {
+          "before": 1854.03,
+          "after": 1832.09
+        },
+        "runtime_change_percent": -1.1833681224144188,
+        "counters_match": true
+      },
+      {
+        "scene": "large_world",
+        "times_ms": {
+          "before": [
+            25.5235,
+            25.1156
+          ],
+          "after": [
+            25.2244,
+            28.6279
+          ]
+        },
+        "medians_ms": {
+          "before": 25.31955,
+          "after": 26.92615
+        },
+        "runtime_change_percent": 6.345294446386296,
+        "counters_match": true
+      },
+      {
+        "scene": "many_pyramids",
+        "times_ms": {
+          "before": [
+            1705.55,
+            1754.0
+          ],
+          "after": [
+            1726.73,
+            2068.21
+          ]
+        },
+        "medians_ms": {
+          "before": 1729.775,
+          "after": 1897.47
+        },
+        "runtime_change_percent": 9.694613461288304,
+        "counters_match": true
+      },
+      {
+        "scene": "rain",
+        "times_ms": {
+          "before": [
+            1477.62,
+            1464.43
+          ],
+          "after": [
+            1448.67,
+            1573.37
+          ]
+        },
+        "medians_ms": {
+          "before": 1471.025,
+          "after": 1511.02
+        },
+        "runtime_change_percent": 2.718852500807256,
+        "counters_match": true
+      },
+      {
+        "scene": "trees100",
+        "times_ms": {
+          "before": [
+            209.129,
+            390.479
+          ],
+          "after": [
+            197.922,
+            207.472
+          ]
+        },
+        "medians_ms": {
+          "before": 299.804,
+          "after": 202.697
+        },
+        "runtime_change_percent": -32.390161572227186,
+        "counters_match": true
+      },
+      {
+        "scene": "trees50",
+        "times_ms": {
+          "before": [
+            337.235,
+            435.955
+          ],
+          "after": [
+            326.55,
+            326.667
+          ]
+        },
+        "medians_ms": {
+          "before": 386.595,
+          "after": 326.6085
+        },
+        "runtime_change_percent": -15.516625926357053,
+        "counters_match": true
+      },
+      {
+        "scene": "trees25",
+        "times_ms": {
+          "before": [
+            697.386,
+            738.378
+          ],
+          "after": [
+            674.963,
+            676.439
+          ]
+        },
+        "medians_ms": {
+          "before": 717.8820000000001,
+          "after": 675.701
+        },
+        "runtime_change_percent": -5.87575673996562,
+        "counters_match": true
+      },
+      {
+        "scene": "washer",
+        "times_ms": {
+          "before": [
+            16286.4,
+            17641.1
+          ],
+          "after": [
+            16274.4,
+            16632.7
+          ]
+        },
+        "medians_ms": {
+          "before": 16963.75,
+          "after": 16453.55
+        },
+        "runtime_change_percent": -3.007589713359371,
+        "counters_match": true
+      }
+    ],
+    "geomean_runtime_ratio": 0.9446911460760578
+  },
+  "grouped_recheck": {
+    "method": "Three per binary per scene, before/after/after/before/before/after, four workers",
+    "rows": [
+      {
+        "scene": "convex_pile",
+        "times_ms": {
+          "before": [
+            14873.9,
+            14666.3,
+            14553.1
+          ],
+          "after": [
+            13361.8,
+            13713.7,
+            12864.4
+          ]
+        },
+        "medians_ms": {
+          "before": 14666.3,
+          "after": 13361.8
+        },
+        "runtime_change_percent": -8.89454054533182,
+        "counters_match": true
+      },
+      {
+        "scene": "junkyard",
+        "times_ms": {
+          "before": [
+            10863.9,
+            10988.8,
+            11336.7
+          ],
+          "after": [
+            11064.9,
+            10827.0,
+            12335.1
+          ]
+        },
+        "medians_ms": {
+          "before": 10988.8,
+          "after": 11064.9
+        },
+        "runtime_change_percent": 0.6925232964472894,
+        "counters_match": true
+      },
+      {
+        "scene": "many_pyramids",
+        "times_ms": {
+          "before": [
+            2241.6,
+            1948.24,
+            2010.75
+          ],
+          "after": [
+            2052.4,
+            1980.81,
+            2063.83
+          ]
+        },
+        "medians_ms": {
+          "before": 2010.75,
+          "after": 2052.4
+        },
+        "runtime_change_percent": 2.071366405570063,
+        "counters_match": true
+      },
+      {
+        "scene": "rain",
+        "times_ms": {
+          "before": [
+            1716.86,
+            1767.2,
+            1732.98
+          ],
+          "after": [
+            1860.85,
+            1713.89,
+            1713.79
+          ]
+        },
+        "medians_ms": {
+          "before": 1732.98,
+          "after": 1713.89
+        },
+        "runtime_change_percent": -1.1015707047975165,
+        "counters_match": true
+      },
+      {
+        "scene": "trees100",
+        "times_ms": {
+          "before": [
+            221.847,
+            245.925,
+            217.483
+          ],
+          "after": [
+            231.248,
+            295.395,
+            271.579
+          ]
+        },
+        "medians_ms": {
+          "before": 221.847,
+          "after": 271.579
+        },
+        "runtime_change_percent": 22.41725152920706,
+        "counters_match": true
+      },
+      {
+        "scene": "large_world",
+        "times_ms": {
+          "before": [
+            31.5634,
+            44.7111,
+            28.2437
+          ],
+          "after": [
+            61.79,
+            28.2471,
+            31.6187
+          ]
+        },
+        "medians_ms": {
+          "before": 31.5634,
+          "after": 31.6187
+        },
+        "runtime_change_percent": 0.1752029249066922,
+        "counters_match": true
+      }
+    ]
+  },
+  "trees_longer_recheck": {
+    "scene": "trees100",
+    "method": "before/after/after/before, 10 repetitions per process, four workers",
+    "times_ms": {
+      "before": [
+        239.815,
+        240.126,
+        238.675,
+        236.294,
+        234.4,
+        235.176,
+        241.702,
+        235.636,
+        237.671,
+        233.393,
+        239.214,
+        240.497,
+        239.29,
+        236.13,
+        236.222,
+        232.608,
+        237.679,
+        234.302,
+        233.939,
+        232.707
+      ],
+      "after": [
+        233.978,
+        235.439,
+        232.406,
+        240.582,
+        240.753,
+        239.401,
+        234.74,
+        238.636,
+        229.676,
+        231.601,
+        228.263,
+        228.418,
+        232.985,
+        232.974,
+        235.432,
+        234.991,
+        230.378,
+        233.415,
+        234.358,
+        236.546
+      ]
+    },
+    "medians_ms": {
+      "before": 236.258,
+      "after": 234.168
+    },
+    "runtime_change_percent": -0.8846261290622937
+  },
+  "visual_parity": {
+    "frames": 120,
+    "repeat_per_binary": 2,
+    "capture_count": 80,
+    "builds": {
+      "before": "c3e59992658bca8fd80850c9ca4354d1d93f2181b5ea5ebe5ff961b004a613eb",
+      "after": "413e4c4ef956725101232d5623b4c0ac188eaa2c98553bce2ecece06ff991872"
+    },
+    "pixel_hash": "SHA256 of ASCII RGBA:WIDTHxHEIGHT followed by NUL and decoded RGBA bytes",
+    "rows": [
+      {
+        "sample": "Collision/Distance Debug",
+        "pixel_sha256": "c2efb9df2a8a59212e25b2c48f2039cf0321e0a27168fbbddc0f0e3def136c6e",
+        "all_four_captures_identical": true
+      },
+      {
+        "sample": "Collision/Shape Distance",
+        "pixel_sha256": "163cefe5ee4bde624ec79301a89dd8fec266f59d7c793e228aecc0943bd93834",
+        "all_four_captures_identical": true
+      },
+      {
+        "sample": "Determinism/Falling Ragdolls",
+        "pixel_sha256": "b1b349f7bb13d8cb2dda8649b968e600f2b47557524b474c34c4a926b9657f1d",
+        "all_four_captures_identical": true
+      },
+      {
+        "sample": "Joints/Ball and Chain",
+        "pixel_sha256": "05414d397b19f3818b2b30e7150404d29e49fe679d1867077d14baf587fc6a89",
+        "all_four_captures_identical": true
+      },
+      {
+        "sample": "Joints/Bridge",
+        "pixel_sha256": "2f00f9b401f3788fe9cee5550e08e2ecf50c4f0d746c9e13fa369aa99750ecf9",
+        "all_four_captures_identical": true
+      },
+      {
+        "sample": "Joints/Distance Joint",
+        "pixel_sha256": "77961532f714e0538b52a22e1ad79ff77ad359b9ef58cb053c37d88a286440ff",
+        "all_four_captures_identical": true
+      },
+      {
+        "sample": "Joints/Door",
+        "pixel_sha256": "d9143295e53c2f76dc142f9bc0ea433892525e8dbec974ad299d16000f73df1c",
+        "all_four_captures_identical": true
+      },
+      {
+        "sample": "Joints/Driving",
+        "pixel_sha256": "4a8f5f97ea9093bf284f83f9002fa53036730f67d3e5c81e01ba058f71dbee9c",
+        "all_four_captures_identical": true
+      },
+      {
+        "sample": "Joints/Filter",
+        "pixel_sha256": "76aee13b7d45545dbcb260337f3bf72cba63cbffe4c3707fd3a37adaf14fc829",
+        "all_four_captures_identical": true
+      },
+      {
+        "sample": "Joints/Gear Lift",
+        "pixel_sha256": "9cf1ca53eec7d2e665cc8a67415949809956e96f2c86dbf0c61acfe2270ae092",
+        "all_four_captures_identical": true
+      },
+      {
+        "sample": "Joints/Motion Locks",
+        "pixel_sha256": "0e97c91e801cd1d011ffaad5c846920f869af58d0091aeb10f8356fe12d32a24",
+        "all_four_captures_identical": true
+      },
+      {
+        "sample": "Joints/Motor Joint",
+        "pixel_sha256": "e4094ab8ec57c6f0ef248d3e9efd0c955629b5d0c7e560a63f9e91609eef1477",
+        "all_four_captures_identical": true
+      },
+      {
+        "sample": "Joints/Parallel Spring",
+        "pixel_sha256": "62a15f34cea73b733b83cd71cd78ddbc3d5bb0d6eae292e6e7d20f420c004cc8",
+        "all_four_captures_identical": true
+      },
+      {
+        "sample": "Joints/Prismatic",
+        "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+        "all_four_captures_identical": true
+      },
+      {
+        "sample": "Joints/Revolute",
+        "pixel_sha256": "6f2e38375e1871d7d578062bc87b837f04a8dad102ab2fb1a8615a42b8140179",
+        "all_four_captures_identical": true
+      },
+      {
+        "sample": "Joints/Spherical",
+        "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+        "all_four_captures_identical": true
+      },
+      {
+        "sample": "Joints/Top Down Friction",
+        "pixel_sha256": "f80d6ee44e9d0d1ac6eca5ae3e3d1989d26d222b049033deb550e04520d69b7f",
+        "all_four_captures_identical": true
+      },
+      {
+        "sample": "Joints/Weld",
+        "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+        "all_four_captures_identical": true
+      },
+      {
+        "sample": "Joints/Wheel",
+        "pixel_sha256": "d37bc980055bb39a4a5a9904d06c32ddae16a8048b7e322ef7325bfab31a1be8",
+        "all_four_captures_identical": true
+      },
+      {
+        "sample": "Stacking/Box Stack",
+        "pixel_sha256": "28aaa8686b52e698ac18cb06ca8f08e380dfefb28d57b707cb972322f209ed86",
+        "all_four_captures_identical": true
+      }
+    ]
+  }
+}

--- a/benchmark/2026-09-07-scalar-edge-reject.md
+++ b/benchmark/2026-09-07-scalar-edge-reject.md
@@ -1,42 +1,42 @@
 # Scalar hull-edge rejection measurements
 
-The default scalar scan can reject ordinary candidate edge pairs using signed
+The default scalar scan rejects ordinary candidate edge pairs using signed
 64-bit raw dots. A conservative magnitude gate proves that products, partial
-sums and negation cannot overflow. Larger inputs keep the 128-bit path, and
-every survivor uses the original full-precision separation calculation.
+sums and negation cannot overflow. Its bounds come from actual hull vertices
+and face normals, avoiding older vendored AABB transforms that can round inward.
+Larger inputs keep the 128-bit path; every survivor uses the original
+full-precision separation calculation, in the same order.
 
 Measured on 2026-09-07 with Apple M3 Ultra, arm64 Apple Clang, RelWithDebInfo,
 `-O2`, default thin LTO, four workers, `BOX3D_NEON=OFF`. The baseline is corrected
-Fixed3D `0b27fe3` from #55; the implementation is `d010dd0`. Both use fixed
+Fixed3D `0b27fe3` from #55; the final implementation is `bb6f23c`. Both use fixed
 `a0fa624d739790844af34499381c55abaa65180f` (v1.4.0). The separate vendor update is
 not included in these measurements.
 
 ## Results
 
-Convex Pile takes about **9% less time**, from 14.67 to 13.36 seconds by the
-median of three runs per binary. Every optimized run in that grouped check was
-faster than every baseline run. Smaller differences in other scenes are
-inconclusive on this shared workstation; these measurements do not establish an
-engine-wide percentage improvement.
+Convex Pile takes **11.3% less time**, from 14.27 to 12.66
+seconds by the median of three runs per binary. Every optimized run in this
+check was faster than every baseline run. Smaller differences in other scenes
+remain inconclusive on the shared workstation. These measurements do not
+establish an engine-wide percentage improvement.
 
-| Scene | Before median (ms) | After median (ms) | Runtime change | Runs per binary |
-|---|---:|---:|---:|---:|
-| convex_pile | 14666.30 | 13361.80 | -8.89% | 3 |
-| junkyard | 10988.80 | 11064.90 | +0.69% | 3 |
-| many_pyramids | 2010.75 | 2052.40 | +2.07% | 3 |
-| rain | 1732.98 | 1713.89 | -1.10% | 3 |
-| trees100 | 236.26 | 234.17 | -0.88% | 20 |
-| large_world | 31.56 | 31.62 | +0.18% | 3 |
+| Scene | Before median (ms) | After median (ms) | Runtime change |
+|---|---:|---:|---:|
+| convex_pile | 14274.20 | 12655.60 | -11.34% |
+| junkyard | 10289.80 | 10167.60 | -1.19% |
+| many_pyramids | 1704.81 | 1715.95 | +0.65% |
+| rain | 1385.23 | 1381.57 | -0.26% |
+| trees100 | 195.58 | 190.76 | -2.47% |
+| large_world | 25.17 | 25.35 | +0.73% |
 
-All eleven benchmarks were initially run in before/after/after/before order.
-Noise was substantial: one baseline Trees run was almost twice another baseline
-run. Six selected scenes were then grouped individually in
-before/after/after/before/before/after order. Trees still had an anomalous short
-result, so it received a final before/after/after/before check with ten repetitions
-per process; that longer check is the Trees row above. All raw trials, including
-the noisy and unfavorable observations, are in
-[the JSON record](2026-09-07-scalar-edge-reject.json). End-of-run body, shape,
-contact, joint and stack counters matched throughout the paired sweeps.
+Each final scene used before/after/after/before/before/after ordering, with one
+run per process. End-of-run body, shape, contact, joint and stack counters match.
+[The JSON record](2026-09-07-scalar-edge-reject.json) contains every final trial
+and executable fingerprints, plus the earlier candidate's full eleven-scene
+sweep, grouped recheck, and longer Trees check. Those earlier measurements are
+explicitly separated: the final vertex-bound implementation was retested.
+Several earlier short runs were noisy or unfavorable, and remain in the record.
 
 ## Reproduction
 
@@ -53,14 +53,13 @@ cmake --build build-perf --parallel 8
 ```
 
 Omit `-b` for all scenes. Use a separate working directory for each process to
-preserve the benchmark's CSV outputs. The JSON also fingerprints the measured
-executables with SHA256. Results on other architectures and compilers may differ.
+preserve CSV outputs. Results on other architectures and compilers may differ.
 
 ## Correctness
 
 All 24 local suites pass in Debug, RelWithDebInfo, wide-position RelWithDebInfo,
 NEON RelWithDebInfo, and Debug ASan+UBSan. Existing determinism hashes are
-unchanged, including worker counts 1–5 and the narrow/wide references. The new
+unchanged, including worker counts 1–5 and narrow/wide references. The new
 analytic test covers separating edges at scales 8192, 16384 and 32768, across the
 64-bit admission boundary.
 
@@ -69,12 +68,12 @@ each with a fresh and reused cache. All 12000 serialized query results matched
 an archive containing the original convex-manifold object exactly. SHA256:
 `62467f0ac17eb4f2277db8bd5d686ef167775a3d4bd3b402904c316a3fb1768d`.
 
-Twenty sample scenes (the joint samples, two distance scenes, Box Stack and
-Falling Ragdolls) were captured at 120 nominal 60 Hz frames, twice per binary.
-All 80 captures reproduce exactly within and across the pre-optimization and
-optimized fixed builds. Decoded RGBA hashes and binary fingerprints are in the
-JSON. This compares fixed against fixed; float-image equality is not required.
+Twenty sample scenes (joint samples, two distance scenes, Box Stack and Falling
+Ragdolls) were captured at 120 nominal 60 Hz frames, twice per binary. All 80
+captures reproduce exactly within and across the pre-optimization and final
+fixed builds. Decoded RGBA hashes and binary fingerprints are in the JSON.
+Both binaries are fixed builds; float-image equality is not required.
 
 The existing NEON and AVX-512 paths and build defaults are unchanged. The
-cross-platform build matrix has not run for the stacked draft: its workflow
-currently targets pull requests into `main`.
+cross-platform matrix has not run for the stacked draft: its workflow currently
+targets pull requests into `main`.

--- a/benchmark/2026-09-07-scalar-edge-reject.md
+++ b/benchmark/2026-09-07-scalar-edge-reject.md
@@ -1,0 +1,80 @@
+# Scalar hull-edge rejection measurements
+
+The default scalar scan can reject ordinary candidate edge pairs using signed
+64-bit raw dots. A conservative magnitude gate proves that products, partial
+sums and negation cannot overflow. Larger inputs keep the 128-bit path, and
+every survivor uses the original full-precision separation calculation.
+
+Measured on 2026-09-07 with Apple M3 Ultra, arm64 Apple Clang, RelWithDebInfo,
+`-O2`, default thin LTO, four workers, `BOX3D_NEON=OFF`. The baseline is corrected
+Fixed3D `0b27fe3` from #55; the implementation is `d010dd0`. Both use fixed
+`a0fa624d739790844af34499381c55abaa65180f` (v1.4.0). The separate vendor update is
+not included in these measurements.
+
+## Results
+
+Convex Pile takes about **9% less time**, from 14.67 to 13.36 seconds by the
+median of three runs per binary. Every optimized run in that grouped check was
+faster than every baseline run. Smaller differences in other scenes are
+inconclusive on this shared workstation; these measurements do not establish an
+engine-wide percentage improvement.
+
+| Scene | Before median (ms) | After median (ms) | Runtime change | Runs per binary |
+|---|---:|---:|---:|---:|
+| convex_pile | 14666.30 | 13361.80 | -8.89% | 3 |
+| junkyard | 10988.80 | 11064.90 | +0.69% | 3 |
+| many_pyramids | 2010.75 | 2052.40 | +2.07% | 3 |
+| rain | 1732.98 | 1713.89 | -1.10% | 3 |
+| trees100 | 236.26 | 234.17 | -0.88% | 20 |
+| large_world | 31.56 | 31.62 | +0.18% | 3 |
+
+All eleven benchmarks were initially run in before/after/after/before order.
+Noise was substantial: one baseline Trees run was almost twice another baseline
+run. Six selected scenes were then grouped individually in
+before/after/after/before/before/after order. Trees still had an anomalous short
+result, so it received a final before/after/after/before check with ten repetitions
+per process; that longer check is the Trees row above. All raw trials, including
+the noisy and unfavorable observations, are in
+[the JSON record](2026-09-07-scalar-edge-reject.json). End-of-run body, shape,
+contact, joint and stack counters matched throughout the paired sweeps.
+
+## Reproduction
+
+Build separate copies of the baseline and optimized revision with the same
+configuration, preserving both executables. Keep other builds/tests idle while
+measuring, then alternate binaries with:
+
+```sh
+cmake -S . -B build-perf -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DBOX3D_SAMPLES=OFF -DBOX3D_UNIT_TESTS=ON -DBOX3D_BENCHMARKS=ON \
+  -DBOX3D_NEON=OFF -DBOX3D_COMPILE_WARNING_AS_ERROR=ON
+cmake --build build-perf --parallel 8
+./build-perf/bin/benchmark -t=4 -w=4 -b=convex_pile -r=1
+```
+
+Omit `-b` for all scenes. Use a separate working directory for each process to
+preserve the benchmark's CSV outputs. The JSON also fingerprints the measured
+executables with SHA256. Results on other architectures and compilers may differ.
+
+## Correctness
+
+All 24 local suites pass in Debug, RelWithDebInfo, wide-position RelWithDebInfo,
+NEON RelWithDebInfo, and Debug ASan+UBSan. Existing determinism hashes are
+unchanged, including worker counts 1–5 and the narrow/wide references. The new
+analytic test covers separating edges at scales 8192, 16384 and 32768, across the
+64-bit admission boundary.
+
+A separate corpus compared 6000 hull pairs at six scales from 0.2 through 32768,
+each with a fresh and reused cache. All 12000 serialized query results matched
+an archive containing the original convex-manifold object exactly. SHA256:
+`62467f0ac17eb4f2277db8bd5d686ef167775a3d4bd3b402904c316a3fb1768d`.
+
+Twenty sample scenes (the joint samples, two distance scenes, Box Stack and
+Falling Ragdolls) were captured at 120 nominal 60 Hz frames, twice per binary.
+All 80 captures reproduce exactly within and across the pre-optimization and
+optimized fixed builds. Decoded RGBA hashes and binary fingerprints are in the
+JSON. This compares fixed against fixed; float-image equality is not required.
+
+The existing NEON and AVX-512 paths and build defaults are unchanged. The
+cross-platform build matrix has not run for the stacked draft: its workflow
+currently targets pull requests into `main`.

--- a/samples/main.cpp
+++ b/samples/main.cpp
@@ -51,6 +51,7 @@ static int s_frame = 0;
 static int s_frameLimit = -1;
 static char s_capturePath[1024];
 static bool s_headless = false;
+static bool s_captureNoAxes = false;
 static int s_sampleOverride = -1;
 static int s_exitCode = 0;
 
@@ -624,6 +625,13 @@ static int RunHeadlessCapture()
 		double gridPeriod = 10.0 * BOX3D_GROUND_GRID_CELL_SIZE;
 		fi.gridWrap.x = (float)fmod( b3FixToDouble( drawOrigin.x ), gridPeriod );
 		fi.gridWrap.y = (float)fmod( b3FixToDouble( drawOrigin.z ), gridPeriod );
+		// Absolute world-axis lines differ when the same scene is translated.
+		// This capture-only option hides them without changing the repeating grid.
+		if ( s_captureNoAxes )
+		{
+			fi.drawOrigin.x = 1.0e20f;
+			fi.drawOrigin.z = 1.0e20f;
+		}
 		fi.time = (float)frame / 60.0f;
 		fi.debugMode = s_context.debugView;
 		fi.disableShadows = !s_context.enableShadows;
@@ -696,6 +704,10 @@ static sapp_desc BuildAppDesc( int argc, char** argv )
 			// End-state screenshot: at --frames N, freeze the sim, render the
 			// final state offscreen, and write it to this PNG path (macOS only).
 			snprintf( s_capturePath, sizeof( s_capturePath ), "%s", argv[++i] );
+		}
+		else if ( strcmp( argv[i], "--capture-no-axes" ) == 0 )
+		{
+			s_captureNoAxes = true;
 		}
 		else if ( strcmp( argv[i], "--headless" ) == 0 )
 		{

--- a/src/body.c
+++ b/src/body.c
@@ -1555,7 +1555,7 @@ void b3Body_ApplyAngularImpulse( b3BodyId bodyId, b3Vec3 impulse, bool wake )
 		b3BodySim* bodySim = b3Array_Get( set->bodySims, localIndex );
 
 		b3Vec3 localImpulse = b3InvRotateVector( bodySim->transform.q, impulse );
-		b3Vec3 localAngularVelocityDelta = b3MulMV( bodySim->invInertiaLocal, localImpulse );
+		b3Vec3 localAngularVelocityDelta = b3InvMulMV( bodySim->invInertiaLocal, localImpulse );
 		state->angularVelocity =
 			b3Add( state->angularVelocity, b3RotateVector( bodySim->transform.q, localAngularVelocityDelta ) );
 	}

--- a/src/convex_manifold.c
+++ b/src/convex_manifold.c
@@ -1022,7 +1022,6 @@ void b3CollideHullAndSphere( b3LocalManifold* manifold, int capacity, const b3Hu
 		return;
 	}
 
-
 	if ( distanceOutput.distance > 100 * B3_FIXED_EPSILON )
 	{
 		// Shallow penetration

--- a/src/convex_manifold.c
+++ b/src/convex_manifold.c
@@ -483,6 +483,7 @@ static b3SeparatingAxis b3QueryEdgeDirections( const b3HullData* hullA, const b3
 	}
 #endif
 
+#if defined( B3_SIMD_AVX512 ) || defined( B3_SIMD_NEON )
 	// |edge component| <= |aabb.lower| + |aabb.upper| for a difference of two
 	// hull points, so the int64 dot bound below is sound for valid hull data
 	uint64_t edgeBound = 0;
@@ -497,6 +498,23 @@ static b3SeparatingAxis b3QueryEdgeDirections( const b3HullData* hullA, const b3
 			edgeBound = candidates[i] > edgeBound ? candidates[i] : edgeBound;
 		}
 	}
+
+#else
+	// Bound the actual vertices rather than the cached AABB: older vendored
+	// AABB transforms can round inward. Every edge component is at most twice
+	// the largest point component, regardless of hull translation or rotation.
+	uint64_t pointBound = 0;
+	for ( int i = 0; i < hullA->vertexCount; ++i )
+	{
+		b3Vec3 p = pointsA[i];
+		uint64_t candidates[3] = { b3EdgeAbsBoundU64( p.x ), b3EdgeAbsBoundU64( p.y ), b3EdgeAbsBoundU64( p.z ) };
+		for ( int j = 0; j < 3; ++j )
+		{
+			pointBound = candidates[j] > pointBound ? candidates[j] : pointBound;
+		}
+	}
+	uint64_t edgeBound = pointBound <= UINT64_MAX / 2 ? 2 * pointBound : UINT64_MAX;
+#endif
 
 	// Arranged to minimize transform operations
 	for ( int indexB = 0; indexB < hullB->edgeCount; indexB += 2 )

--- a/src/convex_manifold.c
+++ b/src/convex_manifold.c
@@ -332,23 +332,6 @@ static inline void b3TestEdgePair( const b3HullHalfEdge* edgesA, const b3Vec3* p
 	}
 }
 
-#if defined( B3_SIMD_AVX512 ) || defined( B3_SIMD_NEON )
-
-#if defined( B3_SIMD_AVX512 )
-#include <immintrin.h>
-// AVX-512 multiplies 64-bit lanes directly
-typedef b3Fixed b3EdgeLane;
-#else
-#include <arm_neon.h>
-// NEON has only 32x32->64 widening multiplies, so the SoA staging narrows to
-// int32; the admission check below rejects anything that would not fit and
-// the truncated values are then never read
-typedef int32_t b3EdgeLane;
-#endif
-
-// Hulls index edges with uint8_t, so at most 256 half-edges = 128 edge pairs
-#define B3_MAX_HULL_EDGE_PAIRS 128
-
 static inline uint64_t b3EdgeAbsBoundU64( b3Fixed a )
 {
 	return a < 0 ? ( 0 - (uint64_t)a ) : (uint64_t)a;
@@ -370,6 +353,54 @@ static inline bool b3EdgeWideAdmissible( uint64_t uvMax, uint64_t edgeBound, uin
 	return uvMax <= UINT64_MAX / 3 && (b3UInt128)( 3 * uvMax ) * edgeBound < ( (b3UInt128)1 << 63 ) &&
 		   normalBoundA <= UINT64_MAX / 3 && (b3UInt128)( 3 * normalBoundA ) * eBMax < ( (b3UInt128)1 << 63 );
 }
+
+#if !defined( B3_SIMD_AVX512 ) && !defined( B3_SIMD_NEON )
+// Called only after b3EdgeWideAdmissible proves that the sum of absolute
+// products is less than 2^63. Products, partial sums, and negation are exact.
+static inline int64_t b3EdgeDot64( b3Vec3 a, b3Vec3 b )
+{
+	return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+
+static inline void b3TestEdgePair64( const b3HullHalfEdge* edgesA, const b3Vec3* pointsA, const b3Plane* planesA, int indexA,
+									 b3Vec3 eB, b3Vec3 qB, b3Vec3 uB, b3Vec3 vB, b3Fixed squaredTolerance, int indexB,
+									 b3SeparatingAxis* best )
+{
+	const b3HullHalfEdge* edgeA = edgesA + indexA;
+	const b3HullHalfEdge* twinA = edgesA + indexA + 1;
+	b3Vec3 eA = b3Sub( pointsA[twinA->origin], pointsA[edgeA->origin] );
+	int64_t cba = b3EdgeDot64( uB, eA );
+	int64_t dba = b3EdgeDot64( vB, eA );
+	if ( cba == 0 || dba == 0 || ( cba ^ dba ) >= 0 )
+	{
+		return;
+	}
+	int64_t adc = -b3EdgeDot64( planesA[edgeA->face].normal, eB );
+	int64_t bdc = -b3EdgeDot64( planesA[twinA->face].normal, eB );
+	if ( adc == 0 || bdc == 0 || ( adc ^ bdc ) >= 0 || ( cba ^ bdc ) < 0 )
+	{
+		return;
+	}
+	b3TestEdgePair( edgesA, pointsA, planesA, indexA, eB, qB, uB, vB, squaredTolerance, indexB, best );
+}
+#endif
+
+#if defined( B3_SIMD_AVX512 ) || defined( B3_SIMD_NEON )
+
+#if defined( B3_SIMD_AVX512 )
+#include <immintrin.h>
+// AVX-512 multiplies 64-bit lanes directly
+typedef b3Fixed b3EdgeLane;
+#else
+#include <arm_neon.h>
+// NEON has only 32x32->64 widening multiplies, so the SoA staging narrows to
+// int32; the admission check below rejects anything that would not fit and
+// the truncated values are then never read
+typedef int32_t b3EdgeLane;
+#endif
+
+// Hulls index edges with uint8_t, so at most 256 half-edges = 128 edge pairs
+#define B3_MAX_HULL_EDGE_PAIRS 128
 
 #endif
 
@@ -439,6 +470,19 @@ static b3SeparatingAxis b3QueryEdgeDirections( const b3HullData* hullA, const b3
 		}
 	}
 
+#else
+	uint64_t normalBoundA = 0;
+	for ( int i = 0; i < hullA->faceCount; ++i )
+	{
+		b3Vec3 n = planesA[i].normal;
+		uint64_t candidates[3] = { b3EdgeAbsBoundU64( n.x ), b3EdgeAbsBoundU64( n.y ), b3EdgeAbsBoundU64( n.z ) };
+		for ( int j = 0; j < 3; ++j )
+		{
+			normalBoundA = candidates[j] > normalBoundA ? candidates[j] : normalBoundA;
+		}
+	}
+#endif
+
 	// |edge component| <= |aabb.lower| + |aabb.upper| for a difference of two
 	// hull points, so the int64 dot bound below is sound for valid hull data
 	uint64_t edgeBound = 0;
@@ -453,7 +497,6 @@ static b3SeparatingAxis b3QueryEdgeDirections( const b3HullData* hullA, const b3
 			edgeBound = candidates[i] > edgeBound ? candidates[i] : edgeBound;
 		}
 	}
-#endif
 
 	// Arranged to minimize transform operations
 	for ( int indexB = 0; indexB < hullB->edgeCount; indexB += 2 )
@@ -469,7 +512,6 @@ static b3SeparatingAxis b3QueryEdgeDirections( const b3HullData* hullA, const b3
 		b3Vec3 uB = b3MulMV( matrix, planesB[edgeB->face].normal );
 		b3Vec3 vB = b3MulMV( matrix, planesB[twinB->face].normal );
 
-#if defined( B3_SIMD_AVX512 ) || defined( B3_SIMD_NEON )
 		// Gate on the actual rotated normals against the edge bound
 		uint64_t uvMax = b3EdgeAbsBoundU64( uB.x );
 		{
@@ -490,6 +532,7 @@ static b3SeparatingAxis b3QueryEdgeDirections( const b3HullData* hullA, const b3
 			eBMax = candidates[1] > eBMax ? candidates[1] : eBMax;
 		}
 
+#if defined( B3_SIMD_AVX512 ) || defined( B3_SIMD_NEON )
 		if ( pairCountA >= 4 && b3EdgeWideAdmissible( uvMax, edgeBound, normalBoundA, eBMax ) )
 		{
 			int pair = 0;
@@ -665,6 +708,15 @@ static b3SeparatingAxis b3QueryEdgeDirections( const b3HullData* hullA, const b3
 				b3TestEdgePair( edgesA, pointsA, planesA, 2 * pair, eB, qB, uB, vB, squaredTolerance, indexB, &best );
 			}
 
+			continue;
+		}
+#else
+		if ( b3EdgeWideAdmissible( uvMax, edgeBound, normalBoundA, eBMax ) )
+		{
+			for ( int indexA = 0; indexA < hullA->edgeCount; indexA += 2 )
+			{
+				b3TestEdgePair64( edgesA, pointsA, planesA, indexA, eB, qB, uB, vB, squaredTolerance, indexB, &best );
+			}
 			continue;
 		}
 #endif
@@ -969,6 +1021,7 @@ void b3CollideHullAndSphere( b3LocalManifold* manifold, int capacity, const b3Hu
 		*cache = (b3SimplexCache){ 0 };
 		return;
 	}
+
 
 	if ( distanceOutput.distance > 100 * B3_FIXED_EPSILON )
 	{

--- a/src/distance.c
+++ b/src/distance.c
@@ -219,10 +219,13 @@ static bool b3SolveSimplex2( b3Simplex* simplex )
 		return false;
 	}
 
-	// VR( AB )
-	b3Fixed denominator = b3FixDiv( B3_FIX( 1.0f ) , divisor );
-	vs[0].a = b3FixMul( denominator , u );
-	vs[1].a = b3FixMul( denominator , v );
+	// VR( AB ). Form the ratio directly: 1 / |AB|^2 rounds to zero for
+	// edges longer than 256. Normalize the rounded numerators and derive the
+	// other weight by subtraction so the witnesses remain affine combinations.
+	// u and v are positive here; their unsigned sum cannot overflow uint64.
+	uint64_t sum = (uint64_t)u + (uint64_t)v;
+	vs[1].a = (b3Fixed)( ( (b3UInt128)(uint64_t)v << B3_FIXED_FRACTION_BITS ) / sum );
+	vs[0].a = B3_FIXED_ONE - vs[1].a;
 
 	return true;
 }

--- a/src/math_internal.h
+++ b/src/math_internal.h
@@ -405,6 +405,31 @@ static inline b3Vec2 b3Solve2( b3Matrix2 m, b3Vec2 b )
 	return B3_LITERAL( b3Vec2 ){ B3_FIX( 0.0f ), B3_FIX( 0.0f ) };
 }
 
+// Solve K*x = b with inverse-scaled K and ordinary b/x. The numerator has
+// 40+16 fractional bits and the determinant has 80, so shift by 40, not 16.
+// Two int64 products and their difference fit in int128; the additional shift
+// need not. Keep ordinary solves in int128 and widen only that overflow case.
+static inline b3Vec2 b3Solve2AcrossScales( b3Matrix2 m, b3Vec2 b )
+{
+	b3Int128 det = b3Cofactor128( m.cx.x, m.cy.y, m.cx.y, m.cy.x );
+	if ( fixInt128Le( det, FIX_INT128_ZERO ) )
+	{
+		return B3_LITERAL( b3Vec2 ){ 0, 0 };
+	}
+
+	b3Int128 nx = b3Cofactor128( m.cy.y, b.x, m.cy.x, b.y );
+	b3Int128 ny = b3Cofactor128( m.cx.x, b.y, m.cx.y, b.x );
+	const int shift = B3_INVERSE_FRACTION_BITS;
+	b3Int128 limit = b3Int128ShiftLeft( fixInt128FromI64( 1 ), 127 - shift );
+	if ( fixInt128InRange( nx, limit ) && fixInt128InRange( ny, limit ) )
+	{
+		return B3_LITERAL( b3Vec2 ){ fixDivShifted( nx, shift, det ), fixDivShifted( ny, shift, det ) };
+	}
+
+	fixUInt256 wideDet = fixUInt256FromU128( fixInt128ToUnsigned( det ) );
+	return B3_LITERAL( b3Vec2 ){ fixDivShiftedWide( nx, shift, wideDet, false ), fixDivShiftedWide( ny, shift, wideDet, false ) };
+}
+
 // Convenience function: s * a + t * b + u * c
 static inline b3Vec3 b3Blend3( b3Fixed s, b3Vec3 a, b3Fixed t, b3Vec3 b, b3Fixed u, b3Vec3 c )
 {

--- a/src/parallel_joint.c
+++ b/src/parallel_joint.c
@@ -209,7 +209,7 @@ void b3SolveParallelJoint( b3JointSim* base, b3StepContext* context )
 		b3Fixed maxImpulse = b3FixMul( context->h , joint->maxTorque );
 		b3Vec2 oldImpulse = joint->perpImpulse;
 		b3Vec2 cdotPlusBias = { cdot.x + bias.x, cdot.y + bias.y };
-		b3Vec2 sol = b3Solve2( k, cdotPlusBias );
+		b3Vec2 sol = b3Solve2AcrossScales( k, cdotPlusBias );
 		b3Vec2 deltaImpulse = {
 			b3FixMul( -massScale , sol.x ) - b3FixMul( impulseScale , oldImpulse.x ),
 			b3FixMul( -massScale , sol.y ) - b3FixMul( impulseScale , oldImpulse.y ),

--- a/src/prismatic_joint.c
+++ b/src/prismatic_joint.c
@@ -661,7 +661,7 @@ void b3SolvePrismaticJoint( b3JointSim* base, b3StepContext* context, bool useBi
 		b3Matrix2 K = { { kyy, kyz }, { kyz, kzz } };
 
 		b3Vec2 oldImpulse = joint->perpImpulse;
-		b3Vec2 sol = b3Solve2( K, b3Add2( cdot, bias ) );
+		b3Vec2 sol = b3Solve2AcrossScales( K, b3Add2( cdot, bias ) );
 		b3Vec2 deltaImpulse = b3Sub2( b3MulSV2( -massScale, sol ), b3MulSV2( impulseScale, oldImpulse ) );
 		joint->perpImpulse = b3Add2( oldImpulse, deltaImpulse );
 

--- a/src/revolute_joint.c
+++ b/src/revolute_joint.c
@@ -546,7 +546,7 @@ void b3SolveRevoluteJoint( b3JointSim* base, b3StepContext* context, bool useBia
 		b3Vec3 wRel = b3Sub( wB, wA );
 		b3Vec2 cdot = { b3Dot( wRel, perpAxisX ), b3Dot( wRel, perpAxisY ) };
 		b3Vec2 oldImpulse = joint->perpImpulse;
-		b3Vec2 sol = b3Solve2( k, b3Add2( cdot, bias ) );
+		b3Vec2 sol = b3Solve2AcrossScales( k, b3Add2( cdot, bias ) );
 		b3Vec2 deltaImpulse = b3Sub2( b3MulSV2( -massScale, sol ), b3MulSV2( impulseScale, oldImpulse ) );
 		joint->perpImpulse = b3Add2( joint->perpImpulse, deltaImpulse );
 

--- a/src/wheel_joint.c
+++ b/src/wheel_joint.c
@@ -923,7 +923,7 @@ void b3SolveWheelJoint( b3JointSim* base, b3StepContext* context, bool useBias )
 			b3Vec2 cdot = { b3Dot( wRel, perpAxisX ), b3Dot( wRel, perpAxisY ) };
 			b3Vec2 oldImpulse = joint->angularImpulse;
 			b3Vec2 cdotPlusBias = { cdot.x + bias.x, cdot.y + bias.y };
-			b3Vec2 sol = b3Solve2( k, cdotPlusBias );
+			b3Vec2 sol = b3Solve2AcrossScales( k, cdotPlusBias );
 			b3Vec2 deltaImpulse = {
 				b3FixMul( -massScale , sol.x ) - b3FixMul( impulseScale , oldImpulse.x ),
 				b3FixMul( -massScale , sol.y ) - b3FixMul( impulseScale , oldImpulse.y ),
@@ -966,7 +966,7 @@ void b3SolveWheelJoint( b3JointSim* base, b3StepContext* context, bool useBias )
 
 		b3Vec2 oldImpulse = joint->linearImpulse;
 		b3Vec2 cdotPlusBias = { cdot.x + bias.x, cdot.y + bias.y };
-		b3Vec2 sol = b3Solve2( k, cdotPlusBias );
+		b3Vec2 sol = b3Solve2AcrossScales( k, cdotPlusBias );
 		b3Vec2 deltaImpulse = {
 			b3FixMul( -massScale , sol.x ) - b3FixMul( impulseScale , oldImpulse.x ),
 			b3FixMul( -massScale , sol.y ) - b3FixMul( impulseScale , oldImpulse.y ),

--- a/test/test_body.c
+++ b/test/test_body.c
@@ -718,8 +718,37 @@ static int ShapeExtents( void )
 	return 0;
 }
 
+// An angular impulse changes velocity by inverse inertia times impulse. Use
+// anisotropic inertia and a rotated body to check the local/world conversion too.
+static int AngularImpulseInverseScale( void )
+{
+	b3WorldDef worldDef = b3DefaultWorldDef();
+	b3WorldId worldId = b3CreateWorld( &worldDef );
+	b3BodyDef bodyDef = b3DefaultBodyDef();
+	bodyDef.type = b3_dynamicBody;
+	bodyDef.rotation = b3MakeQuatFromAxisAngle( b3Vec3_axisZ, B3_FIX( 0.5f ) );
+	b3BodyId bodyId = b3CreateBody( worldId, &bodyDef );
+	b3MassData mass = { 0 };
+	mass.mass = B3_FIX( 1.0f );
+	mass.inertia = (b3Matrix3){ { B3_FIX( 2.0f ), 0, 0 }, { 0, B3_FIX( 4.0f ), 0 }, { 0, 0, B3_FIX( 8.0f ) } };
+	b3Body_SetMassData( bodyId, mass );
+	b3Vec3 localImpulse = { B3_FIX( 1.0f ), B3_FIX( -2.0f ), B3_FIX( 2.0f ) };
+	b3Vec3 initial = { B3_FIX( 0.25f ), B3_FIX( 0.5f ), B3_FIX( -0.25f ) };
+	b3Body_SetAngularVelocity( bodyId, initial );
+	b3Body_ApplyAngularImpulse( bodyId, b3RotateVector( bodyDef.rotation, localImpulse ), true );
+	b3Vec3 expected =
+		b3Add( initial, b3RotateVector( bodyDef.rotation, (b3Vec3){ B3_FIX( 0.5f ), B3_FIX( -0.5f ), B3_FIX( 0.25f ) } ) );
+	b3Vec3 actual = b3Body_GetAngularVelocity( bodyId );
+	b3DestroyWorld( worldId );
+	ENSURE_SMALL( actual.x - expected.x, B3_FIX( 0.001f ) );
+	ENSURE_SMALL( actual.y - expected.y, B3_FIX( 0.001f ) );
+	ENSURE_SMALL( actual.z - expected.z, B3_FIX( 0.001f ) );
+	return 0;
+}
+
 int BodyTest( void )
 {
+	RUN_SUBTEST( AngularImpulseInverseScale );
 	RUN_SUBTEST( InverseMassQuantumFloor );
 	RUN_SUBTEST( InverseInertiaScaleEnvelope );
 	RUN_SUBTEST( InverseMassQuantumFloorFromShapes );

--- a/test/test_determinism.c
+++ b/test/test_determinism.c
@@ -28,11 +28,13 @@
 //
 // A SLEEP STEP OF 0 MEANS THE RAGDOLLS NEVER SETTLED, which is what a missed scale
 // crossing looks like from here. Read a zero as that before re-capturing anything.
-#define RAGDOLL_SLEEP_STEP 312
+// The inverse-scaled 2x2 joint solves restore the ragdolls' alignment constraints.
+// These references include that correction; zero would still mean no settling.
+#define RAGDOLL_SLEEP_STEP 279
 #if defined( BOX3D_LUDICROUS_MODE )
-#define RAGDOLL_HASH 0x5A1D71FF
+#define RAGDOLL_HASH 0x9D664C70
 #else
-#define RAGDOLL_HASH 0xC745DFFF
+#define RAGDOLL_HASH 0x3B32F0B0
 #endif
 
 // Goldens for the wave pile, query spawn and mesh drop scenarios. Fixed-point goldens

--- a/test/test_determinism.c
+++ b/test/test_determinism.c
@@ -29,31 +29,31 @@
 // A SLEEP STEP OF 0 MEANS THE RAGDOLLS NEVER SETTLED, which is what a missed scale
 // crossing looks like from here. Read a zero as that before re-capturing anything.
 // The inverse-scaled 2x2 joint solves restore the ragdolls' alignment constraints.
-// These references include that correction; zero would still mean no settling.
-#define RAGDOLL_SLEEP_STEP 279
+// These references also include normalized GJK edge weights; zero still means no settling.
+#define RAGDOLL_SLEEP_STEP 310
 #if defined( BOX3D_LUDICROUS_MODE )
-#define RAGDOLL_HASH 0x9D664C70
+#define RAGDOLL_HASH 0x4CBB0862
 #else
-#define RAGDOLL_HASH 0x3B32F0B0
+#define RAGDOLL_HASH 0x8B6562E2
 #endif
 
 // Goldens for the wave pile, query spawn and mesh drop scenarios. Fixed-point goldens
 // hold across platforms and worker counts by construction. The sleep steps are shared
 // between builds; the hashes cover absolute transform bytes, so the ludicrous build
 // (128-bit positions, 80-byte b3WorldTransform) carries its own values.
-#define WAVE_PILE_SLEEP_STEP 286
+#define WAVE_PILE_SLEEP_STEP 278
 #define QUERY_SPAWN_SLEEP_STEP 243
 #define QUERY_SPAWN_HIT_COUNT 59
 #define QUERY_SPAWN_QUERY_HASH 0xE583B246
 #define MESH_DROP_SLEEP_STEP 210
 #if defined( BOX3D_LUDICROUS_MODE )
-#define WAVE_PILE_HASH 0x180F40D3
+#define WAVE_PILE_HASH 0xB5731AB7
 #define QUERY_SPAWN_HASH 0x7C6B3268
-#define MESH_DROP_HASH 0xABA23F15
+#define MESH_DROP_HASH 0xDB1DA8B9
 #else
-#define WAVE_PILE_HASH 0x9B108F93
+#define WAVE_PILE_HASH 0x9DF19177
 #define QUERY_SPAWN_HASH 0x49ECDEA8
-#define MESH_DROP_HASH 0x458A95E7
+#define MESH_DROP_HASH 0x491E324B
 #endif
 
 static int SingleMultithreadingTest( int workerCount )

--- a/test/test_distance.c
+++ b/test/test_distance.c
@@ -102,8 +102,38 @@ static int TimeOfImpactTest( void )
 	return 0;
 }
 
+static int LongEdgeDistanceTest( void )
+{
+	// A point above an interior point of a segment has an analytical witness.
+	// At length > 256 the Q48.16 reciprocal of the squared length is zero.
+	const int lengths[] = { 128, 256, 257, 512, 1024 };
+	for ( int i = 0; i < ARRAY_COUNT( lengths ); ++i )
+	{
+		b3Fixed length = b3FixFromInt( lengths[i] );
+		b3Vec3 edge[2] = { { B3_FIX( 3.0f ), B3_FIX( 4.0f ), 0 }, { B3_FIX( 3.0f ) + length, B3_FIX( 4.0f ), 0 } };
+		// The extra unit makes the weight nonrepresentable for non-power-of-two edges.
+		b3Vec3 point = { B3_FIX( 4.0f ) + length / 4, B3_FIX( 6.0f ), 0 };
+		b3DistanceInput input = { 0 };
+		input.proxyA = (b3ShapeProxy){ edge, 2, 0 };
+		input.proxyB = (b3ShapeProxy){ &point, 1, 0 };
+		input.transform = b3Transform_identity;
+		b3SimplexCache cache = { 0 };
+		for ( int repeat = 0; repeat < 2; ++repeat )
+		{
+			b3DistanceOutput output = b3ShapeDistance( &input, &cache, NULL, 0 );
+			ENSURE_SMALL( output.distance - B3_FIX( 2.0f ), B3_FIX( 0.001f ) );
+			ENSURE_SMALL( output.pointA.x - point.x, lengths[i] * B3_FIXED_EPSILON + 2 );
+			ENSURE_SMALL( output.pointA.y - B3_FIX( 4.0f ), 2 * B3_FIXED_EPSILON );
+			ENSURE_SMALL( output.pointB.x - point.x, 2 * B3_FIXED_EPSILON );
+			ENSURE_SMALL( output.pointB.y - point.y, 2 * B3_FIXED_EPSILON );
+		}
+	}
+	return 0;
+}
+
 int DistanceTest( void )
 {
+	RUN_SUBTEST( LongEdgeDistanceTest );
 	RUN_SUBTEST( SegmentDistanceTest );
 	RUN_SUBTEST( ShapeDistanceTest );
 	RUN_SUBTEST( ShapeCastTest );

--- a/test/test_joint.c
+++ b/test/test_joint.c
@@ -597,8 +597,89 @@ static int TestWheelJoint( void )
 	return FinishJoint( jointId, f.worldId );
 }
 
+// Exercise the five 2x2 constraint solves with actual velocity errors. Accessor
+// tests with an already-satisfied joint cannot detect an inverse-scale mismatch.
+static int TestJointInverseScaleCorrection( void )
+{
+	const b3JointType types[] = { b3_parallelJoint, b3_prismaticJoint, b3_revoluteJoint, b3_wheelJoint };
+	int failures = 0;
+	for ( int index = 0; index < ARRAY_COUNT( types ); ++index )
+	{
+		JointFixture f = CreateJointFixture();
+		b3JointType type = types[index];
+		b3JointId jointId = b3_nullJointId;
+		switch ( type )
+		{
+			case b3_parallelJoint:
+			{
+				b3ParallelJointDef def = b3DefaultParallelJointDef();
+				SetCommonFrames( &def.base, &f );
+				def.hertz = B3_FIX( 5.0f );
+				jointId = b3CreateParallelJoint( f.worldId, &def );
+			}
+			break;
+			case b3_prismaticJoint:
+			{
+				b3PrismaticJointDef def = b3DefaultPrismaticJointDef();
+				SetCommonFrames( &def.base, &f );
+				jointId = b3CreatePrismaticJoint( f.worldId, &def );
+			}
+			break;
+			case b3_revoluteJoint:
+			{
+				b3RevoluteJointDef def = b3DefaultRevoluteJointDef();
+				SetCommonFrames( &def.base, &f );
+				jointId = b3CreateRevoluteJoint( f.worldId, &def );
+			}
+			break;
+			case b3_wheelJoint:
+			{
+				b3WheelJointDef def = b3DefaultWheelJointDef();
+				SetCommonFrames( &def.base, &f );
+				def.enableSuspensionSpring = false;
+				jointId = b3CreateWheelJoint( f.worldId, &def );
+			}
+			break;
+			default:
+				break;
+		}
+
+		bool checkLinear = type == b3_prismaticJoint || type == b3_wheelJoint;
+		bool checkAngular = type != b3_prismaticJoint;
+		if ( checkLinear )
+		{
+			b3Body_SetLinearVelocity( f.bodyId, (b3Vec3){ 0, B3_FIX( 1.0f ), -B3_FIX( 0.5f ) } );
+		}
+		if ( checkAngular )
+		{
+			b3Body_SetAngularVelocity( f.bodyId, (b3Vec3){ B3_FIX( 0.5f ), -B3_FIX( 0.25f ), 0 } );
+		}
+
+		for ( int step = 0; step < 30; ++step )
+		{
+			b3World_Step( f.worldId, b3FixDiv( B3_FIX( 1.0f ), B3_FIX( 60.0f ) ), 4 );
+		}
+
+		b3Vec3 v = b3Body_GetLinearVelocity( f.bodyId );
+		b3Vec3 w = b3Body_GetAngularVelocity( f.bodyId );
+		bool linearCorrected = !checkLinear || ( b3FixAbs( v.y ) < B3_FIX( 0.025f ) && b3FixAbs( v.z ) < B3_FIX( 0.025f ) );
+		bool angularCorrected = !checkAngular || ( b3FixAbs( w.x ) < B3_FIX( 0.025f ) && b3FixAbs( w.y ) < B3_FIX( 0.025f ) );
+		if ( !linearCorrected || !angularCorrected )
+		{
+			printf( "  joint type %d: lateral velocity=(%g,%g), angular velocity=(%g,%g)\n", type, b3FixToDouble( v.y ),
+					b3FixToDouble( v.z ), b3FixToDouble( w.x ), b3FixToDouble( w.y ) );
+			failures += 1;
+		}
+		b3DestroyJoint( jointId, true );
+		b3DestroyWorld( f.worldId );
+	}
+	ENSURE( failures == 0 );
+	return 0;
+}
+
 int JointTest( void )
 {
+	RUN_SUBTEST( TestJointInverseScaleCorrection );
 	RUN_SUBTEST( TestParallelJoint );
 	RUN_SUBTEST( TestParallelJointSentinelTorqueCap );
 	RUN_SUBTEST( TestDistanceJoint );

--- a/test/test_manifold.c
+++ b/test/test_manifold.c
@@ -151,6 +151,31 @@ static int EdgeAxisScaleTest( void )
 	return 0;
 }
 
+// Large crossed boxes exercise edge-axis rejection on both sides of the
+// int64 dot bound. A clear gap isolates the separating-axis result from
+// contact reconstruction, and the separating edge has an analytic answer.
+static int EdgeAxisLargeScaleTest( void )
+{
+	b3Fixed scales[] = { B3_FIX( 8192.0f ), B3_FIX( 16384.0f ), B3_FIX( 32768.0f ) };
+	for ( int i = 0; i < ARRAY_COUNT( scales ); ++i )
+	{
+		b3Fixed s = scales[i];
+		b3BoxHull hullA, hullB;
+		MakeCrossedEdgeHulls( &hullA, &hullB, b3FixMul( B3_FIX( 0.5f ), s ) );
+		b3Fixed expected = B3_FIX( 1.0f );
+		b3Fixed d = b3FixMul( s, kRoot2 ) + expected;
+		b3LocalManifoldPoint points[8];
+		b3LocalManifold manifold = { 0 };
+		manifold.points = points;
+		b3SATCache cache = { 0 };
+		b3CollideHulls( &manifold, 8, &hullA.base, &hullB.base, SlideX( d ), &cache );
+		ENSURE( manifold.pointCount == 0 );
+		ENSURE( cache.type == b3_edgePairAxis );
+		ENSURE_SMALL( cache.separation - expected, b3FixMul( 8 * B3_FIXED_EPSILON, s ) );
+	}
+	return 0;
+}
+
 // The cached edge pair rebuilds the axis without a fresh query. An untouched cache proves the
 // cached branch answered rather than falling through to the full SAT.
 static int EdgeCacheTest( void )
@@ -1362,6 +1387,7 @@ int ManifoldTest( void )
 {
 	RUN_SUBTEST( CrossedEdgeTest );
 	RUN_SUBTEST( EdgeAxisScaleTest );
+	RUN_SUBTEST( EdgeAxisLargeScaleTest );
 	RUN_SUBTEST( EdgeCacheTest );
 	RUN_SUBTEST( EdgeEndpointTest );
 	RUN_SUBTEST( ParallelEdgeTest );

--- a/test/test_math.c
+++ b/test/test_math.c
@@ -323,8 +323,44 @@ static int RandomQuatTest( void )
 	return 0;
 }
 
+static int Solve2InverseScaleTest( void )
+{
+	// K = s * [[3, 1], [1, 2]], b = s * [3, -4] has x = [2, -3].
+	// The largest case needs more than 128 bits after shifting its numerator.
+	const int bits[] = { 32, 40, 54 };
+	for ( int i = 0; i < ARRAY_COUNT( bits ); ++i )
+	{
+		b3Fixed scale = (b3Fixed)1 << bits[i];
+		b3Fixed rhsScale = (b3Fixed)1 << ( bits[i] - B3_INVERSE_EXTRA_BITS );
+		b3Matrix2 m = { { 3 * scale, scale }, { scale, 2 * scale } };
+		b3Vec2 b = { 3 * rhsScale, -4 * rhsScale };
+		b3Vec2 x = b3Solve2AcrossScales( m, b );
+		ENSURE( x.x == B3_FIX( 2.0f ) );
+		ENSURE( x.y == -B3_FIX( 3.0f ) );
+	}
+
+	// Straddle the int128 numerator limit on both signs. Both arithmetic paths
+	// must truncate the same exact quotient toward zero.
+	b3Fixed diagonal = (b3Fixed)1 << 47;
+	b3Matrix2 m = { { diagonal, 0 }, { 0, diagonal } };
+	for ( int delta = -1; delta <= 1; ++delta )
+	{
+		b3Fixed rhs = ( (b3Fixed)1 << 40 ) + delta;
+		b3Vec2 x = b3Solve2AcrossScales( m, (b3Vec2){ rhs, -rhs } );
+		b3Fixed expected = ( (b3Fixed)1 << 33 ) - ( delta < 0 ? 1 : 0 );
+		ENSURE( x.x == expected );
+		ENSURE( x.y == -expected );
+	}
+
+	b3Matrix2 singular = { { diagonal, diagonal }, { diagonal, diagonal } };
+	b3Vec2 x = b3Solve2AcrossScales( singular, (b3Vec2){ B3_FIXED_ONE, -B3_FIXED_ONE } );
+	ENSURE( x.x == 0 && x.y == 0 );
+	return 0;
+}
+
 int MathTest( void )
 {
+	RUN_SUBTEST( Solve2InverseScaleTest );
 	// Compare the fixed-point trig against double precision references from libm.
 	// The fixed-point results carry the approximation error of the underlying
 	// polynomial plus Q48.16 output quantization (about 1.5e-5).

--- a/tools/capture/README.md
+++ b/tools/capture/README.md
@@ -50,3 +50,60 @@ frames and structural differences, not pixel equality. Known real divergences as
 of 2026-07-14 (see CLAUDE.md): Stacking/Card House stands in float, collapses in
 fixed (equilibrium knife edge at the Q48.16 resolution floor); the World/Far
 samples diverge in fixed point's favor (float shatters at 10,000 km).
+
+## Repeated captures and exact pixel hashes
+
+`compare_samples.py` runs the same named samples in both applications, prints a
+SHA-256 hash of each decoded RGBA image, and writes `report.json` and `report.html`.
+It requires Python 3.11+ and Pillow. It runs each sample twice by default and fails
+if the same binary produces different pixels, a capture fails, a counterpart is
+missing, or image sizes differ. Its output directory must be new so stale images
+cannot pass as fresh captures. Binary hashes, sample indexes, frame count, full
+image hashes and difference metrics are retained in the JSON report.
+
+For the current float upstream revision `47d7f7c`, use the self-contained
+`float-47d7f7c-capture-hooks.patch` instead of the older patch above. It includes
+both capture support files and changes only the sample host, not the engine:
+
+```sh
+git -C <box3d> worktree add --detach <scratch>/floatref 47d7f7c
+git -C <scratch>/floatref apply <fixed3d>/tools/capture/float-47d7f7c-capture-hooks.patch
+cmake -S <scratch>/floatref -B <scratch>/float-build \
+  -DBOX3D_SAMPLES=ON -DBOX3D_UNIT_TESTS=OFF \
+  -DBOX3D_DOUBLE_PRECISION=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake --build <scratch>/float-build
+```
+
+Then compare selected samples (or omit `--match` for the full sample union):
+
+```sh
+python3 tools/capture/compare_samples.py \
+  --fixed <fixed-build>/bin/samples --fixed-data <fixed3d>/data \
+  --float <float-build>/bin/samples --float-data <floatref>/data \
+  --output <new-output-directory> --seconds 2 --no-axes \
+  --match '^Joints/(Parallel Spring|Prismatic|Revolute|Wheel)$'
+```
+
+`--seconds` means nominal simulation time at 60 Hz; `--frames N` selects the
+number of physics frames directly. Each frame uses the sample's own substep
+setting. The fixed timestep is quantized to Q48.16, so two nominal seconds are
+not exactly two seconds of integrated time. Both apps start from fresh processes
+with their authored seeds, camera, settings and default worker count; interactive
+settings are not loaded by the headless path. Samples that seed from wall time
+can fail the repeatability check and need a deterministic seed before comparison.
+
+`--no-axes` passes `--capture-no-axes` to both headless applications, hiding just
+the colored absolute world-axis lines. This is useful because current Fixed3D
+builds these scenes around 120,000,000,000 units on each axis, while float samples
+are generally centered at zero. The repeating ground grid and physics are
+unchanged. Without this option, those lines alone can produce different hashes.
+
+Add `--exact` to fail on any difference between the two image hashes. This is an
+exact *pixel* check, not a general physics compliance test: an image cannot see
+velocities, hidden objects, contacts or future behavior. Float and fixed are not
+expected to produce identical pixels in every scene, especially after chaotic
+motion. Inspect the full-resolution pairs and retain analytical numerical tests.
+The report also gives changed-pixel percentage, RGB mean absolute difference,
+and a small-image luminance metric for sorting. No tolerance is silently treated
+as a physics pass. GPU/renderer changes can invalidate image references, so keep
+the binaries and environment consistent when using these as regression goldens.

--- a/tools/capture/compare_samples.py
+++ b/tools/capture/compare_samples.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Capture matching samples and compare decoded pixels, with repeatability checks.
+
+Requires macOS capture-enabled binaries and Pillow. Hash equality is exact image
+identity, not proof of physics equivalence. Float/fixed numerical drift is expected.
+"""
+import argparse
+import hashlib
+import html
+import json
+import re
+import subprocess
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+
+from PIL import Image, ImageChops, ImageStat
+
+
+def sha256(path):
+    with path.open('rb') as stream:
+        return hashlib.file_digest(stream, 'sha256').hexdigest()
+
+
+def pixels(path):
+    with Image.open(path) as source:
+        image = source.convert('RGBA')
+    header = f'RGBA:{image.width}x{image.height}\0'.encode('ascii')
+    digest = hashlib.sha256(header + image.tobytes()).hexdigest()
+    return image, digest
+
+
+def enumerate_samples(binary, cwd):
+    result = subprocess.run([str(binary), '--list-samples'], cwd=cwd,
+                            capture_output=True, text=True, check=True, timeout=30)
+    samples = {}
+    for line in result.stdout.splitlines():
+        index, category, name = line.split('\t', 2)
+        key = f'{category}/{name}'
+        if key in samples:
+            raise ValueError(f'duplicate sample name: {key}')
+        samples[key] = int(index)
+    return samples
+
+
+def run(args):
+    pattern = re.compile(args.match)
+    frames = args.frames
+    if args.seconds is not None:
+        count = args.seconds * 60
+        if not count.is_finite() or count != count.to_integral_value() or count < 0:
+            raise ValueError('--seconds must be a nonnegative multiple of 1/60')
+        frames = int(count)
+    if frames < 0 or args.repeat < 1 or args.timeout <= 0:
+        raise ValueError('frames must be nonnegative; repeat and timeout must be positive')
+    out = args.output.resolve()
+    # Refuse reuse: a stale PNG must never count as a successful new capture.
+    out.mkdir(parents=True, exist_ok=False)
+    builds = {}
+    for label in ('fixed', 'float'):
+        binary = getattr(args, label).resolve(strict=True)
+        data = getattr(args, label + '_data').resolve(strict=True)
+        cwd = out / label / 'cwd'
+        cwd.mkdir(parents=True)
+        (cwd / 'data').symlink_to(data, target_is_directory=True)
+        builds[label] = dict(binary=str(binary), binary_sha256=sha256(binary),
+                             data=str(data), samples=enumerate_samples(binary, cwd))
+    names = sorted(k for k in set(builds['fixed']['samples']) | set(builds['float']['samples'])
+                   if pattern.search(k))
+    if not names:
+        raise ValueError('no samples match the expression')
+    report = dict(created_utc=datetime.now(timezone.utc).isoformat(), frames=frames,
+                  nominal_hz=60, repeat=args.repeat, match=args.match, no_axes=args.no_axes, builds=builds,
+                  pixel_hash='SHA256 of ASCII RGBA:WIDTHxHEIGHT followed by NUL and decoded RGBA bytes',
+                  rows=[])
+    failure = False
+    for name in names:
+        slug = re.sub(r'[^A-Za-z0-9_.-]', '_', name) + '-' + hashlib.sha256(name.encode()).hexdigest()[:12]
+        row = dict(sample=name, captures={}, errors=[])
+        for label, build in builds.items():
+            if name not in build['samples']:
+                row['errors'].append(f'{label}: no matching sample')
+                continue
+            captures = []
+            for repeat in range(args.repeat):
+                png = out / label / f'{slug}-{repeat}.png'
+                log = png.with_suffix('.log')
+                command = [build['binary'], '--headless', '--sample', str(build['samples'][name]),
+                           '--frames', str(frames), '--capture', str(png)]
+                if args.no_axes:
+                    command.append('--capture-no-axes')
+                try:
+                    with log.open('w') as stream:
+                        subprocess.run(command, cwd=out / label / 'cwd', stdout=stream,
+                                       stderr=subprocess.STDOUT, check=True, timeout=args.timeout)
+                    image, digest = pixels(png)
+                    captures.append(dict(png=str(png.relative_to(out)), pixel_sha256=digest,
+                                         width=image.width, height=image.height))
+                    print(f'{label} {name} run={repeat} pixel_sha256={digest}', flush=True)
+                except (subprocess.SubprocessError, OSError, ValueError) as error:
+                    row['errors'].append(f'{label} run {repeat}: {error}')
+            row['captures'][label] = captures
+            if len({c['pixel_sha256'] for c in captures}) > 1:
+                row['errors'].append(f'{label}: pixels differ between repeated runs')
+        fixed, flt = (row['captures'].get(k, []) for k in ('fixed', 'float'))
+        if fixed and flt:
+            a, _ = pixels(out / fixed[0]['png'])
+            b, _ = pixels(out / flt[0]['png'])
+            row['exact_pixel_match'] = fixed[0]['pixel_sha256'] == flt[0]['pixel_sha256']
+            if a.size == b.size:
+                diff = ImageChops.difference(a.convert('RGB'), b.convert('RGB'))
+                row['mean_absolute_rgb_difference'] = sum(ImageStat.Stat(diff).mean) / 3
+                channels = diff.split()
+                changed = ImageChops.lighter(ImageChops.lighter(channels[0], channels[1]), channels[2])
+                row['changed_pixel_percent'] = 100 * (1 - changed.histogram()[0] / (a.width * a.height))
+                row['mean_luminance_difference_64x36'] = ImageStat.Stat(ImageChops.difference(
+                    a.convert('L').resize((64, 36)), b.convert('L').resize((64, 36)))).mean[0]
+            else:
+                row['errors'].append('image dimensions differ')
+            for label, image in (('fixed', a), ('float', b)):
+                thumb = out / label / f'{slug}-thumb.png'
+                image.thumbnail((640, 360))
+                image.save(thumb)
+                row[label + '_thumbnail'] = str(thumb.relative_to(out))
+        failure |= bool(row['errors']) or (args.exact and not row.get('exact_pixel_match', False))
+        report['rows'].append(row)
+        # Preserve completed evidence if a later sample is interrupted.
+        (out / 'report.json').write_text(json.dumps(report, indent=2) + '\n')
+    rows = sorted(report['rows'], key=lambda r: r.get('mean_luminance_difference_64x36', -1), reverse=True)
+    doc = ['<!doctype html><meta charset="utf-8"><title>Box3D / Fixed3D sample comparison</title>',
+           '<style>body{font:16px system-ui;background:#161618;color:#eee;margin:24px}table{border-collapse:collapse}'
+           'td,th{padding:12px;vertical-align:top;text-align:left}img{width:100%;max-width:640px}.error{color:#ff9c9c}</style>',
+           '<h1>Box3D / Fixed3D sample comparison</h1>',
+           f'<p>{len(rows)} samples; {frames} steps at nominal 60 Hz; {args.repeat} independent runs per build. '
+           'Sorted by mean luminance difference at 64×36. Hashes compare full-resolution RGBA pixels. '
+           'Different pixels are evidence to inspect, not automatically a physics defect.</p>',
+           '<p><a href="report.json">Run settings, binary hashes, pixel hashes and metrics</a></p>',
+           '<table><tr><th>Sample / difference</th><th>Fixed3D</th><th>Box3D float</th></tr>']
+    for row in rows:
+        info = html.escape(row['sample'])
+        if 'exact_pixel_match' in row:
+            info += '<br>Exact pixels: ' + str(row['exact_pixel_match'])
+        if 'changed_pixel_percent' in row:
+            info += f"<br>Changed: {row['changed_pixel_percent']:.3f}%<br>RGB MAE: {row['mean_absolute_rgb_difference']:.4f}/255"
+        for error in row['errors']:
+            info += '<p class="error">' + html.escape(error) + '</p>'
+        doc.append('<tr><td>' + info + '</td>')
+        for label in ('fixed', 'float'):
+            if label + '_thumbnail' in row:
+                full = html.escape(row['captures'][label][0]['png'], quote=True)
+                thumb = html.escape(row[label + '_thumbnail'], quote=True)
+                doc.append(f'<td><a href="{full}"><img src="{thumb}" alt="{label}"></a></td>')
+            else:
+                doc.append('<td>Capture unavailable</td>')
+        doc.append('</tr>')
+    doc.append('</table>')
+    (out / 'report.html').write_text('\n'.join(doc))
+    print(f"Report: {out / 'report.html'}", flush=True)
+    return int(failure)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    for label in ('fixed', 'float'):
+        parser.add_argument('--' + label, required=True, type=Path, help='capture-enabled samples binary')
+        parser.add_argument('--' + label + '-data', required=True, type=Path)
+    parser.add_argument('--output', required=True, type=Path, help='new directory for captures and reports')
+    duration = parser.add_mutually_exclusive_group()
+    duration.add_argument('--frames', type=int, default=120)
+    duration.add_argument('--seconds', type=Decimal, help='nominal simulation time, converted to steps at 60 Hz')
+    parser.add_argument('--match', default='.', help='regex against Category/Sample Name')
+    parser.add_argument('--repeat', type=int, default=2)
+    parser.add_argument('--no-axes', action='store_true', help='hide absolute world-axis lines in both headless captures')
+    parser.add_argument('--timeout', type=float, default=300, help='per-capture timeout in seconds')
+    parser.add_argument('--exact', action='store_true', help='also fail when the two builds have different pixel hashes')
+    args = parser.parse_args()
+    try:
+        return run(args)
+    except (OSError, ValueError, re.error, subprocess.SubprocessError) as error:
+        parser.exit(2, f'capture comparison: {error}\n')
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/capture/float-47d7f7c-capture-hooks.patch
+++ b/tools/capture/float-47d7f7c-capture-hooks.patch
@@ -1,0 +1,474 @@
+diff --git a/samples/CMakeLists.txt b/samples/CMakeLists.txt
+index 319fb85..0a20ce5 100644
+--- a/samples/CMakeLists.txt
++++ b/samples/CMakeLists.txt
+@@ -190,6 +190,11 @@ if(APPLE)
+     # sokol_app's Cocoa backend is Objective-C. Compile its impl TU as OBJC with ARC.
+     set_source_files_properties(host/sokol_app_impl.c PROPERTIES LANGUAGE OBJC)
+     set_source_files_properties(host/sokol_app_impl.c PROPERTIES COMPILE_OPTIONS "-fobjc-arc")
++
++    # --capture end-state screenshot readback (Metal blit + ImageIO PNG encode).
++    target_sources(samples PRIVATE host/capture.h host/capture_macos.m)
++    set_source_files_properties(host/capture_macos.m PROPERTIES COMPILE_OPTIONS "-fobjc-arc")
++    target_link_libraries(samples PRIVATE "-framework ImageIO" "-framework CoreGraphics")
+ endif()
+ 
+ # Include root is the samples dir so "gfx/..." and "host/..." prefixes resolve.
+diff --git a/samples/host/capture.h b/samples/host/capture.h
+new file mode 100644
+index 0000000..8634a3c
+--- /dev/null
++++ b/samples/host/capture.h
+@@ -0,0 +1,42 @@
++// SPDX-FileCopyrightText: 2026 Erin Catto
++// SPDX-License-Identifier: MIT
++
++#pragma once
++
++#include "sokol_gfx.h"
++
++#include <stdbool.h>
++
++#ifdef __cplusplus
++extern "C"
++{
++#endif
++
++// One-shot end-state screenshot support for the samples app's --capture flag
++// (macOS/Metal only). The final simulated frame is rendered a second time via
++// RenderFrameOffscreen into a private BGRA8 target owned here; the app then
++// runs a few more (paused) frames so sokol's in-flight rotation guarantees the
++// GPU finished with it, and CaptureWritePng blits the texture to CPU memory on
++// a private queue and encodes a PNG with ImageIO.
++
++// True when the active backend supports the readback path.
++bool CaptureSupported( void );
++
++// Create (or recreate) the offscreen color target and its attachment view.
++void CaptureCreateTarget( int width, int height );
++
++// Pass these to RenderFrameOffscreen.
++const sg_attachments* CaptureAttachments( void );
++sg_pixel_format CaptureFormat( void );
++
++// Blit the target to CPU memory and write a PNG. Call only after the GPU is
++// done with the capture render (wait >= SG_NUM_INFLIGHT_FRAMES frames).
++bool CaptureWritePng( const char* path, int width, int height );
++
++// A window-free sokol_gfx environment on the system Metal device, for the
++// --headless capture driver. The device is created and retained here.
++sg_environment CaptureHeadlessEnvironment( void );
++
++#ifdef __cplusplus
++}
++#endif
+diff --git a/samples/host/capture_macos.m b/samples/host/capture_macos.m
+new file mode 100644
+index 0000000..eecab9a
+--- /dev/null
++++ b/samples/host/capture_macos.m
+@@ -0,0 +1,158 @@
++// SPDX-FileCopyrightText: 2026 Erin Catto
++// SPDX-License-Identifier: MIT
++
++// End-state screenshot readback for --capture. See capture.h for the contract.
++//
++// The render target lives on sokol's device/queue; readback happens on a
++// private queue created here. Cross-queue ordering is safe because the caller
++// waits SG_NUM_INFLIGHT_FRAMES+ frames between the capture render and the
++// readback, and sokol's frame rotation blocks on command-buffer completion.
++
++#include "capture.h"
++
++#import <CoreGraphics/CoreGraphics.h>
++#import <Foundation/Foundation.h>
++#import <ImageIO/ImageIO.h>
++#import <Metal/Metal.h>
++
++static sg_image s_captureImage;
++static sg_view s_captureView;
++static sg_attachments s_captureAttachments;
++static int s_captureWidth;
++static int s_captureHeight;
++
++bool CaptureSupported( void )
++{
++	return sg_query_backend() == SG_BACKEND_METAL_MACOS;
++}
++
++sg_environment CaptureHeadlessEnvironment( void )
++{
++	// Offscreen Metal rendering needs no window, view, or swapchain — just a
++	// device. Keep it alive for the process lifetime.
++	static id<MTLDevice> s_device = nil;
++	if ( s_device == nil )
++	{
++		s_device = MTLCreateSystemDefaultDevice();
++	}
++
++	sg_environment env = { 0 };
++	env.defaults.color_format = SG_PIXELFORMAT_BGRA8;
++	env.defaults.depth_format = SG_PIXELFORMAT_DEPTH_STENCIL;
++	env.defaults.sample_count = 1;
++	env.metal.device = (__bridge const void*)s_device;
++	return env;
++}
++
++void CaptureCreateTarget( int width, int height )
++{
++	if ( s_captureImage.id != SG_INVALID_ID && width == s_captureWidth && height == s_captureHeight )
++	{
++		return;
++	}
++	if ( s_captureView.id != SG_INVALID_ID )
++	{
++		sg_destroy_view( s_captureView );
++	}
++	if ( s_captureImage.id != SG_INVALID_ID )
++	{
++		sg_destroy_image( s_captureImage );
++	}
++
++	sg_image_desc idesc = { 0 };
++	idesc.usage.color_attachment = true;
++	idesc.width = width;
++	idesc.height = height;
++	idesc.pixel_format = SG_PIXELFORMAT_BGRA8;
++	idesc.sample_count = 1;
++	idesc.label = "capture_color";
++	s_captureImage = sg_make_image( &idesc );
++
++	sg_view_desc vdesc = { 0 };
++	vdesc.color_attachment.image = s_captureImage;
++	vdesc.label = "capture_color_attach";
++	s_captureView = sg_make_view( &vdesc );
++
++	memset( &s_captureAttachments, 0, sizeof( s_captureAttachments ) );
++	s_captureAttachments.colors[0] = s_captureView;
++
++	s_captureWidth = width;
++	s_captureHeight = height;
++}
++
++const sg_attachments* CaptureAttachments( void )
++{
++	return &s_captureAttachments;
++}
++
++sg_pixel_format CaptureFormat( void )
++{
++	return SG_PIXELFORMAT_BGRA8;
++}
++
++bool CaptureWritePng( const char* path, int width, int height )
++{
++	if ( !CaptureSupported() || s_captureImage.id == SG_INVALID_ID )
++	{
++		fprintf( stderr, "capture: unsupported backend or no target\n" );
++		return false;
++	}
++
++	sg_mtl_image_info info = sg_mtl_query_image_info( s_captureImage );
++	id<MTLTexture> tex = (__bridge id<MTLTexture>)info.tex[info.active_slot];
++	id<MTLDevice> device = (__bridge id<MTLDevice>)sg_mtl_device();
++	if ( tex == nil || device == nil )
++	{
++		fprintf( stderr, "capture: no metal texture\n" );
++		return false;
++	}
++
++	const NSUInteger bytesPerRow = (NSUInteger)width * 4;
++	const NSUInteger byteCount = bytesPerRow * (NSUInteger)height;
++	id<MTLBuffer> readback = [device newBufferWithLength:byteCount options:MTLResourceStorageModeShared];
++	id<MTLCommandQueue> queue = [device newCommandQueue];
++	id<MTLCommandBuffer> cmd = [queue commandBuffer];
++	id<MTLBlitCommandEncoder> blit = [cmd blitCommandEncoder];
++	[blit copyFromTexture:tex
++					 sourceSlice:0
++					 sourceLevel:0
++					sourceOrigin:MTLOriginMake( 0, 0, 0 )
++					  sourceSize:MTLSizeMake( (NSUInteger)width, (NSUInteger)height, 1 )
++						toBuffer:readback
++			   destinationOffset:0
++		  destinationBytesPerRow:bytesPerRow
++		destinationBytesPerImage:byteCount];
++	[blit endEncoding];
++	[cmd commit];
++	[cmd waitUntilCompleted];
++
++	// BGRA8 in memory = 32-bit little-endian ARGB words; alpha carries tonemap
++	// garbage, so skip it.
++	CGColorSpaceRef colorSpace = CGColorSpaceCreateWithName( kCGColorSpaceSRGB );
++	CGDataProviderRef provider = CGDataProviderCreateWithData( NULL, readback.contents, byteCount, NULL );
++	CGImageRef image = CGImageCreate( (size_t)width, (size_t)height, 8, 32, bytesPerRow, colorSpace,
++									  (CGBitmapInfo)kCGBitmapByteOrder32Little | (CGBitmapInfo)kCGImageAlphaNoneSkipFirst,
++									  provider, NULL, false, kCGRenderingIntentDefault );
++
++	bool ok = false;
++	if ( image != NULL )
++	{
++		NSURL* url = [NSURL fileURLWithPath:[NSString stringWithUTF8String:path]];
++		CGImageDestinationRef dest = CGImageDestinationCreateWithURL( (__bridge CFURLRef)url, CFSTR( "public.png" ), 1, NULL );
++		if ( dest != NULL )
++		{
++			CGImageDestinationAddImage( dest, image, NULL );
++			ok = CGImageDestinationFinalize( dest );
++			CFRelease( dest );
++		}
++		CGImageRelease( image );
++	}
++	CGDataProviderRelease( provider );
++	CGColorSpaceRelease( colorSpace );
++
++	if ( !ok )
++	{
++		fprintf( stderr, "capture: failed to write %s\n", path );
++	}
++	return ok;
++}
+diff --git a/samples/main.cpp b/samples/main.cpp
+index 8f31d25..0516870 100644
+--- a/samples/main.cpp
++++ b/samples/main.cpp
+@@ -14,7 +14,9 @@
+ #include "gfx/debug_adapter.h"
+ #include "gfx/keycodes.h"
+ #include "gfx/renderer.h"
++#include "host/capture.h"
+ #include "host/gui.h"
++#include "imgui.h"
+ #include "sample.h"
+ #include "sokol_app.h"
+ #include "sokol_glue.h"
+@@ -47,6 +49,9 @@
+ static SampleContext s_context;
+ static int s_frame = 0;
+ static int s_frameLimit = -1;
++static char s_capturePath[1024];
++static bool s_headless = false;
++static bool s_captureNoAxes = false;
+ static int s_sampleOverride = -1;
+ static int s_exitCode = 0;
+ 
+@@ -360,8 +365,27 @@ static void OnFrame( void )
+ {
+ 	if ( s_frameLimit >= 0 && s_frame >= s_frameLimit )
+ 	{
+-		sapp_quit();
+-		return;
++#if defined( __APPLE__ )
++		if ( s_capturePath[0] != '\0' )
++		{
++			// End-state capture: freeze the sim at the frame limit. The frame at
++			// s_frame == s_frameLimit renders the end state into the capture
++			// target (below); a few more paused frames let sokol's in-flight
++			// rotation guarantee GPU completion before the readback.
++			s_context.pause = true;
++			if ( s_frame >= s_frameLimit + 3 )
++			{
++				CaptureWritePng( s_capturePath, sapp_width(), sapp_height() );
++				sapp_quit();
++				return;
++			}
++		}
++		else
++#endif
++		{
++			sapp_quit();
++			return;
++		}
+ 	}
+ 
+ 	const uint64_t frameStart = b3GetTicks();
+@@ -446,6 +470,15 @@ static void OnFrame( void )
+ 	const sg_swapchain sc = sglue_swapchain();
+ 	RenderFrame( &sc, &fi );
+ 
++#if defined( __APPLE__ )
++	if ( s_capturePath[0] != '\0' && s_frame == s_frameLimit && CaptureSupported() )
++	{
++		// Render the frozen end state a second time into the capture target.
++		CaptureCreateTarget( sapp_width(), sapp_height() );
++		RenderFrameOffscreen( CaptureAttachments(), CaptureFormat(), sapp_width(), sapp_height(), &fi );
++	}
++#endif
++
+ 	// StartUIFrame runs after RenderFrame: it drains the text arena with the
+ 	// camera state RenderFrame just latched and runs the UI draw callback.
+ 	StartUIFrame( dt );
+@@ -508,6 +541,131 @@ static void OnAppLog( const char* tag, uint32_t logLevel, uint32_t logItemId, co
+ 	}
+ }
+ 
++#if defined( __APPLE__ )
++// Window-free capture driver for --headless --capture: physics steps need no
++// GPU at all, so the loop below runs the exact per-frame sequence OnFrame uses
++// (camera, draw origin, arena reset, Step, Render) with no window, no UI, and
++// no swapchain, then renders ONLY the frozen end state through
++// RenderFrameOffscreen and reads it back. No window ever exists, so nothing
++// can take focus or swallow keystrokes.
++static int RunHeadlessCapture()
++{
++	// Match the windowed high-dpi framebuffer (1920x1080 @ 2x) so headless
++	// captures are directly comparable with windowed ones.
++	const int W = 3840;
++	const int H = 2160;
++
++	const sg_environment env = CaptureHeadlessEnvironment();
++	InitRenderer( &env );
++	InitAdapter();
++
++	// A bare ImGui context with a built font atlas: samples touch ImGui
++	// metrics (fonts, frame heights) even when no UI is drawn.
++	ImGui::CreateContext();
++	ImGui::GetIO().DisplaySize = ImVec2( (float)W, (float)H );
++	ImGui::GetIO().Fonts->AddFontDefault();
++	ImGui::GetIO().Fonts->Build();
++
++	constexpr float DEG = 3.14159265358979323846f / 180.0f;
++	s_context.camera.SetFov( 50.0f * DEG );
++	s_context.camera.SetClip( 0.1f, Camera::kViewDistance );
++
++	int cores = (int)std::thread::hardware_concurrency();
++	s_context.workerCount = b3ClampInt( cores / 2, 1, 8 );
++	s_context.windowWidth = W;
++	s_context.windowHeight = H;
++
++	SortSamples();
++	int index = ( s_sampleOverride >= 0 && s_sampleOverride < g_sampleCount ) ? s_sampleOverride : 0;
++	SelectSample( &s_context, index, false );
++
++	Camera& camera = s_context.camera;
++	const float dt = 1.0f / 60.0f;
++
++	for ( int frame = 0; frame <= s_frameLimit; ++frame )
++	{
++		camera.Update( dt, W, H );
++		camera.SetRenderTransform( b3GetLengthUnitsPerMeter(), s_context.viewZUp );
++		camera.SetDrawDistance( s_context.drawDistance );
++		SetDrawOrigin( camera.DrawOrigin() );
++		ResetFrameArena();
++		SetTransparentDynamic( s_context.transparentDynamic );
++		SetTransparentKinematic( s_context.transparentKinematic );
++
++		if ( frame == s_frameLimit )
++		{
++			// Freeze the sim: this iteration renders the end state.
++			s_context.pause = true;
++		}
++
++		s_context.sample->Step();
++
++		if ( frame < s_frameLimit )
++		{
++			continue; // no rendering while stepping
++		}
++
++		s_context.sample->Render();
++
++		FrameInput fi{};
++		fi.view = camera.View();
++		fi.viewInv = camera.ViewInverse();
++		fi.proj = camera.Proj();
++		fi.projInv = camera.ProjInverse();
++		fi.cameraPosition = camera.Position();
++		b3Pos drawOrigin = GetDrawOrigin();
++		fi.drawOrigin = b3ToVec3( drawOrigin );
++		double gridPeriod = 10.0 * BOX3D_GROUND_GRID_CELL_SIZE;
++		fi.gridWrap.x = (float)fmod( (double)drawOrigin.x, gridPeriod );
++		fi.gridWrap.y = (float)fmod( (double)drawOrigin.z, gridPeriod );
++		// Absolute world-axis lines differ when the same scene is translated.
++		// This capture-only option hides them without changing the repeating grid.
++		if ( s_captureNoAxes )
++		{
++			fi.drawOrigin.x = 1.0e20f;
++			fi.drawOrigin.z = 1.0e20f;
++		}
++		fi.time = (float)frame / 60.0f;
++		fi.debugMode = s_context.debugView;
++		fi.disableShadows = !s_context.enableShadows;
++		fi.disableAmbientOcclusion = !s_context.enableGtao;
++		fi.zUp = s_context.viewZUp;
++
++		CaptureCreateTarget( W, H );
++		RenderFrameOffscreen( CaptureAttachments(), CaptureFormat(), W, H, &fi );
++
++		// Rotate past both in-flight command buffers so the capture render is
++		// complete before the cross-queue readback blit. The padding frames
++		// must contain a real pass: an empty sg_commit creates no command
++		// buffer and therefore no rotation, and the blit would race the render
++		// (which reads back as undefined — solid magenta on Apple GPUs). A
++		// LOAD-action pass on the capture target preserves its contents.
++		for ( int k = 0; k < 3; ++k )
++		{
++			sg_pass pad = { 0 };
++			pad.action.colors[0].load_action = SG_LOADACTION_LOAD;
++			pad.attachments = *CaptureAttachments();
++			sg_begin_pass( &pad );
++			sg_end_pass();
++			sg_commit();
++		}
++
++		bool ok = CaptureWritePng( s_capturePath, W, H );
++		RenderStats st = GetRenderStats();
++		fprintf( stderr, "headless stats: geom=%d cubes=%d spheres=%d capsules=%d lines=%d points=%d draws=%d\n",
++				 st.geomInstanceCount, st.cubeCount, st.sphereCount, st.capsuleCount, st.lineCount, st.pointCount,
++				 st.drawCallCount );
++		fprintf( stderr, "headless capture: %s %s\n", ok ? "wrote" : "FAILED", s_capturePath );
++
++		delete s_context.sample;
++		s_context.sample = nullptr;
++		return ok ? 0 : 1;
++	}
++
++	return 1;
++}
++#endif
++
+ static sapp_desc BuildAppDesc( int argc, char** argv )
+ {
+ 	for ( int i = 1; i < argc; ++i )
+@@ -534,8 +692,43 @@ static sapp_desc BuildAppDesc( int argc, char** argv )
+ 		{
+ 			s_context.viewZUp = true;
+ 		}
++		else if ( strcmp( argv[i], "--capture" ) == 0 && i + 1 < argc )
++		{
++			// End-state screenshot: at --frames N, freeze the sim, render the
++			// final state offscreen, and write it to this PNG path (macOS only).
++			snprintf( s_capturePath, sizeof( s_capturePath ), "%s", argv[++i] );
++		}
++		else if ( strcmp( argv[i], "--capture-no-axes" ) == 0 )
++		{
++			s_captureNoAxes = true;
++		}
++		else if ( strcmp( argv[i], "--headless" ) == 0 )
++		{
++			// With --capture and --frames: no window at all — step the physics
++			// CPU-side and render only the final frame offscreen (macOS only).
++			s_headless = true;
++		}
++		else if ( strcmp( argv[i], "--list-samples" ) == 0 )
++		{
++			// Print "index<TAB>category<TAB>name" for every registered sample in
++			// the same sorted order --sample indexes into, then exit. Lets a
++			// harness map sample names across trees whose sample sets differ.
++			SortSamples();
++			for ( int k = 0; k < g_sampleCount; ++k )
++			{
++				printf( "%d\t%s\t%s\n", k, g_sampleEntries[k].Category, g_sampleEntries[k].Name );
++			}
++			exit( 0 );
++		}
+ 	}
+ 
++#if defined( __APPLE__ )
++	if ( s_headless && s_capturePath[0] != '\0' && s_frameLimit >= 0 )
++	{
++		exit( RunHeadlessCapture() );
++	}
++#endif
++
+ 	sapp_desc desc{};
+ 	desc.init_cb = OnInit;
+ 	desc.frame_cb = OnFrame;


### PR DESCRIPTION
The default scalar convex-hull edge scan spends much of Convex Pile's time computing 128-bit dot products just to reject candidate pairs. This adds exact 64-bit rejection when conservative magnitude bounds prove every product, partial sum and negation fits. The bounds come directly from actual vertices and face normals, avoiding older vendored AABB transforms that can round inward. Larger inputs and all surviving pairs retain the original 128-bit calculations and separation-update order.

On an Apple M3 Ultra with matched RelWithDebInfo builds, thin LTO and four workers, the final implementation reduces Convex Pile's median runtime from **14.27 to 12.66 seconds (11.3% less time)** across three grouped trials per binary. Every optimized run beats every baseline run in that check. Smaller scene differences are inconclusive on this shared workstation; no overall engine speedup percentage is claimed.

[Commands, measurements and validation](https://github.com/mas-bandwidth/fixed3d/blob/codex/optimize-fixed3d-collision/benchmark/2026-09-07-scalar-edge-reject.md) and [all raw trials and capture hashes](https://github.com/mas-bandwidth/fixed3d/blob/codex/optimize-fixed3d-collision/benchmark/2026-09-07-scalar-edge-reject.json) preserve the final runs and the earlier candidates' noisy and unfavorable observations separately.

Validation of the final vertex-bound implementation:

- All 24 suites pass locally in Debug, RelWithDebInfo, wide-position RelWithDebInfo, NEON RelWithDebInfo, and Debug ASan+UBSan. Existing determinism hashes remain unchanged, including worker counts 1–5.
- A new analytic edge-separation test covers scales 8192, 16384 and 32768, across the 64-bit admission boundary.
- A separate corpus of 6000 hull pairs, each queried with fresh and reused caches, produces identical serialized results for all 12000 queries against the original convex-manifold object. It covers scales 0.2 through 32768; output SHA256 is `62467f0ac17eb4f2277db8bd5d686ef167775a3d4bd3b402904c316a3fb1768d`.
- Twenty sample scenes at 120 frames, twice per binary: all 80 decoded RGBA captures match within and across the pre-optimization and final fixed builds.

This PR includes #55, which will merge first, and the newly landed fixed library update from #57 (pin `2f1ed91`). The performance and exact-parity evidence above isolates the collision change on the earlier `a0fa624` pin. All 24 suites also pass on the final combined tree in the same five local configurations; the independent math repairs legitimately change settled-state references. The full cross-platform CI matrix is running on the updated branch. Existing NEON and AVX-512 paths and build defaults are unchanged.
