### PR TITLE
Vendor repaired fixed math and refresh deterministic references

### DIFF
--- a/extern/fixed/NOTES.md
+++ b/extern/fixed/NOTES.md
@@ -4,7 +4,14 @@ This directory is a **generated copy** of [mas-bandwidth/fixed](https://github.c
 the deterministic fixed-point math library that Fixed3D's own fixed-point core was
 extracted into.
 
-    Pinned at: v1.4.0  (a0fa624d739790844af34499381c55abaa65180f)
+    Pinned at: unreleased-2f1ed91  (2f1ed913374ab047c061c66f5be737715f7d87b5)
+
+This tested snapshot contains the numerical repairs and exact square-root
+optimizations in [fixed #28](https://github.com/mas-bandwidth/fixed/pull/28).
+It fixes transformed-bound containment, normalization precision/range,
+small-angle extraction, validators, midpoint arithmetic and boundary conversions.
+The square-root optimization preserves exact result bits. This pin is a commit,
+not a published release tag; consumer determinism checks cover integration.
 
 ## Do not edit anything in this directory
 

--- a/extern/fixed/include/fixed/fixed.h
+++ b/extern/fixed/include/fixed/fixed.h
@@ -263,6 +263,18 @@ FIX_ALWAYS_INLINE fixed_t fixDiv( fixed_t a, fixed_t b )
 /// Exact integer square root of an unsigned 128 bit value (helper for fixSqrt).
 FIX_ALWAYS_INLINE uint64_t fixISqrt128High( uint64_t hi, uint64_t lo )
 {
+	// Up to 104 input bits the double seed has at most a few raw units of
+	// error and fits uint64_t. Repair against the full integer input, exactly
+	// as in the 64-bit arm. Lifted vector/quaternion norms land in this range.
+	if ( hi != 0 && hi < ( UINT64_C( 1 ) << 40 ) )
+	{
+		fixUInt128 n = fixUInt128Make( hi, lo );
+		uint64_t r = (uint64_t)FIX_SQRT_SEED( (double)hi * 18446744073709551616.0 + (double)lo );
+		while ( fixUInt128Gt( fixUInt128MulU64( r, r ), n ) ) { --r; }
+		while ( fixUInt128Le( fixUInt128MulU64( r + 1, r + 1 ), n ) ) { ++r; }
+		return r;
+	}
+
 	if ( hi == 0 )
 	{
 		// Common case: 64 bit input. Seed with the hardware double sqrt (an exact,
@@ -278,11 +290,16 @@ FIX_ALWAYS_INLINE uint64_t fixISqrt128High( uint64_t hi, uint64_t lo )
 		{
 			r = 0xFFFFFFFFu;
 		}
-		while ( r > 0 && fixUInt128Gt( fixUInt128MulU64( r, r ), fixUInt128FromU64( lo ) ) )
+		// r <= UINT32_MAX, so its square fits uint64_t. After the downward
+		// repair, lo-r*r is nonnegative. The next square is <= lo exactly
+		// when that remainder exceeds 2*r; this avoids forming (r+1)^2,
+		// which would overflow at r == UINT32_MAX. At that endpoint the
+		// remainder is at most 2*r, so the upward repair cannot overflow r.
+		while ( r * r > lo )
 		{
 			r -= 1;
 		}
-		while ( fixUInt128Le( fixUInt128MulU64( r + 1, r + 1 ), fixUInt128FromU64( lo ) ) )
+		while ( lo - r * r > 2 * r )
 		{
 			r += 1;
 		}

--- a/extern/fixed/include/fixed/fixed_quantize.h
+++ b/extern/fixed/include/fixed/fixed_quantize.h
@@ -95,8 +95,16 @@ FIX_ALWAYS_INLINE double fixDequantize( int64_t raw, int64_t scale )
 FIX_ALWAYS_INLINE int64_t fixQuantizeClamped( double value, int64_t scale, int64_t minRaw, int64_t maxRaw )
 {
 	FIX_ASSERT( minRaw <= maxRaw );
+	FIX_ASSERT( scale > 0 );
 
-	int64_t raw = fixQuantize( value, scale );
+	double scaled = value * (double)scale;
+	double rounded = scaled >= 0.0 ? scaled + 0.5 : scaled - 0.5;
+	// Check the storage range before casting. (double)INT64_MAX is 2^63,
+	// so an inclusive comparison against that value is essential. Compare
+	// the caller's exact int64 bounds AFTER conversion, not as doubles.
+	if ( rounded >= 9223372036854775808.0 ) return maxRaw;
+	if ( rounded <= -9223372036854775808.0 ) return minRaw;
+	int64_t raw = (int64_t)rounded;
 
 	if ( raw < minRaw )
 	{

--- a/extern/fixed/include/fixed/fixed_time.h
+++ b/extern/fixed/include/fixed/fixed_time.h
@@ -28,8 +28,9 @@ FIX_ALWAYS_INLINE fixTime fixTimeFromFixed( fixed_t seconds )
 /// Convert Q32.32 time to Q48.16 seconds, rounding to nearest.
 FIX_ALWAYS_INLINE fixed_t fixTimeToFixed( fixTime t )
 {
-	return ( t + ( (fixTime)1 << ( FIX_TIME_FRACTION_BITS - FIX_FRACTION_BITS - 1 ) ) ) >>
-		   ( FIX_TIME_FRACTION_BITS - FIX_FRACTION_BITS );
+	// Split before rounding: the quotient fits even when t + half would not.
+	const int shift = FIX_TIME_FRACTION_BITS - FIX_FRACTION_BITS;
+	return ( t >> shift ) + ( ( t & ( ( (fixTime)1 << shift ) - 1 ) ) >= ( (fixTime)1 << ( shift - 1 ) ) );
 }
 
 /// Convert seconds (double) to Q32.32 time, rounding to nearest. Init/tooling

--- a/extern/fixed/include/fixed/fixed_vec.h
+++ b/extern/fixed/include/fixed/fixed_vec.h
@@ -202,12 +202,13 @@ FIX_INLINE fixed_t fixDot( fixVec3 a, fixVec3 b )
 	return fixFromDotRaw( fixDotRaw( a, b ) );
 }
 
-/// Vector length. Computed from the exact 128-bit sum of squared components, so
-/// it is accurate even for vectors far below unit length.
+/// Vector length. Computed from the exact unsigned 128-bit sum of squared
+/// components; saturates to FIX_MAX when the length exceeds fixed_t range.
 FIX_INLINE fixed_t fixLength( fixVec3 v )
 {
 	fixInt128 ls = fixDotRaw( v, v ); // Q32.32 in 128 bits
-	return (fixed_t)fixISqrt128High( fixInt128Hi( ls ), fixInt128Lo( ls ) );
+	uint64_t length = fixISqrt128High( fixInt128Hi( ls ), fixInt128Lo( ls ) );
+	return length > (uint64_t)FIX_MAX ? FIX_MAX : (fixed_t)length;
 }
 
 /// Vector length squared. One rounding on the exact 128-bit sum of squares.
@@ -235,11 +236,59 @@ FIX_INLINE fixed_t fixDistanceSquared( fixVec3 a, fixVec3 b )
 /// and the three-term sum ~2^94.
 #define FIX_NORMALIZE_LIFT_BITS 46
 
+// Internal: precision lift shared by vector and quaternion normalization.
+FIX_INLINE int fixNormalizationLift( uint64_t components )
+{
+	FIX_ASSERT( components != 0 );
+#if defined( __GNUC__ ) || defined( __clang__ )
+	int lift = FIX_NORMALIZE_LIFT_BITS - 64 + __builtin_clzll( components );
+#else
+	int lift = FIX_NORMALIZE_LIFT_BITS - ( 64 - fixCountLeadingZeros64( components ) );
+#endif
+	return lift > 0 ? lift : 0;
+}
+
+// A full-range norm can exceed INT64_MAX even though every component fits.
+// Keep that divisor positive; ordinary inputs retain fixDiv's hardware fast path.
+FIX_INLINE fixed_t fixNormalizeByLength( fixed_t component, uint64_t length )
+{
+	if ( length <= (uint64_t)FIX_MAX ) return fixDiv( component, (fixed_t)length );
+	return fixInt128ToI64( fixInt128Div( fixInt128ShiftLeft( fixInt128FromI64( component ), FIX_FRACTION_BITS ),
+		fixInt128FromU64( length ) ) );
+}
+
+// Specialize away the optional output on the normalize-only hot path.
+FIX_FORCE_INLINE fixVec3 fixNormalizeWithLength( fixVec3 a, fixed_t* originalLength )
+{
+	uint64_t ux = a.x < 0 ? -(uint64_t)a.x : (uint64_t)a.x;
+	uint64_t uy = a.y < 0 ? -(uint64_t)a.y : (uint64_t)a.y;
+	uint64_t uz = a.z < 0 ? -(uint64_t)a.z : (uint64_t)a.z;
+	if ( ( ux | uy | uz ) == 0 )
+	{
+		if ( originalLength != NULL ) *originalLength = 0;
+		return fixVec3_zero;
+	}
+	int lift = fixNormalizationLift( ux | uy | uz );
+	a.x = fixShiftLeft( a.x, lift );
+	a.y = fixShiftLeft( a.y, lift );
+	a.z = fixShiftLeft( a.z, lift );
+	// Three squared int64 magnitudes fit UNSIGNED 128 bits, not signed 128.
+	fixInt128 ls = fixDotRaw( a, a );
+	uint64_t length = fixISqrt128High( fixInt128Hi( ls ), fixInt128Lo( ls ) );
+	if ( originalLength != NULL )
+	{
+		uint64_t unlifted = length >> lift;
+		*originalLength = unlifted > (uint64_t)FIX_MAX ? FIX_MAX : (fixed_t)unlifted;
+	}
+	return FIX_LITERAL( fixVec3 ){ fixNormalizeByLength( a.x, length ), fixNormalizeByLength( a.y, length ),
+		fixNormalizeByLength( a.z, length ) };
+}
+
 /// Normalize a vector. Returns a zero vector if the input vector is zero.
 ///
-/// PRECISION: the squared length is exact in 128 bits, but the length is a fixed_t --
-/// a whole raw unit -- with a relative truncation error of ~0.5/L at raw length L,
-/// which would land in the result's squared length as ~1/L. Normalization is
+/// PRECISION: the squared length is exact in unsigned 128 bits, but its integer
+/// root has a relative truncation error below 1/L at raw length L, which can
+/// dominate a short vector's normalized result. Normalization is
 /// scale-invariant and a left shift is EXACT, so the vector is lifted until its
 /// widest component fills the range before the same math runs: the direction is
 /// unchanged bit for bit, only the divisor's precision improves. The result is unit
@@ -249,61 +298,35 @@ FIX_INLINE fixed_t fixDistanceSquared( fixVec3 a, fixVec3 b )
 /// by zero and are untouched.
 FIX_INLINE fixVec3 fixNormalize( fixVec3 a )
 {
-	// magnitude of the widest component, as an unsigned value so the negation is
-	// defined for every input
-	uint64_t ux = a.x < 0 ? ( 0u - (uint64_t)a.x ) : (uint64_t)a.x;
-	uint64_t uy = a.y < 0 ? ( 0u - (uint64_t)a.y ) : (uint64_t)a.y;
-	uint64_t uz = a.z < 0 ? ( 0u - (uint64_t)a.z ) : (uint64_t)a.z;
-	uint64_t widest = ux | uy | uz;
-	if ( widest != 0 )
-	{
-		int bits = 0;
-		while ( ( widest >> bits ) != 0 )
-		{
-			bits++;
-		}
-		if ( bits < FIX_NORMALIZE_LIFT_BITS )
-		{
-			const int lift = FIX_NORMALIZE_LIFT_BITS - bits;
-			a.x = fixShiftLeft( a.x, lift ); // exact: shifts preserve direction
-			a.y = fixShiftLeft( a.y, lift );
-			a.z = fixShiftLeft( a.z, lift );
-		}
-	}
-
-	fixInt128 ls = fixDotRaw( a, a ); // Q32.32 in 128 bits
-	if ( fixInt128Gt( ls, FIX_INT128_ZERO ) )
-	{
-		fixed_t length = (fixed_t)fixISqrt128High( fixInt128Hi( ls ), fixInt128Lo( ls ) );
-		// fixDiv computes the same truncating 128-bit quotient, with a single
-		// hardware divide when the component fits in 47 bits (the common case)
-		fixVec3 u = {
-			fixDiv( a.x, length ),
-			fixDiv( a.y, length ),
-			fixDiv( a.z, length ),
-		};
-		return u;
-	}
-
-	return FIX_LITERAL( fixVec3 ){ FIX( 0.0f ), FIX( 0.0f ), FIX( 0.0f ) };
+	return fixNormalizeWithLength( a, NULL );
 }
 
-/// Normalize a vector and return the length. Returns a zero vector
-/// if the input is zero.
+/// Normalize a vector and return the length (saturated to FIX_MAX if needed).
+/// Zero input returns zero length and vector. The direction is unit within
+/// fixIsNormalized's tolerance; short inputs use a lifted divisor.
 FIX_INLINE fixVec3 fixGetLengthAndNormalize( fixed_t* length, fixVec3 a )
 {
-	*length = fixLength( a );
-	if ( *length < FIX_EPSILON )
+	fixInt128 ls = fixDotRaw( a, a );
+	uint64_t rawLength = fixISqrt128High( fixInt128Hi( ls ), fixInt128Lo( ls ) );
+	// The norm bounds every component. Below 2^47 the three shifted
+	// numerators fit int64, so one range check replaces three fixDiv guards.
+	if ( rawLength >= FIX_HALF && rawLength < ( UINT64_C( 1 ) << 47 ) )
 	{
-		return fixVec3_zero;
+		fixed_t divisor = (fixed_t)rawLength;
+		*length = divisor;
+		return FIX_LITERAL( fixVec3 ){ fixShiftLeft( a.x, FIX_FRACTION_BITS ) / divisor,
+			fixShiftLeft( a.y, FIX_FRACTION_BITS ) / divisor, fixShiftLeft( a.z, FIX_FRACTION_BITS ) / divisor };
 	}
-
-	fixVec3 n = {
-		fixDiv( a.x, *length ),
-		fixDiv( a.y, *length ),
-		fixDiv( a.z, *length ),
-	};
-	return n;
+	// At half a unit or above, flooring the length contributes less than
+	// 1/32768 relative error. Keep this common one-sqrt path and its existing
+	// rounding; short inputs need the lifted divisor instead.
+	if ( rawLength >= FIX_HALF )
+	{
+		*length = rawLength > (uint64_t)FIX_MAX ? FIX_MAX : (fixed_t)rawLength;
+		return FIX_LITERAL( fixVec3 ){ fixNormalizeByLength( a.x, rawLength ),
+			fixNormalizeByLength( a.y, rawLength ), fixNormalizeByLength( a.z, rawLength ) };
+	}
+	return fixNormalizeWithLength( a, length );
 }
 
 /// Get a unit vector that is perpendicular to the supplied vector.
@@ -325,9 +348,17 @@ FIX_INLINE fixVec3 fixPerp( fixVec3 a )
 	return fixNormalize( p );
 }
 
+// Internal guard: a normalized component cannot exceed this range. Reject
+// before squaring so a wrapping or saturating norm cannot pass validation.
+FIX_INLINE bool fixInUnitComponentRange( fixed_t a )
+{
+	return a >= -FIX_ONE - 100 * FIX_EPSILON && a <= FIX_ONE + 100 * FIX_EPSILON;
+}
+
 /// Is a vector normalized? In other words, does it have unit length?
 FIX_INLINE bool fixIsNormalized( fixVec3 a )
 {
+	if ( !fixInUnitComponentRange( a.x ) || !fixInUnitComponentRange( a.y ) || !fixInUnitComponentRange( a.z ) ) return false;
 	fixed_t aa = fixDot( a, a );
 	return fixAbs( FIX( 1.0f ) - aa ) < 100 * FIX_EPSILON;
 }
@@ -447,6 +478,8 @@ FIX_INLINE fixVec3 fixSafeScale( fixVec3 a )
 /// Does the supplied quaternion have unit length?
 FIX_INLINE bool fixIsNormalizedQuat( fixQuat q )
 {
+	if ( !fixInUnitComponentRange( q.v.x ) || !fixInUnitComponentRange( q.v.y ) ||
+		 !fixInUnitComponentRange( q.v.z ) || !fixInUnitComponentRange( q.s ) ) return false;
 	fixed_t qq = fixMul( q.v.x , q.v.x ) + fixMul( q.v.y , q.v.y ) + fixMul( q.v.z , q.v.z ) + fixMul( q.s , q.s );
 	return FIX( 1.0f ) - 100 * FIX_EPSILON < qq && qq < FIX( 1.0f ) + 100 * FIX_EPSILON;
 }
@@ -583,18 +616,41 @@ FIX_INLINE fixQuat fixNegateQuat( fixQuat q )
 FIX_INLINE fixQuat fixNormalizeQuat( fixQuat q )
 {
 	fixInt128 ls = fixInt128Add( fixDotRaw( q.v, q.v ), fixInt128MulI64( q.s, q.s ) );
-	if ( fixInt128Gt( ls, FIX_INT128_ZERO ) )
+	uint64_t length = fixISqrt128High( fixInt128Hi( ls ), fixInt128Lo( ls ) );
+	if ( length >= FIX_HALF && length < ( UINT64_C( 1 ) << 47 ) )
 	{
-		fixed_t length = (fixed_t)fixISqrt128High( fixInt128Hi( ls ), fixInt128Lo( ls ) );
-		// fixDiv computes the same truncating quotient, with a single hardware
-		// divide for the near-unit components this always sees
+		fixed_t divisor = (fixed_t)length;
+		return FIX_LITERAL( fixQuat ){ { fixShiftLeft( q.v.x, FIX_FRACTION_BITS ) / divisor, fixShiftLeft( q.v.y, FIX_FRACTION_BITS ) / divisor,
+			fixShiftLeft( q.v.z, FIX_FRACTION_BITS ) / divisor }, fixShiftLeft( q.s, FIX_FRACTION_BITS ) / divisor };
+	}
+	// Preserve the common near-unit path, including one-quantum rotation
+	// components that unnecessary rescaling could truncate away.
+	if ( length >= FIX_HALF )
+	{
+		return FIX_LITERAL( fixQuat ){ { fixNormalizeByLength( q.v.x, length ), fixNormalizeByLength( q.v.y, length ),
+			fixNormalizeByLength( q.v.z, length ) }, fixNormalizeByLength( q.s, length ) };
+	}
+	uint64_t ux = q.v.x < 0 ? -(uint64_t)q.v.x : (uint64_t)q.v.x;
+	uint64_t uy = q.v.y < 0 ? -(uint64_t)q.v.y : (uint64_t)q.v.y;
+	uint64_t uz = q.v.z < 0 ? -(uint64_t)q.v.z : (uint64_t)q.v.z;
+	uint64_t us = q.s < 0 ? -(uint64_t)q.s : (uint64_t)q.s;
+	if ( ( ux | uy | uz | us ) == 0 ) return fixQuat_identity;
+	int lift = fixNormalizationLift( ux | uy | uz | us );
+	q.v.x = fixShiftLeft( q.v.x, lift );
+	q.v.y = fixShiftLeft( q.v.y, lift );
+	q.v.z = fixShiftLeft( q.v.z, lift );
+	q.s = fixShiftLeft( q.s, lift );
+	ls = fixInt128Add( fixDotRaw( q.v, q.v ), fixInt128MulI64( q.s, q.s ) );
+	if ( !fixInt128Eq( ls, FIX_INT128_ZERO ) )
+	{
+		length = fixISqrt128High( fixInt128Hi( ls ), fixInt128Lo( ls ) );
 		fixQuat qn = {
 			{
-				fixDiv( q.v.x, length ),
-				fixDiv( q.v.y, length ),
-				fixDiv( q.v.z, length ),
+				fixNormalizeByLength( q.v.x, length ),
+				fixNormalizeByLength( q.v.y, length ),
+				fixNormalizeByLength( q.v.z, length ),
 			},
-			fixDiv( q.s, length ),
+			fixNormalizeByLength( q.s, length ),
 		};
 		return qn;
 	}
@@ -614,13 +670,11 @@ FIX_INLINE fixQuat fixMakeQuatFromAxisAngle( fixVec3 axis, fixed_t radians )
 /// Get the axis and angle from a quaternion. Assumes the quaternion is normalized.
 FIX_INLINE fixVec3 fixGetAxisAngle( fixed_t* radians, fixQuat q )
 {
-	fixed_t length = fixSqrt( fixMul( q.v.x , q.v.x ) + fixMul( q.v.y , q.v.y ) + fixMul( q.v.z , q.v.z ) );
+	fixed_t length = fixLength( q.v );
 	*radians = fixMul( FIX( 2.0f ) , fixAtan2( length, q.s ) );
 	if ( length > FIX( 0.0f ) )
 	{
-		fixed_t invLength = fixDiv( FIX( 1.0f ) , length );
-		fixVec3 axis = { fixMul( invLength , q.v.x ), fixMul( invLength , q.v.y ), fixMul( invLength , q.v.z ) };
-		return axis;
+		return fixNormalize( q.v );
 	}
 
 	return fixVec3_zero;
@@ -629,7 +683,7 @@ FIX_INLINE fixVec3 fixGetAxisAngle( fixed_t* radians, fixQuat q )
 /// Get the angle for a quaternion in radians
 FIX_INLINE fixed_t fixGetQuatAngle( fixQuat q )
 {
-	fixed_t length = fixSqrt( fixMul( q.v.x , q.v.x ) + fixMul( q.v.y , q.v.y ) + fixMul( q.v.z , q.v.z ) );
+	fixed_t length = fixLength( q.v );
 	return fixMul( FIX( 2.0f ) , fixAtan2( length, q.s ) );
 }
 
@@ -654,8 +708,8 @@ FIX_INLINE fixed_t fixGetTwistAngle( fixQuat q )
 FIX_INLINE fixed_t fixGetSwingAngle( fixQuat q )
 {
 	// Polarity should not matter because all terms are squared.
-	fixed_t x = fixSqrt( fixMul( q.v.z , q.v.z ) + fixMul( q.s , q.s ) );
-	fixed_t y = fixSqrt( fixMul( q.v.x , q.v.x ) + fixMul( q.v.y , q.v.y ) );
+	fixed_t x = fixLength( FIX_LITERAL( fixVec3 ){ q.v.z, q.s, 0 } );
+	fixed_t y = fixLength( FIX_LITERAL( fixVec3 ){ q.v.x, q.v.y, 0 } );
 	fixed_t swing = fixMul( FIX( 2.0f ) , fixAtan2( y, x ) );
 	FIX_ASSERT( FIX( 0.0f ) <= swing && swing <= FIX_PI + 2 * FIX_EPSILON );
 	return swing;
@@ -1005,16 +1059,30 @@ FIX_INLINE fixed_t fixAABB_Area( fixAABB a )
 	return fixMul( FIX( 2.0f ) , ( fixMul( delta.x , delta.y ) + fixMul( delta.y , delta.z ) + fixMul( delta.z , delta.x ) ) );
 }
 
+// Internal half-up arithmetic. Splitting before adding/subtracting keeps
+// intermediates in range for valid fixed_t endpoints (which exclude INT64_MIN).
+FIX_INLINE fixed_t fixHalfSum( fixed_t a, fixed_t b )
+{
+	return ( a >> 1 ) + ( b >> 1 ) + ( ( a | b ) & 1 );
+}
+
+FIX_INLINE fixed_t fixHalfDifference( fixed_t a, fixed_t b )
+{
+	return ( a >> 1 ) - ( b >> 1 ) + ( ( a & 1 ) & ~( b & 1 ) );
+}
+
 /// Get the center of an axis-aligned bounding box.
 FIX_INLINE fixVec3 fixAABB_Center( fixAABB a )
 {
-	return fixMulSV( FIX( 0.5f ), fixVecAdd( a.upperBound, a.lowerBound ) );
+	return FIX_LITERAL( fixVec3 ){ fixHalfSum( a.upperBound.x, a.lowerBound.x ),
+		fixHalfSum( a.upperBound.y, a.lowerBound.y ), fixHalfSum( a.upperBound.z, a.lowerBound.z ) };
 }
 
 /// Get the extents (half-widths) of an axis-aligned bounding box.
 FIX_INLINE fixVec3 fixAABB_Extents( fixAABB a )
 {
-	return fixMulSV( FIX( 0.5f ), fixVecSub( a.upperBound, a.lowerBound ) );
+	return FIX_LITERAL( fixVec3 ){ fixHalfDifference( a.upperBound.x, a.lowerBound.x ),
+		fixHalfDifference( a.upperBound.y, a.lowerBound.y ), fixHalfDifference( a.upperBound.z, a.lowerBound.z ) };
 }
 
 /// Get the union of two axis-aligned bounding boxes.
@@ -1482,19 +1550,60 @@ FIX_FORCE_INLINE fixMatrix3 fixMakeMatrixFromQuat( fixQuat q )
 	};
 }
 
+// Internal: saturate a bound only after the full calculation, reserving INT64_MIN.
+FIX_INLINE fixed_t fixAABBNarrowBound( fixInt128 value )
+{
+	if ( fixInt128Gt( value, fixInt128FromI64( FIX_MAX ) ) ) return FIX_MAX;
+	if ( fixInt128Lt( value, fixInt128FromI64( FIX_MIN ) ) ) return FIX_MIN;
+	return fixInt128ToI64( value );
+}
+
+// row contains UNROUNDED Q32.32 rotation coefficients. Keep both the center
+// and the radius wide, then round lower down and upper up exactly once.
+FIX_INLINE void fixAABBTransformAxis( fixVec3 row, fixVec3 center, fixVec3 extent, fixed_t translation,
+	fixed_t error, fixed_t* lower, fixed_t* upper )
+{
+	fixInt128 c = fixDotRaw( row, center );
+	fixInt128 r = fixDotRaw( fixVecAbs( row ), extent );
+	fixInt128 lo = fixInt128Shr( fixInt128Sub( c, r ), 32 );
+	fixInt128 hi = fixInt128Shr( fixInt128Add( fixInt128Add( c, r ), fixInt128FromU64( UINT32_MAX ) ), 32 );
+	*lower = fixAABBNarrowBound( fixInt128Sub( fixInt128Add( lo, fixInt128FromI64( translation ) ), fixInt128FromI64( error ) ) );
+	*upper = fixAABBNarrowBound( fixInt128Add( fixInt128Add( hi, fixInt128FromI64( translation ) ), fixInt128FromI64( error ) ) );
+}
+
+FIX_INLINE fixAABB fixTransformAABBCenterExtents( fixTransform t, fixVec3 center, fixVec3 extent )
+{
+	FIX_ASSERT( fixIsNormalizedQuat( t.q ) );
+	// These raw products fit int64 for a normalized quaternion. Rounding them
+	// to Q48.16 first would lose an error proportional to the size of the box.
+	fixed_t x = t.q.v.x, y = t.q.v.y, z = t.q.v.z, w = t.q.s;
+	fixed_t xx = x*x, yy = y*y, zz = z*z, xy = x*y, xz = x*z, yz = y*z;
+	fixed_t xw = x*w, yw = y*w, zw = z*w;
+	fixed_t one = (fixed_t)1 << 32;
+	fixVec3 rowX = { one - 2*(yy+zz), 2*(xy-zw), 2*(xz+yw) };
+	fixVec3 rowY = { 2*(xy+zw), one - 2*(xx+zz), 2*(yz-xw) };
+	fixVec3 rowZ = { 2*(xz-yw), 2*(yz+xw), one - 2*(xx+yy) };
+	// Bound the public two-cross rotation's integer rounding, in raw units:
+	// inner cross <= 1, addition of w*v <= 1.5, outer cross <=
+	// 1 + 1.5*(|q_j|+|q_k|), final factor two is exact. Thus <= 7
+	// for a quaternion within the normalization tolerance. With both relevant
+	// vector components zero the coordinate is unchanged and has no error.
+	fixAABB out;
+	fixAABBTransformAxis( rowX, center, extent, t.p.x, ( y | z ) == 0 ? 0 : 7, &out.lowerBound.x, &out.upperBound.x );
+	fixAABBTransformAxis( rowY, center, extent, t.p.y, ( x | z ) == 0 ? 0 : 7, &out.lowerBound.y, &out.upperBound.y );
+	fixAABBTransformAxis( rowZ, center, extent, t.p.z, ( x | y ) == 0 ? 0 : 7, &out.lowerBound.z, &out.upperBound.z );
+	return out;
+}
+
 /// Transform an axis-aligned bounding box. This can create a larger box than if you
 /// recomputed the AABB of the original shape with the transform applied.
 ///
-/// Defined here rather than beside the other AABB operations because it needs
-/// fixTransformPoint, fixMakeMatrixFromQuat, fixAbsMatrix3 and fixMulMV, all of which are
-/// declared further down this header than the AABB block.
+/// Uses unrounded coefficients and outward rounding to enclose the public
+/// point transform, including its integer rounding error. Requires a normalized
+/// quaternion and representable point-rotation intermediates.
 FIX_INLINE fixAABB fixAABB_Transform( fixTransform transform, fixAABB a )
 {
-	fixVec3 center = fixTransformPoint( transform, fixAABB_Center( a ) );
-	fixMatrix3 m = fixMakeMatrixFromQuat( transform.q );
-	fixVec3 extent = fixMulMV( fixAbsMatrix3( m ), fixAABB_Extents( a ) );
-	fixAABB out = { fixVecSub( center, extent ), fixVecAdd( center, extent ) };
-	return out;
+	return fixTransformAABBCenterExtents( transform, fixAABB_Center( a ), fixAABB_Extents( a ) );
 }
 
 /// Get the closest point on an axis-aligned bounding box.

--- a/extern/fixed/include/fixed/fixed_wide.h
+++ b/extern/fixed/include/fixed/fixed_wide.h
@@ -317,50 +317,37 @@ FIX_ALWAYS_INLINE fixed_t fixAABBWide_Area( fixAABBWide a )
 	return fixMul( FIX( 2.0f ) , ( fixMul( dx , dy ) + fixMul( dy , dz ) + fixMul( dz , dx ) ) );
 }
 
-/// Center, in local space.
-///
-/// Ported exactly as box3d has it, INCLUDING the narrowing, because the rounding is
-/// load-bearing: box3d narrows both bounds to fixed_t and then applies the same
-/// half-up fixMulSV( 0.5, ... ) the narrow build uses, so a box expressed either way
-/// yields the same center. An integer >> 1 here would truncate instead of rounding
-/// half-up and would shift the box by up to 1 ULP relative to the narrow build.
-///
-/// Known limitation, inherited deliberately rather than silently repaired: the center
-/// of a box whose coordinates exceed Q48.16 range saturates. Fixing that means
-/// returning a wide center, which is a behaviour change and belongs in its own commit
-/// with its own goldens -- not smuggled in under the word "extract".
+/// Center, in local space, rounded half up. Average at full width before
+/// narrowing, splitting each endpoint first so even a full-range wide sum
+/// cannot overflow. A center outside the local domain saturates to FIX_MIN/MAX.
 FIX_ALWAYS_INLINE fixVec3 fixAABBWide_Center( fixAABBWide a )
 {
-	fixVec3 lo = fixPosWideToVec3( a.lowerBound );
-	fixVec3 hi = fixPosWideToVec3( a.upperBound );
-	return fixMulSV( FIX( 0.5f ), fixVecAdd( hi, lo ) );
+	fixInt128 lx = fixInt128Shr( a.lowerBound.x, 1 ), ux = fixInt128Shr( a.upperBound.x, 1 );
+	fixInt128 ly = fixInt128Shr( a.lowerBound.y, 1 ), uy = fixInt128Shr( a.upperBound.y, 1 );
+	fixInt128 lz = fixInt128Shr( a.lowerBound.z, 1 ), uz = fixInt128Shr( a.upperBound.z, 1 );
+	fixVec3 out = {
+		fixAABBNarrowBound( fixInt128Add( fixInt128Add( lx, ux ), fixInt128FromU64( ( fixInt128Lo( a.lowerBound.x ) | fixInt128Lo( a.upperBound.x ) ) & 1 ) ) ),
+		fixAABBNarrowBound( fixInt128Add( fixInt128Add( ly, uy ), fixInt128FromU64( ( fixInt128Lo( a.lowerBound.y ) | fixInt128Lo( a.upperBound.y ) ) & 1 ) ) ),
+		fixAABBNarrowBound( fixInt128Add( fixInt128Add( lz, uz ), fixInt128FromU64( ( fixInt128Lo( a.lowerBound.z ) | fixInt128Lo( a.upperBound.z ) ) & 1 ) ) ),
+	};
+	return out;
 }
 
-/// Extents (half-widths) in local space. Exact whenever the box's SIZE fits local
-/// range, regardless of how far from the origin the box sits.
-///
-/// NOT a faithful port -- this is a deliberate BUG FIX, called out because everything
-/// else in this extraction is behaviour-preserving. box3d's wide fixAABB_Extents narrows
-/// each bound to fixed_t and then subtracts:
-///
-///     fixMulSV( FIX( 0.5f ), fixVecSub( fixToVec3( a.upperBound ), fixToVec3( a.lowerBound ) ) )
-///
-/// Past Q48.16 range BOTH bounds saturate to INT64_MAX, their difference is zero, and a
-/// perfectly ordinary box reports zero extents -- at exactly the distances ludicrous mode
-/// exists to serve. fixAABB_Transform consumes Extents, so transformed distant boxes
-/// collapse too. box3d's own wide fixAABB_Area already does it the right way round
-/// (difference in 128-bit, then narrow), so this restores consistency within that file
-/// rather than inventing a convention.
-///
-/// For any box whose bounds both fit local range the two forms agree bit-for-bit, which
-/// the narrow/wide correspondence cases in test/aabb_test.c check directly. The fix is
-/// therefore invisible to every build that was already correct.
+// Internal: subtract as unsigned (ordered endpoints have a non-negative
+// difference up to 128 bits), halve and round before narrowing. A representable
+// half-width survives even when the full width exceeds the local domain.
+FIX_ALWAYS_INLINE fixed_t fixWideHalfExtent( fixedWide_t lower, fixedWide_t upper )
+{
+	fixUInt128 difference = fixInt128ToUnsigned( fixWideSub( upper, lower ) );
+	fixUInt128 half = fixUInt128Add( fixUInt128Shr( difference, 1 ), fixUInt128FromU64( fixUInt128Lo( difference ) & 1 ) );
+	return fixUInt128Gt( half, fixUInt128FromU64( (uint64_t)FIX_MAX ) ) ? FIX_MAX : (fixed_t)fixUInt128Lo( half );
+}
+
+/// Half-widths rounded half up, saturated to FIX_MAX, independent of distance.
 FIX_ALWAYS_INLINE fixVec3 fixAABBWide_Extents( fixAABBWide a )
 {
-	fixVec3 d = { fixWideSubToFixed( a.upperBound.x, a.lowerBound.x ),
-	             fixWideSubToFixed( a.upperBound.y, a.lowerBound.y ),
-	             fixWideSubToFixed( a.upperBound.z, a.lowerBound.z ) };
-	return fixMulSV( FIX( 0.5f ), d );
+	return FIX_LITERAL( fixVec3 ){ fixWideHalfExtent( a.lowerBound.x, a.upperBound.x ),
+		fixWideHalfExtent( a.lowerBound.y, a.upperBound.y ), fixWideHalfExtent( a.lowerBound.z, a.upperBound.z ) };
 }
 
 /// Union of two wide boxes.
@@ -435,27 +422,14 @@ FIX_ALWAYS_INLINE fixAABBWide fixMakeAABBWideAt( const fixVec3* points, int coun
 	return fixOffsetAABBWide( local, origin );
 }
 
-/// Transform a wide box by a local transform.
-///
-/// Ported from box3d's ludicrous build, and it is the same conservative-bound algorithm
-/// as the narrow fixAABB_Transform: rotate the extents through the absolute matrix, then
-/// rebuild around the transformed center. The centre is computed and re-widened rather
-/// than rotated in place, because the rotation is a local operation and only the extents
-/// need it -- the wide part of the coordinate is a translation the rotation does not see.
-///
-/// NOTE the inherited limitation, stated rather than papered over: the centre narrows to
-/// local range, so a box whose CENTRE exceeds Q48.16 saturates. Extents survive at any
-/// distance (that is the fixAABBWide_Extents fix), but a transform about a distant centre
-/// does not. box3d has the same limitation today; fixing it needs a wide-centre
-/// formulation and belongs in its own change with its own goldens.
+/// Transform a wide box by a local transform, with the same unrounded
+/// coefficients and outward error allowance as fixAABB_Transform.
+/// The inherited local-center limit remains: a center outside Q48.16 saturates
+/// before rotation. Extents are computed from the full-width difference.
 FIX_ALWAYS_INLINE fixAABBWide fixAABBWide_Transform( fixTransform transform, fixAABBWide a )
 {
-	fixVec3 center = fixTransformPoint( transform, fixAABBWide_Center( a ) );
-	fixMatrix3 m = fixMakeMatrixFromQuat( transform.q );
-	fixVec3 extent = fixMulMV( fixAbsMatrix3( m ), fixAABBWide_Extents( a ) );
-	fixVec3 lo = fixVecSub( center, extent );
-	fixVec3 hi = fixVecAdd( center, extent );
-	fixAABBWide out = { fixPosWideFromVec3( lo ), fixPosWideFromVec3( hi ) };
+	fixAABB local = fixTransformAABBCenterExtents( transform, fixAABBWide_Center( a ), fixAABBWide_Extents( a ) );
+	fixAABBWide out = { fixPosWideFromVec3( local.lowerBound ), fixPosWideFromVec3( local.upperBound ) };
 	return out;
 }
 

--- a/test/test_determinism.c
+++ b/test/test_determinism.c
@@ -17,7 +17,7 @@
 
 // Golden values for the fixed-point build. Fixed-point math is exactly
 // reproducible across platforms and worker counts, so these hold everywhere.
-// The scene builds at GetSceneOrigin() — 100 km out on every axis — so this
+// The scene builds at GetSceneOrigin(), far out on every axis, so this
 // test also enforces determinism far from the origin.
 //
 // The sleep step is shared by both builds: an exactly representable origin shift is a
@@ -28,28 +28,33 @@
 //
 // A SLEEP STEP OF 0 MEANS THE RAGDOLLS NEVER SETTLED, which is what a missed scale
 // crossing looks like from here. Read a zero as that before re-capturing anything.
-#define RAGDOLL_SLEEP_STEP 312
+// Re-captured for fixed 2f1ed91: corrected small-angle/normalization math and
+// conservative bounds change the ragdoll and wave-pile trajectories. The
+// library's root optimization preserves exact bits. Debug and optimized runs
+// agree across worker counts, and narrow/wide builds share the sleep steps.
+// Query-spawn (including hit/query hashes) and mesh-drop references are unchanged.
+#define RAGDOLL_SLEEP_STEP 353
 #if defined( BOX3D_LUDICROUS_MODE )
-#define RAGDOLL_HASH 0x5A1D71FF
+#define RAGDOLL_HASH 0xE3C6F21F
 #else
-#define RAGDOLL_HASH 0xC745DFFF
+#define RAGDOLL_HASH 0xE96299DF
 #endif
 
 // Goldens for the wave pile, query spawn and mesh drop scenarios. Fixed-point goldens
 // hold across platforms and worker counts by construction. The sleep steps are shared
 // between builds; the hashes cover absolute transform bytes, so the ludicrous build
 // (128-bit positions, 80-byte b3WorldTransform) carries its own values.
-#define WAVE_PILE_SLEEP_STEP 286
+#define WAVE_PILE_SLEEP_STEP 276
 #define QUERY_SPAWN_SLEEP_STEP 243
 #define QUERY_SPAWN_HIT_COUNT 59
 #define QUERY_SPAWN_QUERY_HASH 0xE583B246
 #define MESH_DROP_SLEEP_STEP 210
 #if defined( BOX3D_LUDICROUS_MODE )
-#define WAVE_PILE_HASH 0x180F40D3
+#define WAVE_PILE_HASH 0xE265EC19
 #define QUERY_SPAWN_HASH 0x7C6B3268
 #define MESH_DROP_HASH 0xABA23F15
 #else
-#define WAVE_PILE_HASH 0x9B108F93
+#define WAVE_PILE_HASH 0xFFAF1359
 #define QUERY_SPAWN_HASH 0x49ECDEA8
 #define MESH_DROP_HASH 0x458A95E7
 #endif

--- a/test/test_math.c
+++ b/test/test_math.c
@@ -323,6 +323,42 @@ static int RandomQuatTest( void )
 	return 0;
 }
 
+// Exercise the repaired contracts through the b3 forwarders and both AABB
+// representations, so a stale vendor pin or integration cannot hide behind
+// the upstream library's own tests.
+static int VendoredFixedTest( void )
+{
+	b3Fixed length;
+	b3Vec3 n = b3GetLengthAndNormalize( &length, (b3Vec3){ 1, 1, 1 } );
+	ENSURE( length == 1 );
+	ENSURE( b3IsNormalized( n ) );
+	ENSURE( b3IsNormalizedQuat( b3NormalizeQuat( (b3Quat){ { 1, 1, 0 }, 0 } ) ) );
+	ENSURE( !b3IsNormalized( (b3Vec3){ (b3Fixed)1 << 40, B3_FIXED_ONE, 0 } ) );
+
+	b3Fixed angle;
+	b3Quat small = { { 128, 0, 0 }, B3_FIXED_ONE };
+	b3Vec3 axis = b3GetAxisAngle( &angle, small );
+	ENSURE( angle > 0 && b3IsNormalized( axis ) );
+	ENSURE( b3GetSwingAngle( small ) > 0 );
+
+	b3Vec3 far = { (b3Fixed)1 << 62, 0, 0 };
+	b3AABB point = { b3ToPos( far ), b3ToPos( far ) };
+	ENSURE( b3AABB_Center( point ).x == far.x );
+	ENSURE( b3AABB_Extents( point ).x == 0 );
+
+	b3Fixed extent = B3_FIX( 8.0f );
+	b3AABB box = { b3ToPos( (b3Vec3){ -extent, -extent, -extent } ),
+		b3ToPos( (b3Vec3){ extent, extent, extent } ) };
+	b3Transform t = { { 0, 0, 0 }, { { 0, 0, 46341 }, 46341 } };
+	b3AABB bound = b3AABB_Transform( t, box );
+	b3Vec3 p = b3TransformPoint( t, (b3Vec3){ extent, 0, 0 } );
+	b3Vec3 lower = b3ToVec3( bound.lowerBound ), upper = b3ToVec3( bound.upperBound );
+	ENSURE( lower.x <= p.x && p.x <= upper.x );
+	ENSURE( lower.y <= p.y && p.y <= upper.y );
+	ENSURE( lower.z <= p.z && p.z <= upper.z );
+	return 0;
+}
+
 int MathTest( void )
 {
 	// Compare the fixed-point trig against double precision references from libm.
@@ -654,6 +690,7 @@ int MathTest( void )
 	}
 
 	// the game conversion roster
+	RUN_SUBTEST( VendoredFixedTest );
 	RUN_SUBTEST( Exp2Log2PowTest );
 	RUN_SUBTEST( Quat30Test );
 	RUN_SUBTEST( SmoothingTest );

--- a/tools/revendor-fixed.sh
+++ b/tools/revendor-fixed.sh
@@ -18,10 +18,10 @@
 set -euo pipefail
 
 FIXED_REPO="https://github.com/mas-bandwidth/fixed.git"
-# v1.4.0. Pinned as a SHA rather than the tag name on purpose: a tag can be moved,
-# a commit cannot, and "vendored at v1.3.2" should mean one specific tree forever.
-FIXED_PIN="a0fa624d739790844af34499381c55abaa65180f"
-FIXED_VERSION="v1.4.0"
+# Tested numerical repairs and exact-math optimizations from fixed PR #28.
+# This is an unreleased snapshot, pinned by immutable commit rather than a branch.
+FIXED_PIN="2f1ed913374ab047c061c66f5be737715f7d87b5"
+FIXED_VERSION="unreleased-2f1ed91"
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DEST="$ROOT/extern/fixed"


### PR DESCRIPTION
Update `extern/fixed` from v1.4.0 (`a0fa624d`) to the tested numerical-repair and exact-math optimization snapshot `2f1ed913374ab047c061c66f5be737715f7d87b5` from [fixed #28](https://github.com/mas-bandwidth/fixed/pull/28). This is an unreleased commit pin, with no invented release tag.

The regenerated upstream headers fix conservative transformed bounds, short/full-range normalization, small-angle extraction, validators, midpoint arithmetic and boundary conversions. Exactly repaired square-root seeds and 64-bit residual correction improve the normalization/root paths while retaining exact integer results. `tools/revendor-fixed.sh --check` confirms the copied bytes match the pin; no vendor headers were hand-edited.

Fixed3D's ragdoll and wave-pile trajectories change with the corrected math, so their references were recaptured only after checking settled states across workers and position widths:

| Scene | Sleep step | Narrow hash | Wide hash |
| --- | ---: | --- | --- |
| Ragdolls | 312 -> 353 | `0xC745DFFF` -> `0xE96299DF` | `0x5A1D71FF` -> `0xE3C6F21F` |
| Wave pile | 286 -> 276 | `0x9B108F93` -> `0xFFAF1359` | `0x180F40D3` -> `0xE265EC19` |

Query-spawn (including hits and query hashes) and mesh-drop references remain unchanged. The square-root optimization itself preserves result bits. A new test exercises the repaired contracts through the `b3` wrappers and both AABB representations: tiny normalization, small angles, invalid norms, far midpoint arithmetic and strict transformed-point containment.

Validation on arm64 Apple Clang:

- All **24 suites pass** in Debug, RelWithDebInfo, wide-position RelWithDebInfo, and Debug with ASan/UBSan.
- Independent capture runs agree across Debug/optimized builds and the worker counts covered by each scenario (ragdolls 1–5, wave/query 1–4, mesh 1 and 4).
- Vendor drift check and whitespace checks pass.
- The eleven existing physics benchmarks completed two trials per revision on an M3 Ultra with four workers. Ten scenes improved; the first joint-grid comparison was noisy. Five focused alternating pairs, two repeats per process, gave median times of **913.686 → 918.511 ms** for joint-grid (+0.5%), **24.922 → 24.279 ms** for large-world (-2.6%), and **311.757 → 203.260 ms** for trees50 (-34.8%). The large first-sweep large-world gain was an outlier; no aggregate claim is made from that sweep. The mesh gain repeated in every pair. These are local integrated measurements, with changed trajectories in some scenes, not a cross-platform or zero-regression guarantee.
- All **20 PR checks passed** at `0a9ffe83`, including MemorySanitizer (21m07s), the Linux/macOS/Windows/Emscripten test and sample matrix, vendor drift, CAA and the aggregate build result.

This branch starts at current main and contains only the vendor integration and its tests/metadata. Concurrent repair/optimization branches remain separate.
