### PR TITLE
Reuse unchanged contact geometry and remove unused joint work

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
           - name: ubuntu-wide-positions
             os: ubuntu-latest
             timeout: 10
-            args: '-DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18 -DBOX3D_WIDE_POSITIONS=ON -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"'
+            args: '-DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18 -DBOX3D_LUDICROUS_MODE=ON -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"'
             test: ./bin/test
           # Optimized runs. The determinism golden hashes are otherwise only checked at -O0,
           # and -O2 is where a codegen difference in the integer math would first show up.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ This fork exists to answer two questions:
    was *entirely* fixed point?**
 2. **Exactly how much slower would it be?**
 
-The answers: This repository and currently about **2.4× float runtime in scalar mode**,
-or **2.3× with NEON**, measured over the full benchmark suite on Apple M3 Ultra.
+The answers: This repository and currently about **2.2× float runtime in scalar mode**,
+or **2.1× with NEON**, measured over the full benchmark suite on Apple M3 Ultra.
 
 What you get in exchange is one thing: a truly huge world with uniform precision everywhere.
 
@@ -37,7 +37,7 @@ Measured 2026-09-07 on Apple M3 Ultra, macOS 26.6.2, Apple Clang 21,
 RelWithDebInfo (`-O2`, thin LTO), four workers, continuous collision enabled.
 The table uses median whole-scene runtimes from alternating processes;
 commands, all trials, binary hashes and rechecks are in the
-[measurement record](benchmark/2026-09-07-integrated-performance.md).
+[measurement record](benchmark/2026-09-07-contact-joint-performance.md).
 
 - **Float:** Box3D `47d7f7c`, single precision with default NEON.
 - **Fixed:** this tree with fixed `2f1ed91`, scalar defaults.
@@ -45,24 +45,25 @@ commands, all trials, binary hashes and rechecks are in the
 
 | Benchmark | Float (ms) | Fixed (ms) | Fixed+NEON (ms) | Fixed/float | NEON/float |
 |---|---:|---:|---:|---:|---:|
-| convex_pile | 3,574.5 | 10,828.7 | 7,020.1 | 3.03× | 1.96× |
-| joint_grid | 267.3 | 719.7 | 719.0 | 2.69× | 2.69× |
-| junkyard | 3,530.0 | 8,382.3 | 7,953.3 | 2.37× | 2.25× |
-| large_pyramid | 468.2 | 1,550.7 | 1,597.0 | 3.31× | 3.41× |
-| large_world | 12.4 | 24.3 | 24.7 | 1.95× | 1.99× |
-| many_pyramids | 472.4 | 1,570.2 | 1,588.5 | 3.32× | 3.36× |
-| rain | 566.1 | 1,376.6 | 1,351.7 | 2.43× | 2.39× |
-| trees100 | 84.7 | 151.6 | 146.9 | 1.79× | 1.74× |
-| trees50 | 106.7 | 210.4 | 208.3 | 1.97× | 1.95× |
-| trees25 | 233.3 | 399.4 | 396.9 | 1.71× | 1.70× |
-| washer | 6,770.4 | 13,694.0 | 13,806.2 | 2.02× | 2.04× |
+| convex_pile | 3,769.9 | 11,088.8 | 7,163.6 | 2.94× | 1.90× |
+| joint_grid | 266.7 | 624.2 | 631.3 | 2.34× | 2.37× |
+| junkyard | 4,292.0 | 9,577.5 | 8,985.0 | 2.23× | 2.09× |
+| large_pyramid | 571.7 | 1,633.4 | 1,637.8 | 2.86× | 2.86× |
+| large_world | 13.9 | 25.4 | 25.3 | 1.82× | 1.82× |
+| many_pyramids | 449.6 | 1,444.4 | 1,434.9 | 3.21× | 3.19× |
+| rain | 538.5 | 1,238.7 | 1,235.0 | 2.30× | 2.29× |
+| trees100 | 88.5 | 159.6 | 156.6 | 1.80× | 1.77× |
+| trees50 | 101.2 | 198.4 | 195.4 | 1.96× | 1.93× |
+| trees25 | 237.1 | 405.9 | 398.6 | 1.71× | 1.68× |
+| washer | 7,210.5 | 14,607.6 | 14,246.4 | 2.03× | 1.98× |
 
-Geometric mean: **2.36× float runtime for scalar**, **2.25× with NEON**,
-or about **42% and 44% of float throughput**. The
+Geometric mean: **2.24× float runtime for scalar**, **2.13× with NEON**,
+or about **44.6% and 47.0% of float throughput**. The
 [July measurements](benchmark/2026-07-13-readme-results.md) used an older float
-revision; their approximately 50% figure is historical.
+revision; their approximately 50% figure is historical. The latest contact/joint
+pass cuts geometric-mean runtime by **3.3% scalar / 3.9% NEON**.
 
-The latest work moved the needle in three measured places:
+The preceding passes moved the needle in three measured places:
 
 - Exact scalar hull-edge rejection cut Convex Pile runtime by **11.3%** on the old library.
 - The repaired fixed library cut geometric-mean runtime by **15.0%** against the already optimized old-library scalar build.
@@ -72,6 +73,11 @@ The joint shortcut preserves exact results and the full 256-bit path for
 nonzero solves. The 40-bit inverse scale remains essential for large asteroids
 to respond to impulses. All 24 suites pass locally in Debug, optimized scalar,
 NEON, wide positions and ASan+UBSan, including asteroid-response tests.
+
+The latest pass reuses exact contact geometry, skips unused angular calculations,
+and removes known-zero matrix products. It adds 128 bytes per group of four
+convex constraints. All 4,800 additional state hashes and 80 repeated captures
+match the preceding build exactly.
 
 These are measurements on a shared workstation. Small scene differences are
 inconclusive; the library repair also changes trajectories and contact counts.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ This fork exists to answer two questions:
    was *entirely* fixed point?**
 2. **Exactly how much slower would it be?**
 
-The answers: This repository and **2× slower** (geometric mean over the full benchmark suite,
-measured on Apple silicon and on AMD Zen 4).
+The answers: This repository and currently about **2.4× float runtime in scalar mode**,
+or **2.3× with NEON**, measured over the full benchmark suite on Apple M3 Ultra.
 
 What you get in exchange is one thing: a truly huge world with uniform precision everywhere.
 
@@ -29,35 +29,53 @@ casts, the mass properties, the recording format. The float SIMD is gone (it
 grew back on AVX-512 and NEON — same bits, just faster). In
 exchange, resolution is a uniform 1/65536 everywhere in a ±1.4×10¹⁴ meter
 world, every step is still bit-exact on every platform (Box3D already
-was — see below), and all 22 unit test suites still pass.
+was — see below), and all 24 unit test suites still pass.
 
 ## Profile results: fixed point vs. single precision floating point
 
-`benchmark -t=4 -w=4 -r=2` (4 workers, min of 2 runs, continuous collision on),
-Apple M3 Ultra, macOS 26.5.1, Apple clang 21, RelWithDebInfo, Ninja.
-Measured 2026-07-13 at the current build defaults; all three columns were
-re-run in the same session, float included.
+Measured 2026-09-07 on Apple M3 Ultra, macOS 26.6.2, Apple Clang 21,
+RelWithDebInfo (`-O2`, thin LTO), four workers, continuous collision enabled.
+The table uses median whole-scene runtimes from alternating processes;
+commands, all trials, binary hashes and rechecks are in the
+[measurement record](benchmark/2026-09-07-integrated-performance.md).
 
-- **float** = Box3D at `e961bfb` (single precision, NEON SIMD)
-- **fixed** = this tree, scalar int64 lanes
-- **fixed+NEON** = this tree with `-DBOX3D_NEON=ON` (narrow phase only)
+- **Float:** Box3D `47d7f7c`, single precision with default NEON.
+- **Fixed:** this tree with fixed `2f1ed91`, scalar defaults.
+- **Fixed+NEON:** the same tree with `-DBOX3D_NEON=ON` (narrow phase).
 
-| Benchmark     | float (ms) | fixed (ms) | fixed+NEON (ms) | fixed/float | NEON/float | NEON speedup |
-|---------------|-----------:|-----------:|----------------:|------------:|-----------:|-------------:|
-| convex_pile   |   13,725.4 |   21,391.2 |        10,316.8 |       1.6× |  **0.75×** |        2.07× |
-| joint_grid    |      276.7 |      789.1 |           785.3 |       2.9× |      2.8× |        1.00× |
-| junkyard      |    4,875.1 |    9,859.1 |         8,750.3 |       2.0× |      1.8× |        1.13× |
-| large_pyramid |      547.8 |    1,676.9 |         1,625.0 |       3.1× |      3.0× |        1.03× |
-| large_world   |       13.4 |       23.5 |            23.9 |       1.8× |      1.8× |        0.98× |
-| many_pyramids |      518.0 |    1,681.5 |         1,651.8 |       3.2× |      3.2× |        1.02× |
-| rain          |      610.5 |    1,289.0 |         1,286.1 |       2.1× |      2.1× |        1.00× |
-| trees25       |      234.5 |      358.7 |           348.4 |       1.5× |      1.5× |        1.03× |
-| trees50       |      117.5 |      196.5 |           195.0 |       1.7× |      1.7× |        1.01× |
-| trees100      |       84.2 |      154.1 |           149.0 |       1.8× |      1.8× |        1.03× |
-| washer        |    6,896.4 |   13,599.9 |        13,606.9 |       2.0× |      2.0× |        1.00× |
+| Benchmark | Float (ms) | Fixed (ms) | Fixed+NEON (ms) | Fixed/float | NEON/float |
+|---|---:|---:|---:|---:|---:|
+| convex_pile | 3,574.5 | 10,828.7 | 7,020.1 | 3.03× | 1.96× |
+| joint_grid | 267.3 | 719.7 | 719.0 | 2.69× | 2.69× |
+| junkyard | 3,530.0 | 8,382.3 | 7,953.3 | 2.37× | 2.25× |
+| large_pyramid | 468.2 | 1,550.7 | 1,597.0 | 3.31× | 3.41× |
+| large_world | 12.4 | 24.3 | 24.7 | 1.95× | 1.99× |
+| many_pyramids | 472.4 | 1,570.2 | 1,588.5 | 3.32× | 3.36× |
+| rain | 566.1 | 1,376.6 | 1,351.7 | 2.43× | 2.39× |
+| trees100 | 84.7 | 151.6 | 146.9 | 1.79× | 1.74× |
+| trees50 | 106.7 | 210.4 | 208.3 | 1.97× | 1.95× |
+| trees25 | 233.3 | 399.4 | 396.9 | 1.71× | 1.70× |
+| washer | 6,770.4 | 13,694.0 | 13,806.2 | 2.02× | 2.04× |
 
-Geometric mean: 2.07× slower scalar, 1.90× with NEON. I expect this to worsen to around 2.5× as any
-worthwhile optimizations found during this exercise are backported to the real Box3D.
+Geometric mean: **2.36× float runtime for scalar**, **2.25× with NEON**,
+or about **42% and 44% of float throughput**. The
+[July measurements](benchmark/2026-07-13-readme-results.md) used an older float
+revision; their approximately 50% figure is historical.
+
+The latest work moved the needle in three measured places:
+
+- Exact scalar hull-edge rejection cut Convex Pile runtime by **11.3%** on the old library.
+- The repaired fixed library cut geometric-mean runtime by **15.0%** against the already optimized old-library scalar build.
+- Skipping exactly zero joint corrections cut Joint Grid runtime by **18.7%** in the grouped recheck.
+
+The joint shortcut preserves exact results and the full 256-bit path for
+nonzero solves. The 40-bit inverse scale remains essential for large asteroids
+to respond to impulses. All 24 suites pass locally in Debug, optimized scalar,
+NEON, wide positions and ASan+UBSan, including asteroid-response tests.
+
+These are measurements on a shared workstation. Small scene differences are
+inconclusive; the library repair also changes trajectories and contact counts.
+The percentage improvements above measure separate changes and are not additive.
 
 ## Should I use this?
 
@@ -77,7 +95,7 @@ already does:
 
 If your world genuinely outruns what large positions plus broadphase
 padding cover, this library is the answer to your problem. Be sure that is
-your problem before paying 2× for it.
+your problem before paying the performance cost for it.
 
 For everything else, Box3D almost certainly does what you need: <https://github.com/erincatto/box3d>
 

--- a/benchmark/2026-07-13-readme-results.md
+++ b/benchmark/2026-07-13-readme-results.md
@@ -1,0 +1,32 @@
+# Historical README measurements
+
+These July measurements used an older float revision and are retained as history.
+
+## Profile results: fixed point vs. single precision floating point
+
+`benchmark -t=4 -w=4 -r=2` (4 workers, min of 2 runs, continuous collision on),
+Apple M3 Ultra, macOS 26.5.1, Apple clang 21, RelWithDebInfo, Ninja.
+Measured 2026-07-13 at the current build defaults; all three columns were
+re-run in the same session, float included.
+
+- **float** = Box3D at `e961bfb` (single precision, NEON SIMD)
+- **fixed** = this tree, scalar int64 lanes
+- **fixed+NEON** = this tree with `-DBOX3D_NEON=ON` (narrow phase only)
+
+| Benchmark     | float (ms) | fixed (ms) | fixed+NEON (ms) | fixed/float | NEON/float | NEON speedup |
+|---------------|-----------:|-----------:|----------------:|------------:|-----------:|-------------:|
+| convex_pile   |   13,725.4 |   21,391.2 |        10,316.8 |       1.6× |  **0.75×** |        2.07× |
+| joint_grid    |      276.7 |      789.1 |           785.3 |       2.9× |      2.8× |        1.00× |
+| junkyard      |    4,875.1 |    9,859.1 |         8,750.3 |       2.0× |      1.8× |        1.13× |
+| large_pyramid |      547.8 |    1,676.9 |         1,625.0 |       3.1× |      3.0× |        1.03× |
+| large_world   |       13.4 |       23.5 |            23.9 |       1.8× |      1.8× |        0.98× |
+| many_pyramids |      518.0 |    1,681.5 |         1,651.8 |       3.2× |      3.2× |        1.02× |
+| rain          |      610.5 |    1,289.0 |         1,286.1 |       2.1× |      2.1× |        1.00× |
+| trees25       |      234.5 |      358.7 |           348.4 |       1.5× |      1.5× |        1.03× |
+| trees50       |      117.5 |      196.5 |           195.0 |       1.7× |      1.7× |        1.01× |
+| trees100      |       84.2 |      154.1 |           149.0 |       1.8× |      1.8× |        1.03× |
+| washer        |    6,896.4 |   13,599.9 |        13,606.9 |       2.0× |      2.0× |        1.00× |
+
+Geometric mean: 2.07× slower scalar, 1.90× with NEON. I expect this to worsen to around 2.5× as any
+worthwhile optimizations found during this exercise are backported to the real Box3D.
+

--- a/benchmark/2026-09-07-contact-joint-performance.json
+++ b/benchmark/2026-09-07-contact-joint-performance.json
@@ -1,0 +1,3097 @@
+{
+  "profiles": {
+    "profile-large_pyramid": "\n        b3SolveContacts_Convex  (in benchmark-new_neon)        12016\n        b3PrepareContacts_Convex  (in benchmark-new_neon)        4311\n        b3WarmStartContacts_Convex  (in benchmark-new_neon)        2285\n        b3CollideTask  (in benchmark-new_neon)        2055\n        b3ExecuteBlock  (in benchmark-new_neon)        1504\n        b3MakeMatrixFromQuatW  (in benchmark-new_neon)        1503\n        swtch_pri  (in libsystem_kernel.dylib)        1263\n        b3GatherBodies  (in benchmark-new_neon)        1087\n        __udivmodti4  (in libcompiler_rt.dylib)        920\n        b3InvMulSubMVW  (in benchmark-new_neon)        781\n        b3InvMulAddMVW  (in benchmark-new_neon)        719\n        b3StoreImpulses_Convex  (in benchmark-new_neon)        664\n        b3InvMulWorldTransforms  (in benchmark-new_neon)        581\n        semaphore_wait_trap  (in libsystem_kernel.dylib)        467\n        b3RelVelocityW  (in benchmark-new_neon)        377\n        b3FinalizeBodiesTask  (in benchmark-new_neon)        331\n        b3DynamicTree_Query  (in benchmark-new_neon)        201\n        b3SolverTask  (in benchmark-new_neon)        145\n        b3MulMM  (in benchmark-new_neon)        140\n        b3AABB_Transform  (in benchmark-new_neon)        109\n        DYLD-STUB$$__divti3  (in benchmark-new_neon)        78\n        b3Perp  (in benchmark-new_neon)        64\n        b3SqrtW  (in benchmark-new_neon)        64\n        fixNormalizeQuat  (in benchmark-new_neon)        64\n        __divti3  (in libcompiler_rt.dylib)        47\n        b3PairQueryCallback  (in benchmark-new_neon)        43\n        b3DynamicTree_EnlargeProxy  (in benchmark-new_neon)        38\n        b3QueryEdgeDirections  (in benchmark-new_neon)        34\n        b3PartitionMid  (in benchmark-new_neon)        31\n        b3ExecuteStage  (in benchmark-new_neon)        25\n        b3DynamicTree_Rebuild  (in benchmark-new_neon)        18\n        b3ClipPolygon  (in benchmark-new_neon)        16\n        semaphore_signal_trap  (in libsystem_kernel.dylib)        14\n        cthread_yield  (in libsystem_pthread.dylib)        13\n        b3InsertLeaf  (in benchmark-new_neon)        12\n        __psynch_mutexwait  (in libsystem_kernel.dylib)        9\n        b3FindHullSupportVertex  (in benchmark-new_neon)        6\n        b3QueryFaceDirections  (in benchmark-new_neon)        6\n        _platform_memset  (in libsystem_platform.dylib)        5",
+    "profile-joint_grid": "\n        b3SolveSphericalJoint  (in benchmark-new_neon)        12898\n        b3MulMM  (in benchmark-new_neon)        4106\n        b3ExecuteBlock  (in benchmark-new_neon)        3323\n        b3WarmStartSphericalJoint  (in benchmark-new_neon)        2943\n        fixDivShifted256  (in benchmark-new_neon)        2812\n        b3PrepareSphericalJoint  (in benchmark-new_neon)        1194\n        swtch_pri  (in libsystem_kernel.dylib)        1156\n        semaphore_wait_trap  (in libsystem_kernel.dylib)        1029\n        b3FinalizeBodiesTask  (in benchmark-new_neon)        806\n        b3DynamicTree_Query  (in benchmark-new_neon)        570\n        __udivmodti4  (in libcompiler_rt.dylib)        419\n        b3SolverTask  (in benchmark-new_neon)        202\n        fixNormalizeQuat  (in benchmark-new_neon)        202\n        b3DynamicTree_EnlargeProxy  (in benchmark-new_neon)        128\n        b3PartitionMid  (in benchmark-new_neon)        94\n        b3ComputeSphereAABB  (in benchmark-new_neon)        81\n        b3SolveJoint  (in benchmark-new_neon)        74\n        DYLD-STUB$$__divti3  (in benchmark-new_neon)        65\n        b3DynamicTree_Rebuild  (in benchmark-new_neon)        63\n        DYLD-STUB$$__udivti3  (in benchmark-new_neon)        60\n        b3PrepareJoint  (in benchmark-new_neon)        58\n        _platform_memmove  (in libsystem_platform.dylib)        41\n        __divti3  (in libcompiler_rt.dylib)        40\n        b3InsertLeaf  (in benchmark-new_neon)        40\n        b3WarmStartJoint  (in benchmark-new_neon)        40\n        b3Solve  (in benchmark-new_neon)        36\n        b3ExecuteStage  (in benchmark-new_neon)        24\n        mach_msg2_trap  (in libsystem_kernel.dylib)        11\n        semaphore_signal_trap  (in libsystem_kernel.dylib)        10\n        b3AllocateNode  (in benchmark-new_neon)        9\n        DYLD-STUB$$sched_yield  (in benchmark-new_neon)        6\n        ___chkstk_darwin  (in libsystem_pthread.dylib)        6\n        b3FindPairsTask  (in benchmark-new_neon)        6\n        b3UpdateBroadPhasePairs  (in benchmark-new_neon)        6\n        b3UpdateBodyMassData  (in benchmark-new_neon)        5\n\nBinary Images:\n       0x100de8000 -        0x100ea75d7 +benchmark-new_neon (0) <4610E8B3-FAD3-3846-9488-E82C0437525B> /Users/*/Documents/*/benchmark-new_neon\n       0x1839b0000 -        0x183a02b4b  libobjc.A.dylib (951.7) <03BD9E32-CF0A-37B0-898A-3CE8DE06D842> /usr/lib/libobjc.A.dylib",
+    "profile-washer": "\n        b3SolveContacts_Convex  (in benchmark-new_neon)        6203\n        b3DynamicTree_Query  (in benchmark-new_neon)        3766\n        b3PrepareContacts_Convex  (in benchmark-new_neon)        2991\n        b3CollideTask  (in benchmark-new_neon)        2270\n        b3InvMulWorldTransforms  (in benchmark-new_neon)        1377\n        b3GatherBodies  (in benchmark-new_neon)        1371\n        b3ExecuteBlock  (in benchmark-new_neon)        1353\n        semaphore_wait_trap  (in libsystem_kernel.dylib)        1325\n        b3WarmStartContacts_Convex  (in benchmark-new_neon)        1311\n        swtch_pri  (in libsystem_kernel.dylib)        1225\n        b3MakeMatrixFromQuatW  (in benchmark-new_neon)        857\n        b3QueryEdgeDirections  (in benchmark-new_neon)        740\n        __udivmodti4  (in libcompiler_rt.dylib)        642\n        b3FindHullSupportVertex  (in benchmark-new_neon)        509\n        b3UpdateConvexContact  (in benchmark-new_neon)        460\n        b3ClipPolygon  (in benchmark-new_neon)        458\n        b3CollideHulls  (in benchmark-new_neon)        423\n        b3InvMulSubMVW  (in benchmark-new_neon)        412\n        b3PairQueryCallback  (in benchmark-new_neon)        412\n        b3StoreImpulses_Convex  (in benchmark-new_neon)        377\n        b3BuildFaceAContact  (in benchmark-new_neon)        358\n        b3InvMulAddMVW  (in benchmark-new_neon)        354\n        b3FinalizeBodiesTask  (in benchmark-new_neon)        305\n        b3TestEdgePair  (in benchmark-new_neon)        281\n        b3DynamicTree_EnlargeProxy  (in benchmark-new_neon)        256\n        b3SolverTask  (in benchmark-new_neon)        189\n        b3RelVelocityW  (in benchmark-new_neon)        187\n        <deduplicated_symbol>  (in benchmark-new_neon)        171\n        b3QueryFaceDirections  (in benchmark-new_neon)        167\n        b3PartitionMid  (in benchmark-new_neon)        145\n        b3AABB_Transform  (in benchmark-new_neon)        110\n        b3MulMM  (in benchmark-new_neon)        103\n        b3DynamicTree_Rebuild  (in benchmark-new_neon)        100\n        b3FindIncidentFace  (in benchmark-new_neon)        98\n        b3SolveContinuous  (in benchmark-new_neon)        90\n        fixNormalizeQuat  (in benchmark-new_neon)        88\n        mach_absolute_time  (in libsystem_kernel.dylib)        83\n        b3UpdateContact  (in benchmark-new_neon)        68\n        b3Perp  (in benchmark-new_neon)        64"
+  },
+  "measurement": {
+    "method": "Two runs per scene and binary, before-scalar/after-scalar/before-neon/after-neon/float/float/after-neon/before-neon/after-scalar/before-scalar order, four workers, continuous collision enabled, median runtime. Scenes with an initial within-binary spread over 5% received three additional balanced runs of every binary; their final medians include all five trials, with no discarded observations.",
+    "fixed_source": "542fa3593373b817feed479cf526389a4c6b8e60",
+    "before_source": "33a9008f1839d9c8b062aeebaf115cec7050e67a",
+    "float_source": "47d7f7cc7e091142c08d11dc7d2e493c5d34f536",
+    "configuration": "Apple M3 Ultra, arm64, Apple Clang, RelWithDebInfo, O2 and thin LTO; scalar defaults, optional BOX3D_NEON=ON; float default NEON.",
+    "platform": "macOS-26.6.2-arm64-arm-64bit-Mach-O",
+    "started": "2026-09-07T18:21:55-0400",
+    "binaries": {
+      "before_scalar": {
+        "sha256": "d572871f6bc1a8f4636b4f02feffb35ab7d412491fdb84beae04a2ecb441ff8d"
+      },
+      "before_neon": {
+        "sha256": "51f6c0f5e3fb21f690da4a7127c2aadbea01d6ba47ee8b4baa2b127c5ba728c0"
+      },
+      "after_scalar": {
+        "sha256": "a71ebd321fa4b8143609e6eae8aa2a6a925afd6c05f157077acf1826cccdc074"
+      },
+      "after_neon": {
+        "sha256": "7273e1173d4a0a468f39724e38f069dc32cedb05ae31cc64e9e5480a5ed2f3d4"
+      },
+      "float": {
+        "sha256": "a57073956c8f051652832d47f71cddf3254c0c3c4ca40e4f0baeb0a19b97f8f9"
+      }
+    },
+    "rows": [
+      {
+        "scene": "convex_pile",
+        "runs": [
+          {
+            "binary": "before_scalar",
+            "ms": 11654.0,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776"
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 11088.8,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6403712"
+          },
+          {
+            "binary": "before_neon",
+            "ms": 7311.4,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776"
+          },
+          {
+            "binary": "after_neon",
+            "ms": 7026.81,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6403712"
+          },
+          {
+            "binary": "float",
+            "ms": 3629.76,
+            "counters": "body 5121 / shape 5121 / contact 50764 / joint 0 / stack 2662928"
+          },
+          {
+            "binary": "float",
+            "ms": 3580.16,
+            "counters": "body 5121 / shape 5121 / contact 50764 / joint 0 / stack 2662928"
+          },
+          {
+            "binary": "after_neon",
+            "ms": 6677.56,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6403712"
+          },
+          {
+            "binary": "before_neon",
+            "ms": 6745.86,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776"
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 10592.0,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6403712"
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 10679.7,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776"
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 11114.4,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776",
+            "recheck": 0
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 11200.0,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6403712",
+            "recheck": 0
+          },
+          {
+            "binary": "before_neon",
+            "ms": 7801.43,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776",
+            "recheck": 0
+          },
+          {
+            "binary": "after_neon",
+            "ms": 7308.06,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6403712",
+            "recheck": 0
+          },
+          {
+            "binary": "float",
+            "ms": 3769.91,
+            "counters": "body 5121 / shape 5121 / contact 50764 / joint 0 / stack 2662928",
+            "recheck": 0
+          },
+          {
+            "binary": "float",
+            "ms": 3905.0,
+            "counters": "body 5121 / shape 5121 / contact 50764 / joint 0 / stack 2662928",
+            "recheck": 1
+          },
+          {
+            "binary": "after_neon",
+            "ms": 7279.25,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6403712",
+            "recheck": 1
+          },
+          {
+            "binary": "before_neon",
+            "ms": 7127.92,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776",
+            "recheck": 1
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 10977.8,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6403712",
+            "recheck": 1
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 10987.9,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776",
+            "recheck": 1
+          },
+          {
+            "binary": "before_neon",
+            "ms": 7103.56,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776",
+            "recheck": 2
+          },
+          {
+            "binary": "after_neon",
+            "ms": 7163.61,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6403712",
+            "recheck": 2
+          },
+          {
+            "binary": "float",
+            "ms": 4541.94,
+            "counters": "body 5121 / shape 5121 / contact 50764 / joint 0 / stack 2662928",
+            "recheck": 2
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 12137.1,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776",
+            "recheck": 2
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 11487.8,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6403712",
+            "recheck": 2
+          }
+        ],
+        "medians_ms": {
+          "before_scalar": 11114.4,
+          "after_scalar": 11088.8,
+          "before_neon": 7127.92,
+          "after_neon": 7163.61,
+          "float": 3769.91
+        }
+      },
+      {
+        "scene": "joint_grid",
+        "runs": [
+          {
+            "binary": "before_scalar",
+            "ms": 710.256,
+            "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 622.218,
+            "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+          },
+          {
+            "binary": "before_neon",
+            "ms": 712.437,
+            "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+          },
+          {
+            "binary": "after_neon",
+            "ms": 629.245,
+            "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+          },
+          {
+            "binary": "float",
+            "ms": 267.108,
+            "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+          },
+          {
+            "binary": "float",
+            "ms": 266.294,
+            "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+          },
+          {
+            "binary": "after_neon",
+            "ms": 633.305,
+            "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+          },
+          {
+            "binary": "before_neon",
+            "ms": 706.794,
+            "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 626.241,
+            "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 713.947,
+            "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+          }
+        ],
+        "medians_ms": {
+          "before_scalar": 712.1015,
+          "before_neon": 709.6155,
+          "after_scalar": 624.2294999999999,
+          "after_neon": 631.275,
+          "float": 266.701
+        }
+      },
+      {
+        "scene": "junkyard",
+        "runs": [
+          {
+            "binary": "before_scalar",
+            "ms": 8275.6,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 28761008"
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 8543.27,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 29608368"
+          },
+          {
+            "binary": "before_neon",
+            "ms": 8639.44,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 28761008"
+          },
+          {
+            "binary": "after_neon",
+            "ms": 7763.54,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 29608368"
+          },
+          {
+            "binary": "float",
+            "ms": 3439.38,
+            "counters": "body 10586 / shape 10590 / contact 193415 / joint 0 / stack 11295504"
+          },
+          {
+            "binary": "float",
+            "ms": 3585.24,
+            "counters": "body 10586 / shape 10590 / contact 193415 / joint 0 / stack 11295504"
+          },
+          {
+            "binary": "after_neon",
+            "ms": 8167.83,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 29608368"
+          },
+          {
+            "binary": "before_neon",
+            "ms": 8071.23,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 28761008"
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 8396.76,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 29608368"
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 9092.59,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 28761008"
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 9873.06,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 28761008",
+            "recheck": 0
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 9723.27,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 29608368",
+            "recheck": 0
+          },
+          {
+            "binary": "before_neon",
+            "ms": 9488.56,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 28761008",
+            "recheck": 0
+          },
+          {
+            "binary": "after_neon",
+            "ms": 9384.7,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 29608368",
+            "recheck": 0
+          },
+          {
+            "binary": "float",
+            "ms": 4304.97,
+            "counters": "body 10586 / shape 10590 / contact 193415 / joint 0 / stack 11295504",
+            "recheck": 0
+          },
+          {
+            "binary": "float",
+            "ms": 4390.54,
+            "counters": "body 10586 / shape 10590 / contact 193415 / joint 0 / stack 11295504",
+            "recheck": 1
+          },
+          {
+            "binary": "after_neon",
+            "ms": 9115.15,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 29608368",
+            "recheck": 1
+          },
+          {
+            "binary": "before_neon",
+            "ms": 9386.3,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 28761008",
+            "recheck": 1
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 9577.54,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 29608368",
+            "recheck": 1
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 9719.38,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 28761008",
+            "recheck": 1
+          },
+          {
+            "binary": "before_neon",
+            "ms": 9308.53,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 28761008",
+            "recheck": 2
+          },
+          {
+            "binary": "after_neon",
+            "ms": 8985.01,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 29608368",
+            "recheck": 2
+          },
+          {
+            "binary": "float",
+            "ms": 4291.97,
+            "counters": "body 10586 / shape 10590 / contact 193415 / joint 0 / stack 11295504",
+            "recheck": 2
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 10022.2,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 28761008",
+            "recheck": 2
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 11167.5,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 29608368",
+            "recheck": 2
+          }
+        ],
+        "medians_ms": {
+          "before_scalar": 9719.38,
+          "after_scalar": 9577.54,
+          "before_neon": 9308.53,
+          "after_neon": 8985.01,
+          "float": 4291.97
+        }
+      },
+      {
+        "scene": "large_pyramid",
+        "runs": [
+          {
+            "binary": "before_scalar",
+            "ms": 1577.32,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256"
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 1630.32,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+          },
+          {
+            "binary": "before_neon",
+            "ms": 1698.11,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256"
+          },
+          {
+            "binary": "after_neon",
+            "ms": 1559.22,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+          },
+          {
+            "binary": "float",
+            "ms": 584.263,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 6366112"
+          },
+          {
+            "binary": "float",
+            "ms": 559.071,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 6366112"
+          },
+          {
+            "binary": "after_neon",
+            "ms": 1671.62,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+          },
+          {
+            "binary": "before_neon",
+            "ms": 1755.66,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256"
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 1494.55,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 1594.39,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256"
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 1682.55,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256",
+            "recheck": 0
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 1937.3,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104",
+            "recheck": 0
+          },
+          {
+            "binary": "before_neon",
+            "ms": 2372.6,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256",
+            "recheck": 0
+          },
+          {
+            "binary": "after_neon",
+            "ms": 1631.08,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104",
+            "recheck": 0
+          },
+          {
+            "binary": "float",
+            "ms": 569.85,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 6366112",
+            "recheck": 0
+          },
+          {
+            "binary": "float",
+            "ms": 571.696,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 6366112",
+            "recheck": 1
+          },
+          {
+            "binary": "after_neon",
+            "ms": 1637.78,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104",
+            "recheck": 1
+          },
+          {
+            "binary": "before_neon",
+            "ms": 1762.92,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256",
+            "recheck": 1
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 1636.61,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104",
+            "recheck": 1
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 1759.26,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256",
+            "recheck": 1
+          },
+          {
+            "binary": "before_neon",
+            "ms": 1751.94,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256",
+            "recheck": 2
+          },
+          {
+            "binary": "after_neon",
+            "ms": 1645.68,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104",
+            "recheck": 2
+          },
+          {
+            "binary": "float",
+            "ms": 582.291,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 6366112",
+            "recheck": 2
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 1753.1,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256",
+            "recheck": 2
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 1633.42,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104",
+            "recheck": 2
+          }
+        ],
+        "medians_ms": {
+          "before_scalar": 1682.55,
+          "after_scalar": 1633.42,
+          "before_neon": 1755.66,
+          "after_neon": 1637.78,
+          "float": 571.696
+        }
+      },
+      {
+        "scene": "large_world",
+        "runs": [
+          {
+            "binary": "before_scalar",
+            "ms": 24.2674,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 25.3763,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "before_neon",
+            "ms": 37.7392,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "after_neon",
+            "ms": 22.8688,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "float",
+            "ms": 12.4906,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "float",
+            "ms": 12.4931,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "after_neon",
+            "ms": 22.3744,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "before_neon",
+            "ms": 26.888,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 33.1898,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 23.2894,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 44.5592,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 0
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 24.3428,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 0
+          },
+          {
+            "binary": "before_neon",
+            "ms": 27.761,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 0
+          },
+          {
+            "binary": "after_neon",
+            "ms": 25.4359,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 0
+          },
+          {
+            "binary": "float",
+            "ms": 13.9106,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 0
+          },
+          {
+            "binary": "float",
+            "ms": 15.1458,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 1
+          },
+          {
+            "binary": "after_neon",
+            "ms": 27.7546,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 1
+          },
+          {
+            "binary": "before_neon",
+            "ms": 28.1258,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 1
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 24.7606,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 1
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 29.2903,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 1
+          },
+          {
+            "binary": "before_neon",
+            "ms": 26.3318,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 2
+          },
+          {
+            "binary": "after_neon",
+            "ms": 25.3068,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 2
+          },
+          {
+            "binary": "float",
+            "ms": 14.882,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 2
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 26.6363,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 2
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 29.0349,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 2
+          }
+        ],
+        "medians_ms": {
+          "before_scalar": 26.6363,
+          "after_scalar": 25.3763,
+          "before_neon": 27.761,
+          "after_neon": 25.3068,
+          "float": 13.9106
+        }
+      },
+      {
+        "scene": "many_pyramids",
+        "runs": [
+          {
+            "binary": "before_scalar",
+            "ms": 1533.33,
+            "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 30691376"
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 1463.63,
+            "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 31601072"
+          },
+          {
+            "binary": "before_neon",
+            "ms": 1546.58,
+            "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 30691376"
+          },
+          {
+            "binary": "after_neon",
+            "ms": 1439.31,
+            "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 31601072"
+          },
+          {
+            "binary": "float",
+            "ms": 449.867,
+            "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 12102992"
+          },
+          {
+            "binary": "float",
+            "ms": 449.333,
+            "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 12102992"
+          },
+          {
+            "binary": "after_neon",
+            "ms": 1430.43,
+            "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 31601072"
+          },
+          {
+            "binary": "before_neon",
+            "ms": 1560.62,
+            "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 30691376"
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 1425.23,
+            "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 31601072"
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 1547.41,
+            "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 30691376"
+          }
+        ],
+        "medians_ms": {
+          "before_scalar": 1540.37,
+          "before_neon": 1553.6,
+          "after_scalar": 1444.43,
+          "after_neon": 1434.87,
+          "float": 449.6
+        }
+      },
+      {
+        "scene": "rain",
+        "runs": [
+          {
+            "binary": "before_scalar",
+            "ms": 1290.41,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 1235.31,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+          },
+          {
+            "binary": "before_neon",
+            "ms": 1271.08,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+          },
+          {
+            "binary": "after_neon",
+            "ms": 1240.83,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+          },
+          {
+            "binary": "float",
+            "ms": 539.132,
+            "counters": "body 4300 / shape 4400 / contact 7898 / joint 4200 / stack 1535568"
+          },
+          {
+            "binary": "float",
+            "ms": 537.87,
+            "counters": "body 4300 / shape 4400 / contact 7898 / joint 4200 / stack 1535568"
+          },
+          {
+            "binary": "after_neon",
+            "ms": 1229.12,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+          },
+          {
+            "binary": "before_neon",
+            "ms": 1284.04,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 1242.14,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 1349.36,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+          }
+        ],
+        "medians_ms": {
+          "before_scalar": 1319.885,
+          "before_neon": 1277.56,
+          "after_scalar": 1238.725,
+          "after_neon": 1234.975,
+          "float": 538.501
+        }
+      },
+      {
+        "scene": "trees100",
+        "runs": [
+          {
+            "binary": "before_scalar",
+            "ms": 144.031,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 146.933,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "before_neon",
+            "ms": 142.223,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "after_neon",
+            "ms": 141.148,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "float",
+            "ms": 88.4556,
+            "counters": "body 51 / shape 1101 / contact 1102 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "float",
+            "ms": 82.1158,
+            "counters": "body 51 / shape 1101 / contact 1102 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "after_neon",
+            "ms": 142.824,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "before_neon",
+            "ms": 141.073,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 141.859,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 142.317,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 177.799,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528",
+            "recheck": 0
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 165.839,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528",
+            "recheck": 0
+          },
+          {
+            "binary": "before_neon",
+            "ms": 158.43,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528",
+            "recheck": 0
+          },
+          {
+            "binary": "after_neon",
+            "ms": 161.572,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528",
+            "recheck": 0
+          },
+          {
+            "binary": "float",
+            "ms": 98.1159,
+            "counters": "body 51 / shape 1101 / contact 1102 / joint 0 / stack 572528",
+            "recheck": 0
+          },
+          {
+            "binary": "float",
+            "ms": 87.6232,
+            "counters": "body 51 / shape 1101 / contact 1102 / joint 0 / stack 572528",
+            "recheck": 1
+          },
+          {
+            "binary": "after_neon",
+            "ms": 156.583,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528",
+            "recheck": 1
+          },
+          {
+            "binary": "before_neon",
+            "ms": 163.023,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528",
+            "recheck": 1
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 162.609,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528",
+            "recheck": 1
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 179.989,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528",
+            "recheck": 1
+          },
+          {
+            "binary": "before_neon",
+            "ms": 162.914,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528",
+            "recheck": 2
+          },
+          {
+            "binary": "after_neon",
+            "ms": 169.209,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528",
+            "recheck": 2
+          },
+          {
+            "binary": "float",
+            "ms": 91.1845,
+            "counters": "body 51 / shape 1101 / contact 1102 / joint 0 / stack 572528",
+            "recheck": 2
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 160.326,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528",
+            "recheck": 2
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 159.6,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528",
+            "recheck": 2
+          }
+        ],
+        "medians_ms": {
+          "before_scalar": 160.326,
+          "after_scalar": 159.6,
+          "before_neon": 158.43,
+          "after_neon": 156.583,
+          "float": 88.4556
+        }
+      },
+      {
+        "scene": "trees50",
+        "runs": [
+          {
+            "binary": "before_scalar",
+            "ms": 196.839,
+            "counters": "body 51 / shape 1101 / contact 1114 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 199.419,
+            "counters": "body 51 / shape 1101 / contact 1114 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "before_neon",
+            "ms": 195.025,
+            "counters": "body 51 / shape 1101 / contact 1114 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "after_neon",
+            "ms": 195.235,
+            "counters": "body 51 / shape 1101 / contact 1114 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "float",
+            "ms": 101.036,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "float",
+            "ms": 101.368,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "after_neon",
+            "ms": 195.505,
+            "counters": "body 51 / shape 1101 / contact 1114 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "before_neon",
+            "ms": 195.611,
+            "counters": "body 51 / shape 1101 / contact 1114 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 197.462,
+            "counters": "body 51 / shape 1101 / contact 1114 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 197.655,
+            "counters": "body 51 / shape 1101 / contact 1114 / joint 0 / stack 572528"
+          }
+        ],
+        "medians_ms": {
+          "before_scalar": 197.247,
+          "before_neon": 195.31799999999998,
+          "after_scalar": 198.4405,
+          "after_neon": 195.37,
+          "float": 101.202
+        }
+      },
+      {
+        "scene": "trees25",
+        "runs": [
+          {
+            "binary": "before_scalar",
+            "ms": 368.592,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 369.681,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "before_neon",
+            "ms": 361.531,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "after_neon",
+            "ms": 361.111,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "float",
+            "ms": 211.994,
+            "counters": "body 51 / shape 1101 / contact 1112 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "float",
+            "ms": 267.741,
+            "counters": "body 51 / shape 1101 / contact 1112 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "after_neon",
+            "ms": 398.575,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "before_neon",
+            "ms": 369.441,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 378.005,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 378.51,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 408.532,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528",
+            "recheck": 0
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 405.899,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528",
+            "recheck": 0
+          },
+          {
+            "binary": "before_neon",
+            "ms": 392.676,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528",
+            "recheck": 0
+          },
+          {
+            "binary": "after_neon",
+            "ms": 396.463,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528",
+            "recheck": 0
+          },
+          {
+            "binary": "float",
+            "ms": 233.779,
+            "counters": "body 51 / shape 1101 / contact 1112 / joint 0 / stack 572528",
+            "recheck": 0
+          },
+          {
+            "binary": "float",
+            "ms": 239.53,
+            "counters": "body 51 / shape 1101 / contact 1112 / joint 0 / stack 572528",
+            "recheck": 1
+          },
+          {
+            "binary": "after_neon",
+            "ms": 403.835,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528",
+            "recheck": 1
+          },
+          {
+            "binary": "before_neon",
+            "ms": 454.74,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528",
+            "recheck": 1
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 424.782,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528",
+            "recheck": 1
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 805.465,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528",
+            "recheck": 1
+          },
+          {
+            "binary": "before_neon",
+            "ms": 1086.0,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528",
+            "recheck": 2
+          },
+          {
+            "binary": "after_neon",
+            "ms": 486.661,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528",
+            "recheck": 2
+          },
+          {
+            "binary": "float",
+            "ms": 237.143,
+            "counters": "body 51 / shape 1101 / contact 1112 / joint 0 / stack 572528",
+            "recheck": 2
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 419.438,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528",
+            "recheck": 2
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 427.027,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528",
+            "recheck": 2
+          }
+        ],
+        "medians_ms": {
+          "before_scalar": 408.532,
+          "after_scalar": 405.899,
+          "before_neon": 392.676,
+          "after_neon": 398.575,
+          "float": 237.143
+        }
+      },
+      {
+        "scene": "washer",
+        "runs": [
+          {
+            "binary": "before_scalar",
+            "ms": 13559.0,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 18551760"
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 15437.1,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 19101392"
+          },
+          {
+            "binary": "before_neon",
+            "ms": 14814.5,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 18551760"
+          },
+          {
+            "binary": "after_neon",
+            "ms": 15541.6,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 19101392"
+          },
+          {
+            "binary": "float",
+            "ms": 8266.66,
+            "counters": "body 8002 / shape 8041 / contact 40444 / joint 0 / stack 7289728"
+          },
+          {
+            "binary": "float",
+            "ms": 8149.05,
+            "counters": "body 8002 / shape 8041 / contact 40444 / joint 0 / stack 7289728"
+          },
+          {
+            "binary": "after_neon",
+            "ms": 14246.4,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 19101392"
+          },
+          {
+            "binary": "before_neon",
+            "ms": 14038.4,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 18551760"
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 15765.6,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 19101392"
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 16624.9,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 18551760"
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 14713.1,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 18551760",
+            "recheck": 0
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 14430.5,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 19101392",
+            "recheck": 0
+          },
+          {
+            "binary": "before_neon",
+            "ms": 15701.1,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 18551760",
+            "recheck": 0
+          },
+          {
+            "binary": "after_neon",
+            "ms": 14330.1,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 19101392",
+            "recheck": 0
+          },
+          {
+            "binary": "float",
+            "ms": 7180.64,
+            "counters": "body 8002 / shape 8041 / contact 40444 / joint 0 / stack 7289728",
+            "recheck": 0
+          },
+          {
+            "binary": "float",
+            "ms": 7147.18,
+            "counters": "body 8002 / shape 8041 / contact 40444 / joint 0 / stack 7289728",
+            "recheck": 1
+          },
+          {
+            "binary": "after_neon",
+            "ms": 13690.9,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 19101392",
+            "recheck": 1
+          },
+          {
+            "binary": "before_neon",
+            "ms": 14111.6,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 18551760",
+            "recheck": 1
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 14607.6,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 19101392",
+            "recheck": 1
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 14740.2,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 18551760",
+            "recheck": 1
+          },
+          {
+            "binary": "before_neon",
+            "ms": 14577.7,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 18551760",
+            "recheck": 2
+          },
+          {
+            "binary": "after_neon",
+            "ms": 13795.1,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 19101392",
+            "recheck": 2
+          },
+          {
+            "binary": "float",
+            "ms": 7210.53,
+            "counters": "body 8002 / shape 8041 / contact 40444 / joint 0 / stack 7289728",
+            "recheck": 2
+          },
+          {
+            "binary": "before_scalar",
+            "ms": 14878.5,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 18551760",
+            "recheck": 2
+          },
+          {
+            "binary": "after_scalar",
+            "ms": 14547.1,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 19101392",
+            "recheck": 2
+          }
+        ],
+        "medians_ms": {
+          "before_scalar": 14740.2,
+          "after_scalar": 14607.6,
+          "before_neon": 14577.7,
+          "after_neon": 14246.4,
+          "float": 7210.53
+        }
+      }
+    ],
+    "finished": "2026-09-07T18:27:46-0400",
+    "rechecks": [
+      {
+        "scene": "convex_pile",
+        "reason": "Initial pair spread exceeded 5%",
+        "triggering_binaries": [
+          "before_scalar",
+          "before_neon",
+          "after_neon"
+        ]
+      },
+      {
+        "scene": "junkyard",
+        "reason": "Initial pair spread exceeded 5%",
+        "triggering_binaries": [
+          "before_scalar",
+          "before_neon",
+          "after_neon"
+        ]
+      },
+      {
+        "scene": "large_pyramid",
+        "reason": "Initial pair spread exceeded 5%",
+        "triggering_binaries": [
+          "after_scalar",
+          "after_neon"
+        ]
+      },
+      {
+        "scene": "large_world",
+        "reason": "Initial pair spread exceeded 5%",
+        "triggering_binaries": [
+          "after_scalar",
+          "before_neon"
+        ]
+      },
+      {
+        "scene": "trees100",
+        "reason": "Initial pair spread exceeded 5%",
+        "triggering_binaries": [
+          "float"
+        ]
+      },
+      {
+        "scene": "trees25",
+        "reason": "Initial pair spread exceeded 5%",
+        "triggering_binaries": [
+          "after_neon",
+          "float"
+        ]
+      },
+      {
+        "scene": "washer",
+        "reason": "Initial pair spread exceeded 5%",
+        "triggering_binaries": [
+          "before_scalar",
+          "before_neon",
+          "after_neon"
+        ]
+      }
+    ],
+    "rechecks_finished": "2026-09-07T18:37:38-0400"
+  },
+  "float_runtime_ratios": {
+    "before_scalar": 2.320299866135633,
+    "after_scalar": 2.2438407648143097,
+    "before_neon": 2.2164967311046686,
+    "after_neon": 2.1291292186601805
+  },
+  "runtime_reduction_percent": {
+    "scalar": 3.2952250024761875,
+    "neon": 3.9416937195727475
+  },
+  "validation": {
+    "frames": 4800,
+    "hash_sha256": "de8a36a2165eb2062329cc432d0357f9709785152d0d5a9fea6d8461bbd82d04",
+    "workers": [
+      1,
+      4
+    ],
+    "substeps": [
+      1,
+      2,
+      4,
+      8,
+      "varying"
+    ],
+    "cube_sides": [
+      1,
+      250
+    ],
+    "warm_start_toggles": [
+      70,
+      130
+    ]
+  },
+  "checks": {
+    "code_commit": "542fa3593373b817feed479cf526389a4c6b8e60",
+    "ci_run": 34166282099,
+    "ci_conclusion": "success",
+    "local_suites": 24,
+    "local_configurations": [
+      "Debug",
+      "RelWithDebInfo scalar",
+      "RelWithDebInfo NEON",
+      "RelWithDebInfo wide positions",
+      "Debug ASan+UBSan"
+    ],
+    "generic_skew_comparisons": 6144,
+    "frame_hashes": 4800,
+    "cross_worker_frames": 2400,
+    "capture_count": 80,
+    "matching_scenes": 20,
+    "nonzero_solve_unchanged": true
+  },
+  "experiments": {
+    "inline": {
+      "source_diff": "diff --git a/src/contact_solver.c b/src/contact_solver.c\nindex 1b77ca3..53aa8a2 100644\n--- a/src/contact_solver.c\n+++ b/src/contact_solver.c\n@@ -1618,7 +1618,7 @@ static inline b3FloatW b3Dot3W( b3FloatW a, b3FloatW b, b3FloatW c, b3FloatW d,\n // Relative velocity along an axis using precomputed cross(r, axis) rows:\n // dot(dv, axis) + dot(wB, rbxa) - dot(wA, raxa), nine products accumulated\n // at 128 bits with a single rounding.\n-static inline b3FloatW b3RelVelocityW( b3Vec3W dv, b3Vec3W axis, b3Vec3W wB, b3Vec3W rbxa, b3Vec3W wA, b3Vec3W raxa )\n+B3_FORCE_INLINE b3FloatW b3RelVelocityW( b3Vec3W dv, b3Vec3W axis, b3Vec3W wB, b3Vec3W rbxa, b3Vec3W wA, b3Vec3W raxa )\n {\n #if defined( B3_SIMD_AVX512 )\n \tb3DotAccAVX sum = b3DotBeginAVX( dv.X.v, axis.X.v );\n@@ -1783,7 +1783,7 @@ static inline b3FloatW b3RotSubW( b3FloatW a, b3FloatW b, b3FloatW c, b3FloatW d\n }\n \n // Same element layout as the scalar b3MakeMatrixFromQuat, stored as rows\n-static inline b3Matrix3W b3MakeMatrixFromQuatW( b3QuatW q )\n+B3_FORCE_INLINE b3Matrix3W b3MakeMatrixFromQuatW( b3QuatW q )\n {\n \tb3FloatW x = q.V.X;\n \tb3FloatW y = q.V.Y;\n@@ -1896,7 +1896,7 @@ static inline b3Vec3W b3InvMulAddSVW( b3Vec3W a, b3FloatW s, b3Vec3W b )\n }\n \n // a - m * b, where m is an inverse inertia and the result is an angular velocity.\n-static inline b3Vec3W b3InvMulSubMVW( b3Vec3W a, b3SymMatrix3W m, b3Vec3W b )\n+B3_FORCE_INLINE b3Vec3W b3InvMulSubMVW( b3Vec3W a, b3SymMatrix3W m, b3Vec3W b )\n {\n \treturn (b3Vec3W){\n \t\tb3SubW( a.X, b3AddW( b3AddW( b3InvMulW( m.cxx, b.X ), b3InvMulW( m.cxy, b.Y ) ), b3InvMulW( m.cxz, b.Z ) ) ),\n@@ -1906,7 +1906,7 @@ static inline b3Vec3W b3InvMulSubMVW( b3Vec3W a, b3SymMatrix3W m, b3Vec3W b )\n }\n \n // a + m * b, likewise.\n-static inline b3Vec3W b3InvMulAddMVW( b3Vec3W a, b3SymMatrix3W m, b3Vec3W b )\n+B3_FORCE_INLINE b3Vec3W b3InvMulAddMVW( b3Vec3W a, b3SymMatrix3W m, b3Vec3W b )\n {\n \treturn (b3Vec3W){\n \t\tb3AddW( a.X, b3AddW( b3AddW( b3InvMulW( m.cxx, b.X ), b3InvMulW( m.cxy, b.Y ) ), b3InvMulW( m.cxz, b.Z ) ) ),\n@@ -2193,7 +2193,7 @@ static inline void b3Transpose4x4AVX( __m256i r0, __m256i r1, __m256i r2, __m256\n // b3Fixed fields of b3BodyState (deltaRotation.s stays scalar: a fourth\n // vector load would read past the end of the states array for the last\n // body). Pure data movement, bit-identical to the scalar member loads.\n-static b3BodyStateW b3GatherBodies( const b3BodyState* states, int* indices )\n+B3_FORCE_INLINE b3BodyStateW b3GatherBodies( const b3BodyState* states, int* indices )\n {\n \t_Static_assert( offsetof( b3BodyState, angularVelocity ) == 3 * sizeof( b3Fixed ), \"b3BodyState layout\" );\n \t_Static_assert( offsetof( b3BodyState, deltaPosition ) == 6 * sizeof( b3Fixed ), \"b3BodyState layout\" );\n@@ -2267,7 +2267,7 @@ static void b3ScatterBodies( b3BodyState* states, int* indices, const b3BodyStat\n \n #else\n \n-static b3BodyStateW b3GatherBodies( const b3BodyState* states, int* indices )\n+B3_FORCE_INLINE b3BodyStateW b3GatherBodies( const b3BodyState* states, int* indices )\n {\n \tb3BodyState identity = b3_identityBodyState;\n \n",
+      "started": "2026-09-07T18:13:51-0400",
+      "binaries": {
+        "before": {
+          "sha256": "51f6c0f5e3fb21f690da4a7127c2aadbea01d6ba47ee8b4baa2b127c5ba728c0"
+        },
+        "after": {
+          "sha256": "0314c7ab6d400c9dfaa5833e8d61c6afc0ed805ec661c229e9dee20da13ce6b6"
+        }
+      },
+      "rows": [
+        {
+          "scene": "large_pyramid",
+          "runs": [
+            {
+              "binary": "before",
+              "ms": 1646.31,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256"
+            },
+            {
+              "binary": "after",
+              "ms": 1805.16,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256"
+            },
+            {
+              "binary": "after",
+              "ms": 1802.75,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256"
+            },
+            {
+              "binary": "before",
+              "ms": 1579.71,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256"
+            }
+          ],
+          "medians_ms": {
+            "before": 1613.01,
+            "after": 1803.955
+          }
+        },
+        {
+          "scene": "many_pyramids",
+          "runs": [
+            {
+              "binary": "before",
+              "ms": 1624.17,
+              "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 30691376"
+            },
+            {
+              "binary": "after",
+              "ms": 1856.28,
+              "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 30691376"
+            },
+            {
+              "binary": "after",
+              "ms": 1872.73,
+              "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 30691376"
+            },
+            {
+              "binary": "before",
+              "ms": 1723.85,
+              "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 30691376"
+            }
+          ],
+          "medians_ms": {
+            "before": 1674.01,
+            "after": 1864.505
+          }
+        },
+        {
+          "scene": "rain",
+          "runs": [
+            {
+              "binary": "before",
+              "ms": 1591.93,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+            },
+            {
+              "binary": "after",
+              "ms": 1443.65,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+            },
+            {
+              "binary": "after",
+              "ms": 1374.26,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+            },
+            {
+              "binary": "before",
+              "ms": 1386.4,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+            }
+          ],
+          "medians_ms": {
+            "before": 1489.165,
+            "after": 1408.955
+          }
+        },
+        {
+          "scene": "joint_grid",
+          "runs": [
+            {
+              "binary": "before",
+              "ms": 752.069,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "after",
+              "ms": 741.849,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "after",
+              "ms": 793.554,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "before",
+              "ms": 750.448,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            }
+          ],
+          "medians_ms": {
+            "before": 751.2584999999999,
+            "after": 767.7015
+          }
+        },
+        {
+          "scene": "washer",
+          "runs": [
+            {
+              "binary": "before",
+              "ms": 14393.7,
+              "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 18551760"
+            },
+            {
+              "binary": "after",
+              "ms": 16017.8,
+              "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 18551760"
+            },
+            {
+              "binary": "after",
+              "ms": 14416.3,
+              "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 18551760"
+            },
+            {
+              "binary": "before",
+              "ms": 13710.4,
+              "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 18551760"
+            }
+          ],
+          "medians_ms": {
+            "before": 14052.05,
+            "after": 15217.05
+          }
+        }
+      ],
+      "finished": "2026-09-07T18:15:13-0400"
+    },
+    "cache": {
+      "source_diff": "diff --git a/src/contact_solver.c b/src/contact_solver.c\nindex 1b77ca3..86ff61c 100644\n--- a/src/contact_solver.c\n+++ b/src/contact_solver.c\n@@ -1973,6 +1973,7 @@ typedef struct b3ContactConstraintPointWide\n \tb3Vec3W iRnAs, iRnBs;\n \n \tb3FloatW baseSeparations;\n+\tb3FloatW cachedSeparations;\n \tb3FloatW normalImpulses;\n \tb3FloatW totalNormalImpulses;\n \tb3FloatW normalMasses;\n@@ -2031,6 +2032,7 @@ typedef struct b3ContactConstraintWide\n \t// exact zeros in every lane and contribute nothing, so skipping them is\n \t// bit-identical and one-point-manifold scenes skip 3/4 of the point work.\n \tint maxPointCount;\n+\tint separationGeneration;\n \n \tb3ContactConstraintPointWide points[B3_MAX_MANIFOLD_POINTS];\n \n@@ -2695,6 +2697,7 @@ void b3PrepareContacts_Convex( b3SolverBlock block, b3StepContext* context )\n \t\t\t\tmaxPointCount = b3MaxInt( maxPointCount, (int)laneCounts[lane] );\n \t\t\t}\n \t\t\tconstraint->maxPointCount = maxPointCount;\n+\t\t\tconstraint->separationGeneration = -1;\n \n \t\t\tfor ( int pointIndex = 0; pointIndex < maxPointCount; ++pointIndex )\n \t\t\t{\n@@ -3270,6 +3273,7 @@ void b3PrepareContacts_Convex( b3SolverBlock block, b3StepContext* context )\n \t\t\t}\n \n \t\t\tconstraint->maxPointCount = maxPointCount;\n+\t\t\tconstraint->separationGeneration = -1;\n \t\t}\n \n \t\t// Advance to next color\n@@ -3376,13 +3380,26 @@ void b3SolveContacts_Convex( b3SolverBlock block, b3StepContext* context, bool u\n \t\t\timpulseScale = b3ZeroW();\n \t\t}\n \n-\t\tb3Vec3W dp = b3SubVW( bB.dp, bA.dp );\n \t\tb3Vec3W normal = b3WidenVW( c->normal );\n \n-\t\t// The delta rotations are constant across the four manifold points, so build\n-\t\t// them as matrices once and rotate each anchor with three fused reductions\n-\t\tb3Matrix3W rotA = b3MakeMatrixFromQuatW( bA.dq );\n-\t\tb3Matrix3W rotB = b3MakeMatrixFromQuatW( bB.dq );\n+\t\t// Velocities change in solve/warm-start stages, but positions and rotations\n+\t\t// change only in the integration stage. Reuse the exact separation from\n+\t\t// relaxation in the next solve while that geometry is unchanged.\n+\t\tif ( c->separationGeneration != context->positionGeneration )\n+\t\t{\n+\t\t\tb3Vec3W dp = b3SubVW( bB.dp, bA.dp );\n+\t\t\tb3Matrix3W rotA = b3MakeMatrixFromQuatW( bA.dq );\n+\t\t\tb3Matrix3W rotB = b3MakeMatrixFromQuatW( bB.dq );\n+\t\t\tfor ( int pointIndex = 0; pointIndex < c->maxPointCount; ++pointIndex )\n+\t\t\t{\n+\t\t\t\tb3ContactConstraintPointWide* cp = c->points + pointIndex;\n+\t\t\t\tb3Vec3W rsA = b3MulMV3W( rotA, b3WidenVW( cp->anchorAs ) );\n+\t\t\t\tb3Vec3W rsB = b3MulMV3W( rotB, b3WidenVW( cp->anchorBs ) );\n+\t\t\t\tb3Vec3W ds = b3AddVW( dp, b3SubVW( rsB, rsA ) );\n+\t\t\t\tcp->cachedSeparations = b3AddW( b3DotW( normal, ds ), cp->baseSeparations );\n+\t\t\t}\n+\t\t\tc->separationGeneration = context->positionGeneration;\n+\t\t}\n \n \t\tb3FloatW totalNormalImpulse = b3ZeroW();\n \t\tb3FloatW totalTwistLimit = b3ZeroW();\n@@ -3394,18 +3411,7 @@ void b3SolveContacts_Convex( b3SolverBlock block, b3StepContext* context, bool u\n \t\t{\n \t\t\tb3ContactConstraintPointWide* cp = c->points + pointIndex;\n \n-\t\t\t// Fixed anchor points for applying impulses\n-\t\t\tb3Vec3W rA = b3WidenVW( cp->anchorAs );\n-\t\t\tb3Vec3W rB = b3WidenVW( cp->anchorBs );\n-\n-\t\t\t// Moving anchors for current separation\n-\t\t\tb3Vec3W rsA = b3MulMV3W( rotA, rA );\n-\t\t\tb3Vec3W rsB = b3MulMV3W( rotB, rB );\n-\n-\t\t\t// compute current separation\n-\t\t\t// this is subject to round-off error if the anchor is far from the body center of mass\n-\t\t\tb3Vec3W ds = b3AddVW( dp, b3SubVW( rsB, rsA ) );\n-\t\t\tb3FloatW s = b3AddW( b3DotW( normal, ds ), cp->baseSeparations );\n+\t\t\tb3FloatW s = cp->cachedSeparations;\n \n \t\t\t// Apply speculative bias if separation is greater than zero, otherwise apply soft constraint bias\n \t\t\tb3FloatW mask = b3GreaterThanW( s, b3ZeroW() );\ndiff --git a/src/solver.c b/src/solver.c\nindex 1e9e15d..0b2f104 100644\n--- a/src/solver.c\n+++ b/src/solver.c\n@@ -1327,6 +1327,10 @@ static void b3SolverTask( void* taskContext )\n \n \t\t\tprofile->solveImpulses += b3GetMillisecondsAndReset( &ticks );\n \n+\t\t\t// The preceding stage has finished; publish the new geometry generation\n+\t\t\t// through the existing stage barrier before contacts run again.\n+\t\t\tcontext->positionGeneration += 1;\n+\n \t\t\t// Integrate positions\n \t\t\tB3_ASSERT( stages[iterationStageIndex].type == b3_stageIntegratePositions );\n \t\t\tsyncBits = ( bodySyncIndex << 16 ) | iterationStageIndex;\n@@ -1508,6 +1512,7 @@ void b3Solve( b3World* world, b3StepContext* stepContext )\n \n \t\tstepContext->sims = awakeSet->bodySims.data;\n \t\tstepContext->states = awakeSet->bodyStates.data;\n+\t\tstepContext->positionGeneration = 0;\n \n \t\t// count contacts, joints, and colors\n \t\tint activeColorCount = 0;\ndiff --git a/src/solver.h b/src/solver.h\nindex 745d82c..bac84a7 100644\n--- a/src/solver.h\n+++ b/src/solver.h\n@@ -198,6 +198,9 @@ typedef struct b3StepContext\n \n \tint subStepCount;\n \n+\t// Geometry generation for per-constraint separation caches. Published by stage barriers.\n+\tint positionGeneration;\n+\n \tb3Softness contactSoftness;\n \tb3Softness staticSoftness;\n \n",
+      "started": "2026-09-07T18:15:41-0400",
+      "binaries": {
+        "before": {
+          "sha256": "51f6c0f5e3fb21f690da4a7127c2aadbea01d6ba47ee8b4baa2b127c5ba728c0"
+        },
+        "after": {
+          "sha256": "7920921f7f5451399b7e6309aad607e7bd7a6d61f7b10ae949746863c62f484c"
+        }
+      },
+      "rows": [
+        {
+          "scene": "large_pyramid",
+          "runs": [
+            {
+              "binary": "before",
+              "ms": 1687.01,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256"
+            },
+            {
+              "binary": "after",
+              "ms": 1591.9,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+            },
+            {
+              "binary": "after",
+              "ms": 1722.17,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+            },
+            {
+              "binary": "before",
+              "ms": 1716.0,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256"
+            }
+          ],
+          "medians_ms": {
+            "before": 1701.505,
+            "after": 1657.035
+          }
+        },
+        {
+          "scene": "many_pyramids",
+          "runs": [
+            {
+              "binary": "before",
+              "ms": 1691.65,
+              "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 30691376"
+            },
+            {
+              "binary": "after",
+              "ms": 1562.62,
+              "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 31601072"
+            },
+            {
+              "binary": "after",
+              "ms": 1565.08,
+              "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 31601072"
+            },
+            {
+              "binary": "before",
+              "ms": 1687.12,
+              "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 30691376"
+            }
+          ],
+          "medians_ms": {
+            "before": 1689.385,
+            "after": 1563.85
+          }
+        },
+        {
+          "scene": "rain",
+          "runs": [
+            {
+              "binary": "before",
+              "ms": 1538.25,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+            },
+            {
+              "binary": "after",
+              "ms": 1409.92,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+            },
+            {
+              "binary": "after",
+              "ms": 1335.68,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+            },
+            {
+              "binary": "before",
+              "ms": 1347.46,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+            }
+          ],
+          "medians_ms": {
+            "before": 1442.855,
+            "after": 1372.8000000000002
+          }
+        },
+        {
+          "scene": "joint_grid",
+          "runs": [
+            {
+              "binary": "before",
+              "ms": 743.255,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "after",
+              "ms": 743.798,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "after",
+              "ms": 732.35,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "before",
+              "ms": 723.724,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            }
+          ],
+          "medians_ms": {
+            "before": 733.4895,
+            "after": 738.0740000000001
+          }
+        },
+        {
+          "scene": "washer",
+          "runs": [
+            {
+              "binary": "before",
+              "ms": 14019.9,
+              "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 18551760"
+            },
+            {
+              "binary": "after",
+              "ms": 13392.9,
+              "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 19101392"
+            },
+            {
+              "binary": "after",
+              "ms": 13944.5,
+              "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 19101392"
+            },
+            {
+              "binary": "before",
+              "ms": 14409.7,
+              "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 18551760"
+            }
+          ],
+          "medians_ms": {
+            "before": 14214.8,
+            "after": 13668.7
+          }
+        }
+      ],
+      "finished": "2026-09-07T18:16:59-0400"
+    },
+    "angular": {
+      "source_diff": "diff --git a/src/contact_solver.c b/src/contact_solver.c\nindex 1b77ca3..86ff61c 100644\n--- a/src/contact_solver.c\n+++ b/src/contact_solver.c\n@@ -1973,6 +1973,7 @@ typedef struct b3ContactConstraintPointWide\n \tb3Vec3W iRnAs, iRnBs;\n \n \tb3FloatW baseSeparations;\n+\tb3FloatW cachedSeparations;\n \tb3FloatW normalImpulses;\n \tb3FloatW totalNormalImpulses;\n \tb3FloatW normalMasses;\n@@ -2031,6 +2032,7 @@ typedef struct b3ContactConstraintWide\n \t// exact zeros in every lane and contribute nothing, so skipping them is\n \t// bit-identical and one-point-manifold scenes skip 3/4 of the point work.\n \tint maxPointCount;\n+\tint separationGeneration;\n \n \tb3ContactConstraintPointWide points[B3_MAX_MANIFOLD_POINTS];\n \n@@ -2695,6 +2697,7 @@ void b3PrepareContacts_Convex( b3SolverBlock block, b3StepContext* context )\n \t\t\t\tmaxPointCount = b3MaxInt( maxPointCount, (int)laneCounts[lane] );\n \t\t\t}\n \t\t\tconstraint->maxPointCount = maxPointCount;\n+\t\t\tconstraint->separationGeneration = -1;\n \n \t\t\tfor ( int pointIndex = 0; pointIndex < maxPointCount; ++pointIndex )\n \t\t\t{\n@@ -3270,6 +3273,7 @@ void b3PrepareContacts_Convex( b3SolverBlock block, b3StepContext* context )\n \t\t\t}\n \n \t\t\tconstraint->maxPointCount = maxPointCount;\n+\t\t\tconstraint->separationGeneration = -1;\n \t\t}\n \n \t\t// Advance to next color\n@@ -3376,13 +3380,26 @@ void b3SolveContacts_Convex( b3SolverBlock block, b3StepContext* context, bool u\n \t\t\timpulseScale = b3ZeroW();\n \t\t}\n \n-\t\tb3Vec3W dp = b3SubVW( bB.dp, bA.dp );\n \t\tb3Vec3W normal = b3WidenVW( c->normal );\n \n-\t\t// The delta rotations are constant across the four manifold points, so build\n-\t\t// them as matrices once and rotate each anchor with three fused reductions\n-\t\tb3Matrix3W rotA = b3MakeMatrixFromQuatW( bA.dq );\n-\t\tb3Matrix3W rotB = b3MakeMatrixFromQuatW( bB.dq );\n+\t\t// Velocities change in solve/warm-start stages, but positions and rotations\n+\t\t// change only in the integration stage. Reuse the exact separation from\n+\t\t// relaxation in the next solve while that geometry is unchanged.\n+\t\tif ( c->separationGeneration != context->positionGeneration )\n+\t\t{\n+\t\t\tb3Vec3W dp = b3SubVW( bB.dp, bA.dp );\n+\t\t\tb3Matrix3W rotA = b3MakeMatrixFromQuatW( bA.dq );\n+\t\t\tb3Matrix3W rotB = b3MakeMatrixFromQuatW( bB.dq );\n+\t\t\tfor ( int pointIndex = 0; pointIndex < c->maxPointCount; ++pointIndex )\n+\t\t\t{\n+\t\t\t\tb3ContactConstraintPointWide* cp = c->points + pointIndex;\n+\t\t\t\tb3Vec3W rsA = b3MulMV3W( rotA, b3WidenVW( cp->anchorAs ) );\n+\t\t\t\tb3Vec3W rsB = b3MulMV3W( rotB, b3WidenVW( cp->anchorBs ) );\n+\t\t\t\tb3Vec3W ds = b3AddVW( dp, b3SubVW( rsB, rsA ) );\n+\t\t\t\tcp->cachedSeparations = b3AddW( b3DotW( normal, ds ), cp->baseSeparations );\n+\t\t\t}\n+\t\t\tc->separationGeneration = context->positionGeneration;\n+\t\t}\n \n \t\tb3FloatW totalNormalImpulse = b3ZeroW();\n \t\tb3FloatW totalTwistLimit = b3ZeroW();\n@@ -3394,18 +3411,7 @@ void b3SolveContacts_Convex( b3SolverBlock block, b3StepContext* context, bool u\n \t\t{\n \t\t\tb3ContactConstraintPointWide* cp = c->points + pointIndex;\n \n-\t\t\t// Fixed anchor points for applying impulses\n-\t\t\tb3Vec3W rA = b3WidenVW( cp->anchorAs );\n-\t\t\tb3Vec3W rB = b3WidenVW( cp->anchorBs );\n-\n-\t\t\t// Moving anchors for current separation\n-\t\t\tb3Vec3W rsA = b3MulMV3W( rotA, rA );\n-\t\t\tb3Vec3W rsB = b3MulMV3W( rotB, rB );\n-\n-\t\t\t// compute current separation\n-\t\t\t// this is subject to round-off error if the anchor is far from the body center of mass\n-\t\t\tb3Vec3W ds = b3AddVW( dp, b3SubVW( rsB, rsA ) );\n-\t\t\tb3FloatW s = b3AddW( b3DotW( normal, ds ), cp->baseSeparations );\n+\t\t\tb3FloatW s = cp->cachedSeparations;\n \n \t\t\t// Apply speculative bias if separation is greater than zero, otherwise apply soft constraint bias\n \t\t\tb3FloatW mask = b3GreaterThanW( s, b3ZeroW() );\ndiff --git a/src/solver.c b/src/solver.c\nindex 1e9e15d..0b2f104 100644\n--- a/src/solver.c\n+++ b/src/solver.c\n@@ -1327,6 +1327,10 @@ static void b3SolverTask( void* taskContext )\n \n \t\t\tprofile->solveImpulses += b3GetMillisecondsAndReset( &ticks );\n \n+\t\t\t// The preceding stage has finished; publish the new geometry generation\n+\t\t\t// through the existing stage barrier before contacts run again.\n+\t\t\tcontext->positionGeneration += 1;\n+\n \t\t\t// Integrate positions\n \t\t\tB3_ASSERT( stages[iterationStageIndex].type == b3_stageIntegratePositions );\n \t\t\tsyncBits = ( bodySyncIndex << 16 ) | iterationStageIndex;\n@@ -1508,6 +1512,7 @@ void b3Solve( b3World* world, b3StepContext* stepContext )\n \n \t\tstepContext->sims = awakeSet->bodySims.data;\n \t\tstepContext->states = awakeSet->bodyStates.data;\n+\t\tstepContext->positionGeneration = 0;\n \n \t\t// count contacts, joints, and colors\n \t\tint activeColorCount = 0;\ndiff --git a/src/solver.h b/src/solver.h\nindex 745d82c..bac84a7 100644\n--- a/src/solver.h\n+++ b/src/solver.h\n@@ -198,6 +198,9 @@ typedef struct b3StepContext\n \n \tint subStepCount;\n \n+\t// Geometry generation for per-constraint separation caches. Published by stage barriers.\n+\tint positionGeneration;\n+\n \tb3Softness contactSoftness;\n \tb3Softness staticSoftness;\n \ndiff --git a/src/spherical_joint.c b/src/spherical_joint.c\nindex ae196a7..f0fd3ab 100644\n--- a/src/spherical_joint.c\n+++ b/src/spherical_joint.c\n@@ -449,10 +449,16 @@ void b3SolveSphericalJoint( b3JointSim* base, b3StepContext* context, bool useBi\n \tb3Vec3 wB = stateB->angularVelocity;\n \n \tbool fixedRotation = base->fixedRotation;\n-\tb3Quat quatA = b3MulQuat( stateA->deltaRotation, joint->frameA.q );\n-\tb3Quat quatB = b3MulQuat( stateB->deltaRotation, joint->frameB.q );\n-\n-\tb3Quat relQ = b3InvMulQuat( quatA, quatB );\n+\tb3Quat quatA = b3Quat_identity;\n+\tb3Quat relQ = b3Quat_identity;\n+\t// A point-only joint has no angular error to evaluate. The angular motor\n+\t// uses relative velocity, so it does not need these orientations either.\n+\tif ( fixedRotation == false && ( joint->enableSpring || joint->enableTwistLimit || joint->enableConeLimit ) )\n+\t{\n+\t\tquatA = b3MulQuat( stateA->deltaRotation, joint->frameA.q );\n+\t\tb3Quat quatB = b3MulQuat( stateB->deltaRotation, joint->frameB.q );\n+\t\trelQ = b3InvMulQuat( quatA, quatB );\n+\t}\n \n \t// Solve spring\n \tif ( joint->enableSpring && fixedRotation == false )\n",
+      "started": "2026-09-07T18:17:12-0400",
+      "binaries": {
+        "before": {
+          "sha256": "51f6c0f5e3fb21f690da4a7127c2aadbea01d6ba47ee8b4baa2b127c5ba728c0"
+        },
+        "after": {
+          "sha256": "dee3c8ad4fefd32b717631dd20bd1e8c54f9ffdee1585d6bc6ec8e6301c0f09a"
+        }
+      },
+      "rows": [
+        {
+          "scene": "joint_grid",
+          "runs": [
+            {
+              "binary": "before",
+              "ms": 750.911,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "after",
+              "ms": 702.476,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "after",
+              "ms": 701.34,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "before",
+              "ms": 747.87,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            }
+          ],
+          "medians_ms": {
+            "before": 749.3905,
+            "after": 701.908
+          }
+        },
+        {
+          "scene": "rain",
+          "runs": [
+            {
+              "binary": "before",
+              "ms": 1428.84,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+            },
+            {
+              "binary": "after",
+              "ms": 1459.37,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+            },
+            {
+              "binary": "after",
+              "ms": 1575.1,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+            },
+            {
+              "binary": "before",
+              "ms": 1629.97,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+            }
+          ],
+          "medians_ms": {
+            "before": 1529.405,
+            "after": 1517.235
+          }
+        }
+      ],
+      "finished": "2026-09-07T18:17:22-0400"
+    },
+    "skew": {
+      "source_diff": "diff --git a/src/contact_solver.c b/src/contact_solver.c\nindex 1b77ca3..86ff61c 100644\n--- a/src/contact_solver.c\n+++ b/src/contact_solver.c\n@@ -1973,6 +1973,7 @@ typedef struct b3ContactConstraintPointWide\n \tb3Vec3W iRnAs, iRnBs;\n \n \tb3FloatW baseSeparations;\n+\tb3FloatW cachedSeparations;\n \tb3FloatW normalImpulses;\n \tb3FloatW totalNormalImpulses;\n \tb3FloatW normalMasses;\n@@ -2031,6 +2032,7 @@ typedef struct b3ContactConstraintWide\n \t// exact zeros in every lane and contribute nothing, so skipping them is\n \t// bit-identical and one-point-manifold scenes skip 3/4 of the point work.\n \tint maxPointCount;\n+\tint separationGeneration;\n \n \tb3ContactConstraintPointWide points[B3_MAX_MANIFOLD_POINTS];\n \n@@ -2695,6 +2697,7 @@ void b3PrepareContacts_Convex( b3SolverBlock block, b3StepContext* context )\n \t\t\t\tmaxPointCount = b3MaxInt( maxPointCount, (int)laneCounts[lane] );\n \t\t\t}\n \t\t\tconstraint->maxPointCount = maxPointCount;\n+\t\t\tconstraint->separationGeneration = -1;\n \n \t\t\tfor ( int pointIndex = 0; pointIndex < maxPointCount; ++pointIndex )\n \t\t\t{\n@@ -3270,6 +3273,7 @@ void b3PrepareContacts_Convex( b3SolverBlock block, b3StepContext* context )\n \t\t\t}\n \n \t\t\tconstraint->maxPointCount = maxPointCount;\n+\t\t\tconstraint->separationGeneration = -1;\n \t\t}\n \n \t\t// Advance to next color\n@@ -3376,13 +3380,26 @@ void b3SolveContacts_Convex( b3SolverBlock block, b3StepContext* context, bool u\n \t\t\timpulseScale = b3ZeroW();\n \t\t}\n \n-\t\tb3Vec3W dp = b3SubVW( bB.dp, bA.dp );\n \t\tb3Vec3W normal = b3WidenVW( c->normal );\n \n-\t\t// The delta rotations are constant across the four manifold points, so build\n-\t\t// them as matrices once and rotate each anchor with three fused reductions\n-\t\tb3Matrix3W rotA = b3MakeMatrixFromQuatW( bA.dq );\n-\t\tb3Matrix3W rotB = b3MakeMatrixFromQuatW( bB.dq );\n+\t\t// Velocities change in solve/warm-start stages, but positions and rotations\n+\t\t// change only in the integration stage. Reuse the exact separation from\n+\t\t// relaxation in the next solve while that geometry is unchanged.\n+\t\tif ( c->separationGeneration != context->positionGeneration )\n+\t\t{\n+\t\t\tb3Vec3W dp = b3SubVW( bB.dp, bA.dp );\n+\t\t\tb3Matrix3W rotA = b3MakeMatrixFromQuatW( bA.dq );\n+\t\t\tb3Matrix3W rotB = b3MakeMatrixFromQuatW( bB.dq );\n+\t\t\tfor ( int pointIndex = 0; pointIndex < c->maxPointCount; ++pointIndex )\n+\t\t\t{\n+\t\t\t\tb3ContactConstraintPointWide* cp = c->points + pointIndex;\n+\t\t\t\tb3Vec3W rsA = b3MulMV3W( rotA, b3WidenVW( cp->anchorAs ) );\n+\t\t\t\tb3Vec3W rsB = b3MulMV3W( rotB, b3WidenVW( cp->anchorBs ) );\n+\t\t\t\tb3Vec3W ds = b3AddVW( dp, b3SubVW( rsB, rsA ) );\n+\t\t\t\tcp->cachedSeparations = b3AddW( b3DotW( normal, ds ), cp->baseSeparations );\n+\t\t\t}\n+\t\t\tc->separationGeneration = context->positionGeneration;\n+\t\t}\n \n \t\tb3FloatW totalNormalImpulse = b3ZeroW();\n \t\tb3FloatW totalTwistLimit = b3ZeroW();\n@@ -3394,18 +3411,7 @@ void b3SolveContacts_Convex( b3SolverBlock block, b3StepContext* context, bool u\n \t\t{\n \t\t\tb3ContactConstraintPointWide* cp = c->points + pointIndex;\n \n-\t\t\t// Fixed anchor points for applying impulses\n-\t\t\tb3Vec3W rA = b3WidenVW( cp->anchorAs );\n-\t\t\tb3Vec3W rB = b3WidenVW( cp->anchorBs );\n-\n-\t\t\t// Moving anchors for current separation\n-\t\t\tb3Vec3W rsA = b3MulMV3W( rotA, rA );\n-\t\t\tb3Vec3W rsB = b3MulMV3W( rotB, rB );\n-\n-\t\t\t// compute current separation\n-\t\t\t// this is subject to round-off error if the anchor is far from the body center of mass\n-\t\t\tb3Vec3W ds = b3AddVW( dp, b3SubVW( rsB, rsA ) );\n-\t\t\tb3FloatW s = b3AddW( b3DotW( normal, ds ), cp->baseSeparations );\n+\t\t\tb3FloatW s = cp->cachedSeparations;\n \n \t\t\t// Apply speculative bias if separation is greater than zero, otherwise apply soft constraint bias\n \t\t\tb3FloatW mask = b3GreaterThanW( s, b3ZeroW() );\ndiff --git a/src/math_internal.h b/src/math_internal.h\nindex 4163d6f..c97f578 100644\n--- a/src/math_internal.h\n+++ b/src/math_internal.h\n@@ -465,6 +465,36 @@ static inline b3Matrix3 b3Skew( b3Vec3 v )\n \treturn out;\n }\n \n+// skew(r) * m * skew(r), with the same product rounding and addition order\n+// as two b3MulMM calls. Only multiplication by exact zero is removed. In\n+// particular, keep negation inside each product: rounded(-a*b) can differ\n+// from -rounded(a*b) at a half quantum. Full-width inverse entries stay wide.\n+static inline b3Matrix3 b3SkewSandwich( b3Matrix3 m, b3Vec3 r )\n+{\n+\tb3Matrix3 t;\n+\tt.cx.x = b3FixMul( m.cy.x, r.z ) + b3FixMul( m.cz.x, -r.y );\n+\tt.cx.y = b3FixMul( m.cy.y, r.z ) + b3FixMul( m.cz.y, -r.y );\n+\tt.cx.z = b3FixMul( m.cy.z, r.z ) + b3FixMul( m.cz.z, -r.y );\n+\tt.cy.x = b3FixMul( m.cx.x, -r.z ) + b3FixMul( m.cz.x, r.x );\n+\tt.cy.y = b3FixMul( m.cx.y, -r.z ) + b3FixMul( m.cz.y, r.x );\n+\tt.cy.z = b3FixMul( m.cx.z, -r.z ) + b3FixMul( m.cz.z, r.x );\n+\tt.cz.x = b3FixMul( m.cx.x, r.y ) + b3FixMul( m.cy.x, -r.x );\n+\tt.cz.y = b3FixMul( m.cx.y, r.y ) + b3FixMul( m.cy.y, -r.x );\n+\tt.cz.z = b3FixMul( m.cx.z, r.y ) + b3FixMul( m.cy.z, -r.x );\n+\n+\tb3Matrix3 out;\n+\tout.cx.x = b3FixMul( -r.z, t.cx.y ) + b3FixMul( r.y, t.cx.z );\n+\tout.cx.y = b3FixMul( r.z, t.cx.x ) + b3FixMul( -r.x, t.cx.z );\n+\tout.cx.z = b3FixMul( -r.y, t.cx.x ) + b3FixMul( r.x, t.cx.y );\n+\tout.cy.x = b3FixMul( -r.z, t.cy.y ) + b3FixMul( r.y, t.cy.z );\n+\tout.cy.y = b3FixMul( r.z, t.cy.x ) + b3FixMul( -r.x, t.cy.z );\n+\tout.cy.z = b3FixMul( -r.y, t.cy.x ) + b3FixMul( r.x, t.cy.y );\n+\tout.cz.x = b3FixMul( -r.z, t.cz.y ) + b3FixMul( r.y, t.cz.z );\n+\tout.cz.y = b3FixMul( r.z, t.cz.x ) + b3FixMul( -r.x, t.cz.z );\n+\tout.cz.z = b3FixMul( -r.y, t.cz.x ) + b3FixMul( r.x, t.cz.y );\n+\treturn out;\n+}\n+\n static inline b3Plane b3NormalizePlane( b3Plane plane )\n {\n \tb3Fixed invLength = b3FixDiv( B3_FIX( 1.0f ) , b3Length( plane.normal ) );\ndiff --git a/src/motor_joint.c b/src/motor_joint.c\nindex b4812ce..e995daf 100644\n--- a/src/motor_joint.c\n+++ b/src/motor_joint.c\n@@ -366,10 +366,8 @@ void b3SolveMotorJoint( b3JointSim* base, b3StepContext* context )\n \t\tif ( rhs.x != 0 || rhs.y != 0 || rhs.z != 0 )\n \t\t{\n \t\t\t//// K = [(1/m1 + 1/m2) * eye(2) - skew(r1) * invI1 * skew(r1) - skew(r2) * invI2 * skew(r2)]\n-\t\t\tb3Matrix3 sA = b3Skew( rA );\n-\t\t\tb3Matrix3 sB = b3Skew( rB );\n-\t\t\tb3Matrix3 kA = b3MulMM( sA, b3MulMM( base->invIA, sA ) );\n-\t\t\tb3Matrix3 kB = b3MulMM( sB, b3MulMM( base->invIB, sB ) );\n+\t\t\tb3Matrix3 kA = b3SkewSandwich( base->invIA, rA );\n+\t\t\tb3Matrix3 kB = b3SkewSandwich( base->invIB, rB );\n \t\t\tb3Matrix3 k = b3NegateMat3( b3AddMM( kA, kB ) );\n \t\t\tk.cx.x += mA + mB;\n \t\t\tk.cy.y += mA + mB;\n@@ -407,10 +405,8 @@ void b3SolveMotorJoint( b3JointSim* base, b3StepContext* context )\n \t\tif ( rhs.x != 0 || rhs.y != 0 || rhs.z != 0 )\n \t\t{\n \t\t\t//// K = [(1/m1 + 1/m2) * eye(2) - skew(r1) * invI1 * skew(r1) - skew(r2) * invI2 * skew(r2)]\n-\t\t\tb3Matrix3 sA = b3Skew( rA );\n-\t\t\tb3Matrix3 sB = b3Skew( rB );\n-\t\t\tb3Matrix3 kA = b3MulMM( sA, b3MulMM( base->invIA, sA ) );\n-\t\t\tb3Matrix3 kB = b3MulMM( sB, b3MulMM( base->invIB, sB ) );\n+\t\t\tb3Matrix3 kA = b3SkewSandwich( base->invIA, rA );\n+\t\t\tb3Matrix3 kB = b3SkewSandwich( base->invIB, rB );\n \t\t\tb3Matrix3 k = b3NegateMat3( b3AddMM( kA, kB ) );\n \t\t\tk.cx.x += mA + mB;\n \t\t\tk.cy.y += mA + mB;\ndiff --git a/src/revolute_joint.c b/src/revolute_joint.c\nindex eee8fd8..efaea6b 100644\n--- a/src/revolute_joint.c\n+++ b/src/revolute_joint.c\n@@ -583,10 +583,8 @@ void b3SolveRevoluteJoint( b3JointSim* base, b3StepContext* context, bool useBia\n \t\tif ( rhs.x != 0 || rhs.y != 0 || rhs.z != 0 )\n \t\t{\n \t\t\t//// K = [(1/m1 + 1/m2) * eye(2) - skew(r1) * invI1 * skew(r1) - skew(r2) * invI2 * skew(r2)]\n-\t\t\tb3Matrix3 sA = b3Skew( rA );\n-\t\t\tb3Matrix3 sB = b3Skew( rB );\n-\t\t\tb3Matrix3 kA = b3MulMM( sA, b3MulMM( base->invIA, sA ) );\n-\t\t\tb3Matrix3 kB = b3MulMM( sB, b3MulMM( base->invIB, sB ) );\n+\t\t\tb3Matrix3 kA = b3SkewSandwich( base->invIA, rA );\n+\t\t\tb3Matrix3 kB = b3SkewSandwich( base->invIB, rB );\n \t\t\tb3Matrix3 k = b3NegateMat3( b3AddMM( kA, kB ) );\n \t\t\tk.cx.x += mA + mB;\n \t\t\tk.cy.y += mA + mB;\ndiff --git a/src/solver.c b/src/solver.c\nindex 1e9e15d..0b2f104 100644\n--- a/src/solver.c\n+++ b/src/solver.c\n@@ -1327,6 +1327,10 @@ static void b3SolverTask( void* taskContext )\n \n \t\t\tprofile->solveImpulses += b3GetMillisecondsAndReset( &ticks );\n \n+\t\t\t// The preceding stage has finished; publish the new geometry generation\n+\t\t\t// through the existing stage barrier before contacts run again.\n+\t\t\tcontext->positionGeneration += 1;\n+\n \t\t\t// Integrate positions\n \t\t\tB3_ASSERT( stages[iterationStageIndex].type == b3_stageIntegratePositions );\n \t\t\tsyncBits = ( bodySyncIndex << 16 ) | iterationStageIndex;\n@@ -1508,6 +1512,7 @@ void b3Solve( b3World* world, b3StepContext* stepContext )\n \n \t\tstepContext->sims = awakeSet->bodySims.data;\n \t\tstepContext->states = awakeSet->bodyStates.data;\n+\t\tstepContext->positionGeneration = 0;\n \n \t\t// count contacts, joints, and colors\n \t\tint activeColorCount = 0;\ndiff --git a/src/solver.h b/src/solver.h\nindex 745d82c..bac84a7 100644\n--- a/src/solver.h\n+++ b/src/solver.h\n@@ -198,6 +198,9 @@ typedef struct b3StepContext\n \n \tint subStepCount;\n \n+\t// Geometry generation for per-constraint separation caches. Published by stage barriers.\n+\tint positionGeneration;\n+\n \tb3Softness contactSoftness;\n \tb3Softness staticSoftness;\n \ndiff --git a/src/spherical_joint.c b/src/spherical_joint.c\nindex ae196a7..785641d 100644\n--- a/src/spherical_joint.c\n+++ b/src/spherical_joint.c\n@@ -449,10 +449,16 @@ void b3SolveSphericalJoint( b3JointSim* base, b3StepContext* context, bool useBi\n \tb3Vec3 wB = stateB->angularVelocity;\n \n \tbool fixedRotation = base->fixedRotation;\n-\tb3Quat quatA = b3MulQuat( stateA->deltaRotation, joint->frameA.q );\n-\tb3Quat quatB = b3MulQuat( stateB->deltaRotation, joint->frameB.q );\n-\n-\tb3Quat relQ = b3InvMulQuat( quatA, quatB );\n+\tb3Quat quatA = b3Quat_identity;\n+\tb3Quat relQ = b3Quat_identity;\n+\t// A point-only joint has no angular error to evaluate. The angular motor\n+\t// uses relative velocity, so it does not need these orientations either.\n+\tif ( fixedRotation == false && ( joint->enableSpring || joint->enableTwistLimit || joint->enableConeLimit ) )\n+\t{\n+\t\tquatA = b3MulQuat( stateA->deltaRotation, joint->frameA.q );\n+\t\tb3Quat quatB = b3MulQuat( stateB->deltaRotation, joint->frameB.q );\n+\t\trelQ = b3InvMulQuat( quatA, quatB );\n+\t}\n \n \t// Solve spring\n \tif ( joint->enableSpring && fixedRotation == false )\n@@ -630,10 +636,8 @@ void b3SolveSphericalJoint( b3JointSim* base, b3StepContext* context, bool useBi\n \t\tif ( rhs.x != 0 || rhs.y != 0 || rhs.z != 0 )\n \t\t{\n \t\t\t//// K = [(1/m1 + 1/m2) * eye(2) - skew(r1) * invI1 * skew(r1) - skew(r2) * invI2 * skew(r2)]\n-\t\t\tb3Matrix3 sA = b3Skew( rA );\n-\t\t\tb3Matrix3 sB = b3Skew( rB );\n-\t\t\tb3Matrix3 kA = b3MulMM( sA, b3MulMM( base->invIA, sA ) );\n-\t\t\tb3Matrix3 kB = b3MulMM( sB, b3MulMM( base->invIB, sB ) );\n+\t\t\tb3Matrix3 kA = b3SkewSandwich( base->invIA, rA );\n+\t\t\tb3Matrix3 kB = b3SkewSandwich( base->invIB, rB );\n \t\t\tb3Matrix3 k = b3NegateMat3( b3AddMM( kA, kB ) );\n \t\t\tk.cx.x += mA + mB;\n \t\t\tk.cy.y += mA + mB;\ndiff --git a/src/weld_joint.c b/src/weld_joint.c\nindex 827fbf3..1cbdd66 100644\n--- a/src/weld_joint.c\n+++ b/src/weld_joint.c\n@@ -275,10 +275,8 @@ void b3SolveWeldJoint( b3JointSim* base, b3StepContext* context, bool useBias )\n \t\tif ( rhs.x != 0 || rhs.y != 0 || rhs.z != 0 )\n \t\t{\n \t\t\t//// K = [(1/m1 + 1/m2) * eye(2) - skew(r1) * invI1 * skew(r1) - skew(r2) * invI2 * skew(r2)]\n-\t\t\tb3Matrix3 sA = b3Skew( rA );\n-\t\t\tb3Matrix3 sB = b3Skew( rB );\n-\t\t\tb3Matrix3 kA = b3MulMM( sA, b3MulMM( base->invIA, sA ) );\n-\t\t\tb3Matrix3 kB = b3MulMM( sB, b3MulMM( base->invIB, sB ) );\n+\t\t\tb3Matrix3 kA = b3SkewSandwich( base->invIA, rA );\n+\t\t\tb3Matrix3 kB = b3SkewSandwich( base->invIB, rB );\n \t\t\tb3Matrix3 k = b3NegateMat3( b3AddMM( kA, kB ) );\n \t\t\tk.cx.x += mA + mB;\n \t\t\tk.cy.y += mA + mB;\ndiff --git a/test/test_math.c b/test/test_math.c\nindex cf83b8c..a9164c0 100644\n--- a/test/test_math.c\n+++ b/test/test_math.c\n@@ -358,6 +358,55 @@ static int Solve2InverseScaleTest( void )\n \treturn 0;\n }\n \n+// Differentially preserve the original two full matrix products, including\n+// half-quantum signs, tiny inverse entries and large inverse-scaled entries.\n+static int SkewSandwichTest( void )\n+{\n+\tconst int matrixBits[] = { 6, 16, 24, 40, 54, 60 };\n+\tconst int anchorBits[] = { 27, 24, 16, 20, 12, 8 };\n+\tuint64_t rng = UINT64_C( 0x257837492019bc43 );\n+\tfor ( int scale = 0; scale < 6; ++scale )\n+\t{\n+\t\tfor ( int trial = 0; trial < 1024; ++trial )\n+\t\t{\n+\t\t\tb3Fixed values[12];\n+\t\t\tfor ( int j = 0; j < 12; ++j )\n+\t\t\t{\n+\t\t\t\trng = rng * UINT64_C( 6364136223846793005 ) + UINT64_C( 1442695040888963407 );\n+\t\t\t\tint bits = j < 9 ? matrixBits[scale] : anchorBits[scale];\n+\t\t\t\tvalues[j] = (b3Fixed)( rng & ( ( UINT64_C( 1 ) << bits ) - 1 ) );\n+\t\t\t\tif ( rng >> 63 )\n+\t\t\t\t{\n+\t\t\t\t\tvalues[j] = -values[j];\n+\t\t\t\t}\n+\t\t\t}\n+\t\t\t// Include exact zeros and half-quantum products, whose negation must\n+\t\t\t// stay inside the multiply under round-half-up.\n+\t\t\tif ( trial % 8 == 0 ) { values[9] = 0; }\n+\t\t\tif ( trial % 8 == 1 ) { values[0] = 1; values[10] = B3_FIXED_HALF; }\n+\t\t\tb3Matrix3 m = {\n+\t\t\t\t{ values[0], values[1], values[2] },\n+\t\t\t\t{ values[3], values[4], values[5] },\n+\t\t\t\t{ values[6], values[7], values[8] },\n+\t\t\t};\n+\t\t\tb3Vec3 r = { values[9], values[10], values[11] };\n+\t\t\tb3Matrix3 skew = b3Skew( r );\n+\t\t\tb3Matrix3 expected = b3MulMM( skew, b3MulMM( m, skew ) );\n+\t\t\tb3Matrix3 actual = b3SkewSandwich( m, r );\n+\t\t\tENSURE( actual.cx.x == expected.cx.x );\n+\t\t\tENSURE( actual.cx.y == expected.cx.y );\n+\t\t\tENSURE( actual.cx.z == expected.cx.z );\n+\t\t\tENSURE( actual.cy.x == expected.cy.x );\n+\t\t\tENSURE( actual.cy.y == expected.cy.y );\n+\t\t\tENSURE( actual.cy.z == expected.cy.z );\n+\t\t\tENSURE( actual.cz.x == expected.cz.x );\n+\t\t\tENSURE( actual.cz.y == expected.cz.y );\n+\t\t\tENSURE( actual.cz.z == expected.cz.z );\n+\t\t}\n+\t}\n+\treturn 0;\n+}\n+\n static int Solve3InverseScaleTest( void )\n {\n \t// K = s * [[4,1,0],[1,3,1],[0,1,2]], b = s * [5,-3,5]\n@@ -438,6 +487,7 @@ int MathTest( void )\n {\n \tRUN_SUBTEST( Solve2InverseScaleTest );\n \tRUN_SUBTEST( Solve3InverseScaleTest );\n+\tRUN_SUBTEST( SkewSandwichTest );\n \tRUN_SUBTEST( VendoredFixedTest );\n \t// Compare the fixed-point trig against double precision references from libm.\n \t// The fixed-point results carry the approximation error of the underlying\n",
+      "started": "2026-09-07T18:18:14-0400",
+      "binaries": {
+        "before": {
+          "sha256": "51f6c0f5e3fb21f690da4a7127c2aadbea01d6ba47ee8b4baa2b127c5ba728c0"
+        },
+        "after": {
+          "sha256": "7273e1173d4a0a468f39724e38f069dc32cedb05ae31cc64e9e5480a5ed2f3d4"
+        }
+      },
+      "rows": [
+        {
+          "scene": "joint_grid",
+          "runs": [
+            {
+              "binary": "before",
+              "ms": 753.141,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "after",
+              "ms": 660.397,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "after",
+              "ms": 659.328,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "before",
+              "ms": 743.642,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            }
+          ],
+          "medians_ms": {
+            "before": 748.3915,
+            "after": 659.8625
+          }
+        },
+        {
+          "scene": "rain",
+          "runs": [
+            {
+              "binary": "before",
+              "ms": 1382.84,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+            },
+            {
+              "binary": "after",
+              "ms": 1354.63,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+            },
+            {
+              "binary": "after",
+              "ms": 1333.95,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+            },
+            {
+              "binary": "before",
+              "ms": 1468.8,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+            }
+          ],
+          "medians_ms": {
+            "before": 1425.82,
+            "after": 1344.29
+          }
+        },
+        {
+          "scene": "large_pyramid",
+          "runs": [
+            {
+              "binary": "before",
+              "ms": 1734.82,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256"
+            },
+            {
+              "binary": "after",
+              "ms": 1602.85,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+            },
+            {
+              "binary": "after",
+              "ms": 1619.19,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+            },
+            {
+              "binary": "before",
+              "ms": 1719.07,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256"
+            }
+          ],
+          "medians_ms": {
+            "before": 1726.945,
+            "after": 1611.02
+          }
+        }
+      ],
+      "finished": "2026-09-07T18:18:29-0400"
+    }
+  },
+  "visual": {
+    "created_utc": "2026-09-07T22:27:46.411644+00:00",
+    "frames": 120,
+    "nominal_hz": 60,
+    "repeat": 2,
+    "match": "^(Joints/|Collision/(Shape Distance|Distance Debug)$|Stacking/Box Stack$|Determinism/Falling Ragdolls$)",
+    "no_axes": true,
+    "builds": {
+      "fixed": {
+        "binary_sha256": "f15e0b18360f848035c07eda0ec27d660f300369b3947955c3ce3e0fe93d7b46",
+        "samples": {
+          "Benchmark/Candy Cups": 0,
+          "Benchmark/Chains": 1,
+          "Benchmark/Convex Pile": 2,
+          "Benchmark/Destruction": 3,
+          "Benchmark/Explosion": 4,
+          "Benchmark/Falling Boxes": 5,
+          "Benchmark/Falling Trees": 6,
+          "Benchmark/Height Field": 7,
+          "Benchmark/Hull": 8,
+          "Benchmark/Joint Grid": 9,
+          "Benchmark/Junkyard": 10,
+          "Benchmark/Large Pyramid": 11,
+          "Benchmark/Large World": 12,
+          "Benchmark/Many Pyramids": 13,
+          "Benchmark/Rain": 14,
+          "Benchmark/Sensor": 15,
+          "Benchmark/Washer": 16,
+          "Benchmark/Wide Pyramid": 17,
+          "Bodies/Body Type": 18,
+          "Bodies/Cast": 19,
+          "Bodies/Disable": 20,
+          "Bodies/Fixed Rotation": 21,
+          "Bodies/Gyroscopic Precession": 22,
+          "Bodies/Gyroscopic Torque": 23,
+          "Bodies/Kinematic": 24,
+          "Bodies/Lock Mixing": 25,
+          "Bodies/Spinning Book": 26,
+          "Bodies/Weeble": 27,
+          "Character/CapsulePlane": 28,
+          "Character/Mover": 29,
+          "Character/MoverOverlap": 30,
+          "Character/Rigid Body": 31,
+          "Collision/Capsule Cast Ray": 32,
+          "Collision/Cast World": 33,
+          "Collision/Distance Debug": 34,
+          "Collision/Initial Overlap": 35,
+          "Collision/Long Ray Cast": 36,
+          "Collision/Mesh Scale": 37,
+          "Collision/Overlap World": 38,
+          "Collision/Ray Curtain": 39,
+          "Collision/Shape Cast": 40,
+          "Collision/Shape Cast Debug": 41,
+          "Collision/Shape Distance": 42,
+          "Collision/Time of Impact": 43,
+          "Compound/Hulls": 44,
+          "Compound/Mesh Tile": 45,
+          "Compound/Simple": 46,
+          "Compound/Spheres": 47,
+          "Compound/Tile Floor": 48,
+          "Compound/Village": 49,
+          "Continuous/Bounce House": 50,
+          "Continuous/Bullet vs Stack": 51,
+          "Continuous/Hump Mesh": 52,
+          "Continuous/Is Fast": 53,
+          "Continuous/Mesh Drop": 54,
+          "Continuous/Needle Mesh": 55,
+          "Continuous/Spinning Stick": 56,
+          "Continuous/Stall": 57,
+          "Continuous/Thin Wall": 58,
+          "Determinism/Falling Ragdolls": 59,
+          "Determinism/Mesh Drop": 60,
+          "Determinism/Query Spawn": 61,
+          "Determinism/Wave Pile": 62,
+          "Events/Hit": 63,
+          "Events/Joint": 64,
+          "Events/Move": 65,
+          "Events/Persistent Contact": 66,
+          "Events/Sensor Hits": 67,
+          "Events/Sensor Visit": 68,
+          "Geometry/Box Hull": 69,
+          "Geometry/Capsule Mass": 70,
+          "Geometry/Hull": 71,
+          "Geometry/Hull Reduction": 72,
+          "Geometry/Hull Transform": 73,
+          "Issues/Capsule Mesh": 74,
+          "Issues/Convex Jitter": 75,
+          "Issues/Crash": 76,
+          "Issues/GMod Wheel Stack": 77,
+          "Issues/Hull Crash": 78,
+          "Issues/Multiple Prismatic": 79,
+          "Issues/Restitution Overshoot": 80,
+          "Issues/Slide Twist Off Center Shape": 81,
+          "Issues/s&box Ghost Collisions": 82,
+          "Issues/s&box mover": 83,
+          "Joints/Ball and Chain": 84,
+          "Joints/Bridge": 85,
+          "Joints/Distance Joint": 86,
+          "Joints/Door": 87,
+          "Joints/Driving": 88,
+          "Joints/Filter": 89,
+          "Joints/Gear Lift": 90,
+          "Joints/Motion Locks": 91,
+          "Joints/Motor Joint": 92,
+          "Joints/Parallel Spring": 93,
+          "Joints/Prismatic": 94,
+          "Joints/Revolute": 95,
+          "Joints/Spherical": 96,
+          "Joints/Top Down Friction": 97,
+          "Joints/Weld": 98,
+          "Joints/Wheel": 99,
+          "Manifold/Capsule vs Capsule": 100,
+          "Manifold/Capsule vs Hull": 101,
+          "Manifold/Capsule vs Sphere": 102,
+          "Manifold/Hull vs Hull": 103,
+          "Manifold/Hull vs Sphere": 104,
+          "Manifold/Sphere vs Sphere": 105,
+          "Manifold/Triangle vs Capsule": 106,
+          "Manifold/Triangle vs Hull": 107,
+          "Manifold/Triangle vs Sphere": 108,
+          "Mesh/Big Box": 109,
+          "Mesh/Box": 110,
+          "Mesh/Creation Benchmark": 111,
+          "Mesh/Grid": 112,
+          "Mesh/Height Field": 113,
+          "Mesh/Hollow Box": 114,
+          "Mesh/Reflection": 115,
+          "Mesh/Viewer": 116,
+          "Mesh/Voxel": 117,
+          "Ragdoll/Box": 118,
+          "Ragdoll/Incline": 119,
+          "Ragdoll/Mesh": 120,
+          "Ragdoll/Pile": 121,
+          "Replay/Viewer": 122,
+          "Robustness/HighMassRatio1": 123,
+          "Robustness/Overflow Color Pile": 124,
+          "Robustness/Overlap Recovery": 125,
+          "Robustness/Tiny Pyramid": 126,
+          "Shapes/Conveyor Belt": 127,
+          "Shapes/Conveyor Mesh": 128,
+          "Shapes/High Resistance": 129,
+          "Shapes/Inclined Plane": 130,
+          "Shapes/Isotropic Friction": 131,
+          "Shapes/Restitution": 132,
+          "Shapes/Rolling Resistance": 133,
+          "Shapes/Slide Twist": 134,
+          "Shapes/Static Invoke": 135,
+          "Shapes/Wind": 136,
+          "Shapes/Wind Drop": 137,
+          "Shapes/Wind Flap": 138,
+          "Stacking/Arch": 139,
+          "Stacking/Box Stack": 140,
+          "Stacking/Capsule Stack": 141,
+          "Stacking/Card House": 142,
+          "Stacking/Cylinder": 143,
+          "Stacking/Cylinder Stack": 144,
+          "Stacking/Dominoes": 145,
+          "Stacking/Double Domino": 146,
+          "Stacking/Edge Crossing": 147,
+          "Stacking/Jenga Stack": 148,
+          "Stacking/Pyramid2D": 149,
+          "Stacking/Single Box": 150,
+          "Stacking/Sphere Stack": 151,
+          "Stacking/Wedge": 152,
+          "Tree/Benchmark": 153,
+          "World/Far Mesh Drop": 154,
+          "World/Far Pyramid": 155,
+          "World/Far Ragdolls": 156,
+          "World/Far Stack": 157
+        }
+      },
+      "float": {
+        "binary_sha256": "b41b0bbbe498058ab9abc4baf4fd2f09d3d1f086ebc4c53d86b82ef6baf41149",
+        "samples": {
+          "Benchmark/Candy Cups": 0,
+          "Benchmark/Chains": 1,
+          "Benchmark/Convex Pile": 2,
+          "Benchmark/Destruction": 3,
+          "Benchmark/Explosion": 4,
+          "Benchmark/Falling Boxes": 5,
+          "Benchmark/Falling Trees": 6,
+          "Benchmark/Height Field": 7,
+          "Benchmark/Hull": 8,
+          "Benchmark/Joint Grid": 9,
+          "Benchmark/Junkyard": 10,
+          "Benchmark/Large Pyramid": 11,
+          "Benchmark/Large World": 12,
+          "Benchmark/Many Pyramids": 13,
+          "Benchmark/Rain": 14,
+          "Benchmark/Sensor": 15,
+          "Benchmark/Washer": 16,
+          "Benchmark/Wide Pyramid": 17,
+          "Bodies/Body Type": 18,
+          "Bodies/Cast": 19,
+          "Bodies/Disable": 20,
+          "Bodies/Fixed Rotation": 21,
+          "Bodies/Gyroscopic Precession": 22,
+          "Bodies/Gyroscopic Torque": 23,
+          "Bodies/Kinematic": 24,
+          "Bodies/Lock Mixing": 25,
+          "Bodies/Spinning Book": 26,
+          "Bodies/Weeble": 27,
+          "Character/CapsulePlane": 28,
+          "Character/Mover": 29,
+          "Character/MoverOverlap": 30,
+          "Character/Rigid Body": 31,
+          "Collision/Capsule Cast Ray": 32,
+          "Collision/Cast World": 33,
+          "Collision/Distance Debug": 34,
+          "Collision/Initial Overlap": 35,
+          "Collision/Long Ray Cast": 36,
+          "Collision/Mesh Scale": 37,
+          "Collision/Overlap World": 38,
+          "Collision/Ray Curtain": 39,
+          "Collision/Shape Cast": 40,
+          "Collision/Shape Cast Debug": 41,
+          "Collision/Shape Distance": 42,
+          "Collision/Time of Impact": 43,
+          "Compound/Hulls": 44,
+          "Compound/Mesh Tile": 45,
+          "Compound/Simple": 46,
+          "Compound/Spheres": 47,
+          "Compound/Tile Floor": 48,
+          "Compound/Village": 49,
+          "Continuous/Bounce House": 50,
+          "Continuous/Bullet vs Stack": 51,
+          "Continuous/Hump Mesh": 52,
+          "Continuous/Is Fast": 53,
+          "Continuous/Mesh Drop": 54,
+          "Continuous/Needle Mesh": 55,
+          "Continuous/Spinning Stick": 56,
+          "Continuous/Stall": 57,
+          "Continuous/Thin Wall": 58,
+          "Determinism/Falling Ragdolls": 59,
+          "Determinism/Mesh Drop": 60,
+          "Determinism/Query Spawn": 61,
+          "Determinism/Wave Pile": 62,
+          "Events/Hit": 63,
+          "Events/Joint": 64,
+          "Events/Move": 65,
+          "Events/Persistent Contact": 66,
+          "Events/Sensor Hits": 67,
+          "Events/Sensor Visit": 68,
+          "Geometry/Box Hull": 69,
+          "Geometry/Capsule Mass": 70,
+          "Geometry/Hull": 71,
+          "Geometry/Hull Reduction": 72,
+          "Geometry/Hull Transform": 73,
+          "Issues/Capsule Mesh": 74,
+          "Issues/Convex Jitter": 75,
+          "Issues/Crash": 76,
+          "Issues/GMod Wheel Stack": 77,
+          "Issues/Hull Crash": 78,
+          "Issues/Multiple Prismatic": 79,
+          "Issues/Restitution Overshoot": 80,
+          "Issues/Slide Twist Off Center Shape": 81,
+          "Issues/s&box Ghost Collisions": 82,
+          "Issues/s&box mover": 83,
+          "Joints/Ball and Chain": 84,
+          "Joints/Bridge": 85,
+          "Joints/Distance Joint": 86,
+          "Joints/Door": 87,
+          "Joints/Driving": 88,
+          "Joints/Filter": 89,
+          "Joints/Gear Lift": 90,
+          "Joints/Motion Locks": 91,
+          "Joints/Motor Joint": 92,
+          "Joints/Parallel Spring": 93,
+          "Joints/Prismatic": 94,
+          "Joints/Revolute": 95,
+          "Joints/Spherical": 96,
+          "Joints/Top Down Friction": 97,
+          "Joints/Weld": 98,
+          "Joints/Wheel": 99,
+          "Manifold/Capsule vs Capsule": 100,
+          "Manifold/Capsule vs Hull": 101,
+          "Manifold/Capsule vs Sphere": 102,
+          "Manifold/Hull vs Hull": 103,
+          "Manifold/Hull vs Sphere": 104,
+          "Manifold/Sphere vs Sphere": 105,
+          "Manifold/Triangle vs Capsule": 106,
+          "Manifold/Triangle vs Hull": 107,
+          "Manifold/Triangle vs Sphere": 108,
+          "Mesh/Big Box": 109,
+          "Mesh/Box": 110,
+          "Mesh/Creation Benchmark": 111,
+          "Mesh/Grid": 112,
+          "Mesh/Height Field": 113,
+          "Mesh/Hollow Box": 114,
+          "Mesh/Reflection": 115,
+          "Mesh/Viewer": 116,
+          "Mesh/Voxel": 117,
+          "Ragdoll/Box": 118,
+          "Ragdoll/Incline": 119,
+          "Ragdoll/Mesh": 120,
+          "Ragdoll/Pile": 121,
+          "Replay/Viewer": 122,
+          "Robustness/HighMassRatio1": 123,
+          "Robustness/Overflow Color Pile": 124,
+          "Robustness/Overlap Recovery": 125,
+          "Robustness/Tiny Pyramid": 126,
+          "Shapes/Conveyor Belt": 127,
+          "Shapes/Conveyor Mesh": 128,
+          "Shapes/High Resistance": 129,
+          "Shapes/Inclined Plane": 130,
+          "Shapes/Isotropic Friction": 131,
+          "Shapes/Restitution": 132,
+          "Shapes/Rolling Resistance": 133,
+          "Shapes/Slide Twist": 134,
+          "Shapes/Static Invoke": 135,
+          "Shapes/Wind": 136,
+          "Shapes/Wind Drop": 137,
+          "Shapes/Wind Flap": 138,
+          "Stacking/Arch": 139,
+          "Stacking/Box Stack": 140,
+          "Stacking/Capsule Stack": 141,
+          "Stacking/Card House": 142,
+          "Stacking/Cylinder": 143,
+          "Stacking/Cylinder Stack": 144,
+          "Stacking/Dominoes": 145,
+          "Stacking/Double Domino": 146,
+          "Stacking/Edge Crossing": 147,
+          "Stacking/Jenga Stack": 148,
+          "Stacking/Pyramid2D": 149,
+          "Stacking/Single Box": 150,
+          "Stacking/Sphere Stack": 151,
+          "Stacking/Wedge": 152,
+          "Tree/Benchmark": 153,
+          "World/Far Mesh Drop": 154,
+          "World/Far Pyramid": 155,
+          "World/Far Ragdolls": 156,
+          "World/Far Stack": 157
+        }
+      }
+    },
+    "pixel_hash": "SHA256 of ASCII RGBA:WIDTHxHEIGHT followed by NUL and decoded RGBA bytes",
+    "rows": [
+      {
+        "sample": "Collision/Distance Debug",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Collision_Distance_Debug-67957c757033-0.png",
+              "pixel_sha256": "c2efb9df2a8a59212e25b2c48f2039cf0321e0a27168fbbddc0f0e3def136c6e",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Collision_Distance_Debug-67957c757033-1.png",
+              "pixel_sha256": "c2efb9df2a8a59212e25b2c48f2039cf0321e0a27168fbbddc0f0e3def136c6e",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Collision_Distance_Debug-67957c757033-0.png",
+              "pixel_sha256": "c2efb9df2a8a59212e25b2c48f2039cf0321e0a27168fbbddc0f0e3def136c6e",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Collision_Distance_Debug-67957c757033-1.png",
+              "pixel_sha256": "c2efb9df2a8a59212e25b2c48f2039cf0321e0a27168fbbddc0f0e3def136c6e",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Collision_Distance_Debug-67957c757033-thumb.png",
+        "float_thumbnail": "float/Collision_Distance_Debug-67957c757033-thumb.png"
+      },
+      {
+        "sample": "Collision/Shape Distance",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Collision_Shape_Distance-1efae0869794-0.png",
+              "pixel_sha256": "163cefe5ee4bde624ec79301a89dd8fec266f59d7c793e228aecc0943bd93834",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Collision_Shape_Distance-1efae0869794-1.png",
+              "pixel_sha256": "163cefe5ee4bde624ec79301a89dd8fec266f59d7c793e228aecc0943bd93834",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Collision_Shape_Distance-1efae0869794-0.png",
+              "pixel_sha256": "163cefe5ee4bde624ec79301a89dd8fec266f59d7c793e228aecc0943bd93834",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Collision_Shape_Distance-1efae0869794-1.png",
+              "pixel_sha256": "163cefe5ee4bde624ec79301a89dd8fec266f59d7c793e228aecc0943bd93834",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Collision_Shape_Distance-1efae0869794-thumb.png",
+        "float_thumbnail": "float/Collision_Shape_Distance-1efae0869794-thumb.png"
+      },
+      {
+        "sample": "Determinism/Falling Ragdolls",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Determinism_Falling_Ragdolls-1278b0375383-0.png",
+              "pixel_sha256": "6c45500976867ff315314530a73f1c3060728e1e86c8acfd1132525efede766c",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Determinism_Falling_Ragdolls-1278b0375383-1.png",
+              "pixel_sha256": "6c45500976867ff315314530a73f1c3060728e1e86c8acfd1132525efede766c",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Determinism_Falling_Ragdolls-1278b0375383-0.png",
+              "pixel_sha256": "6c45500976867ff315314530a73f1c3060728e1e86c8acfd1132525efede766c",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Determinism_Falling_Ragdolls-1278b0375383-1.png",
+              "pixel_sha256": "6c45500976867ff315314530a73f1c3060728e1e86c8acfd1132525efede766c",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Determinism_Falling_Ragdolls-1278b0375383-thumb.png",
+        "float_thumbnail": "float/Determinism_Falling_Ragdolls-1278b0375383-thumb.png"
+      },
+      {
+        "sample": "Joints/Ball and Chain",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Ball_and_Chain-aa4a237dd0eb-0.png",
+              "pixel_sha256": "05414d397b19f3818b2b30e7150404d29e49fe679d1867077d14baf587fc6a89",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Ball_and_Chain-aa4a237dd0eb-1.png",
+              "pixel_sha256": "05414d397b19f3818b2b30e7150404d29e49fe679d1867077d14baf587fc6a89",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Ball_and_Chain-aa4a237dd0eb-0.png",
+              "pixel_sha256": "05414d397b19f3818b2b30e7150404d29e49fe679d1867077d14baf587fc6a89",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Ball_and_Chain-aa4a237dd0eb-1.png",
+              "pixel_sha256": "05414d397b19f3818b2b30e7150404d29e49fe679d1867077d14baf587fc6a89",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Ball_and_Chain-aa4a237dd0eb-thumb.png",
+        "float_thumbnail": "float/Joints_Ball_and_Chain-aa4a237dd0eb-thumb.png"
+      },
+      {
+        "sample": "Joints/Bridge",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Bridge-87a11cde2063-0.png",
+              "pixel_sha256": "2f00f9b401f3788fe9cee5550e08e2ecf50c4f0d746c9e13fa369aa99750ecf9",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Bridge-87a11cde2063-1.png",
+              "pixel_sha256": "2f00f9b401f3788fe9cee5550e08e2ecf50c4f0d746c9e13fa369aa99750ecf9",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Bridge-87a11cde2063-0.png",
+              "pixel_sha256": "2f00f9b401f3788fe9cee5550e08e2ecf50c4f0d746c9e13fa369aa99750ecf9",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Bridge-87a11cde2063-1.png",
+              "pixel_sha256": "2f00f9b401f3788fe9cee5550e08e2ecf50c4f0d746c9e13fa369aa99750ecf9",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Bridge-87a11cde2063-thumb.png",
+        "float_thumbnail": "float/Joints_Bridge-87a11cde2063-thumb.png"
+      },
+      {
+        "sample": "Joints/Distance Joint",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Distance_Joint-5583ed521efa-0.png",
+              "pixel_sha256": "77961532f714e0538b52a22e1ad79ff77ad359b9ef58cb053c37d88a286440ff",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Distance_Joint-5583ed521efa-1.png",
+              "pixel_sha256": "77961532f714e0538b52a22e1ad79ff77ad359b9ef58cb053c37d88a286440ff",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Distance_Joint-5583ed521efa-0.png",
+              "pixel_sha256": "77961532f714e0538b52a22e1ad79ff77ad359b9ef58cb053c37d88a286440ff",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Distance_Joint-5583ed521efa-1.png",
+              "pixel_sha256": "77961532f714e0538b52a22e1ad79ff77ad359b9ef58cb053c37d88a286440ff",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Distance_Joint-5583ed521efa-thumb.png",
+        "float_thumbnail": "float/Joints_Distance_Joint-5583ed521efa-thumb.png"
+      },
+      {
+        "sample": "Joints/Door",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Door-098cd82e95dd-0.png",
+              "pixel_sha256": "d9143295e53c2f76dc142f9bc0ea433892525e8dbec974ad299d16000f73df1c",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Door-098cd82e95dd-1.png",
+              "pixel_sha256": "d9143295e53c2f76dc142f9bc0ea433892525e8dbec974ad299d16000f73df1c",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Door-098cd82e95dd-0.png",
+              "pixel_sha256": "d9143295e53c2f76dc142f9bc0ea433892525e8dbec974ad299d16000f73df1c",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Door-098cd82e95dd-1.png",
+              "pixel_sha256": "d9143295e53c2f76dc142f9bc0ea433892525e8dbec974ad299d16000f73df1c",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Door-098cd82e95dd-thumb.png",
+        "float_thumbnail": "float/Joints_Door-098cd82e95dd-thumb.png"
+      },
+      {
+        "sample": "Joints/Driving",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Driving-3bc709ba0287-0.png",
+              "pixel_sha256": "4a8f5f97ea9093bf284f83f9002fa53036730f67d3e5c81e01ba058f71dbee9c",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Driving-3bc709ba0287-1.png",
+              "pixel_sha256": "4a8f5f97ea9093bf284f83f9002fa53036730f67d3e5c81e01ba058f71dbee9c",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Driving-3bc709ba0287-0.png",
+              "pixel_sha256": "4a8f5f97ea9093bf284f83f9002fa53036730f67d3e5c81e01ba058f71dbee9c",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Driving-3bc709ba0287-1.png",
+              "pixel_sha256": "4a8f5f97ea9093bf284f83f9002fa53036730f67d3e5c81e01ba058f71dbee9c",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Driving-3bc709ba0287-thumb.png",
+        "float_thumbnail": "float/Joints_Driving-3bc709ba0287-thumb.png"
+      },
+      {
+        "sample": "Joints/Filter",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Filter-48a5e9fe7a24-0.png",
+              "pixel_sha256": "76aee13b7d45545dbcb260337f3bf72cba63cbffe4c3707fd3a37adaf14fc829",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Filter-48a5e9fe7a24-1.png",
+              "pixel_sha256": "76aee13b7d45545dbcb260337f3bf72cba63cbffe4c3707fd3a37adaf14fc829",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Filter-48a5e9fe7a24-0.png",
+              "pixel_sha256": "76aee13b7d45545dbcb260337f3bf72cba63cbffe4c3707fd3a37adaf14fc829",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Filter-48a5e9fe7a24-1.png",
+              "pixel_sha256": "76aee13b7d45545dbcb260337f3bf72cba63cbffe4c3707fd3a37adaf14fc829",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Filter-48a5e9fe7a24-thumb.png",
+        "float_thumbnail": "float/Joints_Filter-48a5e9fe7a24-thumb.png"
+      },
+      {
+        "sample": "Joints/Gear Lift",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Gear_Lift-c5959c1c2f53-0.png",
+              "pixel_sha256": "d06db1c00d432c4f6ad073a26d13b9254bf8ac4fc9215bc6c788d8930682fb5c",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Gear_Lift-c5959c1c2f53-1.png",
+              "pixel_sha256": "d06db1c00d432c4f6ad073a26d13b9254bf8ac4fc9215bc6c788d8930682fb5c",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Gear_Lift-c5959c1c2f53-0.png",
+              "pixel_sha256": "d06db1c00d432c4f6ad073a26d13b9254bf8ac4fc9215bc6c788d8930682fb5c",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Gear_Lift-c5959c1c2f53-1.png",
+              "pixel_sha256": "d06db1c00d432c4f6ad073a26d13b9254bf8ac4fc9215bc6c788d8930682fb5c",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Gear_Lift-c5959c1c2f53-thumb.png",
+        "float_thumbnail": "float/Joints_Gear_Lift-c5959c1c2f53-thumb.png"
+      },
+      {
+        "sample": "Joints/Motion Locks",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Motion_Locks-c61733b12ea3-0.png",
+              "pixel_sha256": "0e97c91e801cd1d011ffaad5c846920f869af58d0091aeb10f8356fe12d32a24",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Motion_Locks-c61733b12ea3-1.png",
+              "pixel_sha256": "0e97c91e801cd1d011ffaad5c846920f869af58d0091aeb10f8356fe12d32a24",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Motion_Locks-c61733b12ea3-0.png",
+              "pixel_sha256": "0e97c91e801cd1d011ffaad5c846920f869af58d0091aeb10f8356fe12d32a24",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Motion_Locks-c61733b12ea3-1.png",
+              "pixel_sha256": "0e97c91e801cd1d011ffaad5c846920f869af58d0091aeb10f8356fe12d32a24",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Motion_Locks-c61733b12ea3-thumb.png",
+        "float_thumbnail": "float/Joints_Motion_Locks-c61733b12ea3-thumb.png"
+      },
+      {
+        "sample": "Joints/Motor Joint",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Motor_Joint-868ec4be5e8b-0.png",
+              "pixel_sha256": "e4094ab8ec57c6f0ef248d3e9efd0c955629b5d0c7e560a63f9e91609eef1477",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Motor_Joint-868ec4be5e8b-1.png",
+              "pixel_sha256": "e4094ab8ec57c6f0ef248d3e9efd0c955629b5d0c7e560a63f9e91609eef1477",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Motor_Joint-868ec4be5e8b-0.png",
+              "pixel_sha256": "e4094ab8ec57c6f0ef248d3e9efd0c955629b5d0c7e560a63f9e91609eef1477",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Motor_Joint-868ec4be5e8b-1.png",
+              "pixel_sha256": "e4094ab8ec57c6f0ef248d3e9efd0c955629b5d0c7e560a63f9e91609eef1477",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Motor_Joint-868ec4be5e8b-thumb.png",
+        "float_thumbnail": "float/Joints_Motor_Joint-868ec4be5e8b-thumb.png"
+      },
+      {
+        "sample": "Joints/Parallel Spring",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Parallel_Spring-7f32c3ef0cd1-0.png",
+              "pixel_sha256": "62a15f34cea73b733b83cd71cd78ddbc3d5bb0d6eae292e6e7d20f420c004cc8",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Parallel_Spring-7f32c3ef0cd1-1.png",
+              "pixel_sha256": "62a15f34cea73b733b83cd71cd78ddbc3d5bb0d6eae292e6e7d20f420c004cc8",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Parallel_Spring-7f32c3ef0cd1-0.png",
+              "pixel_sha256": "62a15f34cea73b733b83cd71cd78ddbc3d5bb0d6eae292e6e7d20f420c004cc8",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Parallel_Spring-7f32c3ef0cd1-1.png",
+              "pixel_sha256": "62a15f34cea73b733b83cd71cd78ddbc3d5bb0d6eae292e6e7d20f420c004cc8",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Parallel_Spring-7f32c3ef0cd1-thumb.png",
+        "float_thumbnail": "float/Joints_Parallel_Spring-7f32c3ef0cd1-thumb.png"
+      },
+      {
+        "sample": "Joints/Prismatic",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Prismatic-bf5747dbac19-0.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Prismatic-bf5747dbac19-1.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Prismatic-bf5747dbac19-0.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Prismatic-bf5747dbac19-1.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Prismatic-bf5747dbac19-thumb.png",
+        "float_thumbnail": "float/Joints_Prismatic-bf5747dbac19-thumb.png"
+      },
+      {
+        "sample": "Joints/Revolute",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Revolute-452789cf75e8-0.png",
+              "pixel_sha256": "6f2e38375e1871d7d578062bc87b837f04a8dad102ab2fb1a8615a42b8140179",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Revolute-452789cf75e8-1.png",
+              "pixel_sha256": "6f2e38375e1871d7d578062bc87b837f04a8dad102ab2fb1a8615a42b8140179",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Revolute-452789cf75e8-0.png",
+              "pixel_sha256": "6f2e38375e1871d7d578062bc87b837f04a8dad102ab2fb1a8615a42b8140179",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Revolute-452789cf75e8-1.png",
+              "pixel_sha256": "6f2e38375e1871d7d578062bc87b837f04a8dad102ab2fb1a8615a42b8140179",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Revolute-452789cf75e8-thumb.png",
+        "float_thumbnail": "float/Joints_Revolute-452789cf75e8-thumb.png"
+      },
+      {
+        "sample": "Joints/Spherical",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Spherical-a8058e2d9295-0.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Spherical-a8058e2d9295-1.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Spherical-a8058e2d9295-0.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Spherical-a8058e2d9295-1.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Spherical-a8058e2d9295-thumb.png",
+        "float_thumbnail": "float/Joints_Spherical-a8058e2d9295-thumb.png"
+      },
+      {
+        "sample": "Joints/Top Down Friction",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Top_Down_Friction-659f78e954b8-0.png",
+              "pixel_sha256": "f80d6ee44e9d0d1ac6eca5ae3e3d1989d26d222b049033deb550e04520d69b7f",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Top_Down_Friction-659f78e954b8-1.png",
+              "pixel_sha256": "f80d6ee44e9d0d1ac6eca5ae3e3d1989d26d222b049033deb550e04520d69b7f",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Top_Down_Friction-659f78e954b8-0.png",
+              "pixel_sha256": "f80d6ee44e9d0d1ac6eca5ae3e3d1989d26d222b049033deb550e04520d69b7f",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Top_Down_Friction-659f78e954b8-1.png",
+              "pixel_sha256": "f80d6ee44e9d0d1ac6eca5ae3e3d1989d26d222b049033deb550e04520d69b7f",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Top_Down_Friction-659f78e954b8-thumb.png",
+        "float_thumbnail": "float/Joints_Top_Down_Friction-659f78e954b8-thumb.png"
+      },
+      {
+        "sample": "Joints/Weld",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Weld-6500556cbe84-0.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Weld-6500556cbe84-1.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Weld-6500556cbe84-0.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Weld-6500556cbe84-1.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Weld-6500556cbe84-thumb.png",
+        "float_thumbnail": "float/Joints_Weld-6500556cbe84-thumb.png"
+      },
+      {
+        "sample": "Joints/Wheel",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Wheel-491be789035e-0.png",
+              "pixel_sha256": "daa34c5af43995dd80d3c21e570e7571fc2e9bfa058934059dc9543bccfaa70b",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Wheel-491be789035e-1.png",
+              "pixel_sha256": "daa34c5af43995dd80d3c21e570e7571fc2e9bfa058934059dc9543bccfaa70b",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Wheel-491be789035e-0.png",
+              "pixel_sha256": "daa34c5af43995dd80d3c21e570e7571fc2e9bfa058934059dc9543bccfaa70b",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Wheel-491be789035e-1.png",
+              "pixel_sha256": "daa34c5af43995dd80d3c21e570e7571fc2e9bfa058934059dc9543bccfaa70b",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Wheel-491be789035e-thumb.png",
+        "float_thumbnail": "float/Joints_Wheel-491be789035e-thumb.png"
+      },
+      {
+        "sample": "Stacking/Box Stack",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Stacking_Box_Stack-8f5eaf073c5e-0.png",
+              "pixel_sha256": "28aaa8686b52e698ac18cb06ca8f08e380dfefb28d57b707cb972322f209ed86",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Stacking_Box_Stack-8f5eaf073c5e-1.png",
+              "pixel_sha256": "28aaa8686b52e698ac18cb06ca8f08e380dfefb28d57b707cb972322f209ed86",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Stacking_Box_Stack-8f5eaf073c5e-0.png",
+              "pixel_sha256": "28aaa8686b52e698ac18cb06ca8f08e380dfefb28d57b707cb972322f209ed86",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Stacking_Box_Stack-8f5eaf073c5e-1.png",
+              "pixel_sha256": "28aaa8686b52e698ac18cb06ca8f08e380dfefb28d57b707cb972322f209ed86",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Stacking_Box_Stack-8f5eaf073c5e-thumb.png",
+        "float_thumbnail": "float/Stacking_Box_Stack-8f5eaf073c5e-thumb.png"
+      }
+    ]
+  }
+}

--- a/benchmark/2026-09-07-contact-joint-performance.md
+++ b/benchmark/2026-09-07-contact-joint-performance.md
@@ -1,0 +1,66 @@
+# Contact and joint optimization, 7 September 2026
+
+This pass reduces geometric-mean runtime by **3.3% in scalar mode** and **3.9% with NEON** across eleven benchmark scenes. The resulting float-speed ratios are **44.6% scalar** and **47.0% NEON** (2.24x and 2.13x float runtime). The 50% target remains the next milestone in this comparison.
+
+## Method and full results
+
+Apple M3 Ultra, macOS 26.6.2, Apple Clang 21, arm64, RelWithDebInfo/O2, thin LTO, four workers, four substeps per 60 Hz step, continuous collision enabled. Before: fixed3d `33a9008` (code identical to `8f52c18`). After: `542fa3593373b817feed479cf526389a4c6b8e60`. Both use fixed `2f1ed91`. Float: Box3D `47d7f7c`, default NEON. All executables are preserved with SHA256 fingerprints in the [raw record](2026-09-07-contact-joint-performance.json).
+
+Two runs per scene and binary, before-scalar/after-scalar/before-neon/after-neon/float/float/after-neon/before-neon/after-scalar/before-scalar order, four workers, continuous collision enabled, median runtime. Scenes with an initial within-binary spread over 5% received three additional balanced runs of every binary; their final medians include all five trials, with no discarded observations.
+
+Each observation is a separate process and working directory. No builds, tests or captures from this task ran during timing. Other builds and file-sync processes were observed on the shared workstation. Small differences and short-scene percentages are inconclusive; the float-speed percentage is an estimate under these conditions. Rechecks use temporary working directories outside the synced workspace, and all five binaries run under the same procedure. Geometric means weight each scene equally. Earlier measurements remain in the [integrated library report](2026-09-07-integrated-performance.md); do not add percentages measured against different baselines.
+
+| Scene | Before scalar (ms) | After scalar (ms) | Before NEON (ms) | After NEON (ms) | Float (ms) |
+|---|---:|---:|---:|---:|---:|
+| convex_pile | 11114.40 | 11088.80 | 7127.92 | 7163.61 | 3769.91 |
+| joint_grid | 712.10 | 624.23 | 709.62 | 631.27 | 266.70 |
+| junkyard | 9719.38 | 9577.54 | 9308.53 | 8985.01 | 4291.97 |
+| large_pyramid | 1682.55 | 1633.42 | 1755.66 | 1637.78 | 571.70 |
+| large_world | 26.64 | 25.38 | 27.76 | 25.31 | 13.91 |
+| many_pyramids | 1540.37 | 1444.43 | 1553.60 | 1434.87 | 449.60 |
+| rain | 1319.88 | 1238.72 | 1277.56 | 1234.97 | 538.50 |
+| trees100 | 160.33 | 159.60 | 158.43 | 156.58 | 88.46 |
+| trees50 | 197.25 | 198.44 | 195.32 | 195.37 | 101.20 |
+| trees25 | 408.53 | 405.90 | 392.68 | 398.57 | 237.14 |
+| washer | 14740.20 | 14607.60 | 14577.70 | 14246.40 | 7210.53 |
+
+Physics counters repeat exactly within each binary and match between the four fixed builds in all eleven scenes. The cache increases temporary solver storage, so the stack-byte counter changes deliberately. Float contact counts may differ.
+
+## Retained changes
+
+- Cache exact convex contact separation until the position-integration stage changes geometry. The next solve reuses the preceding relaxation's value. Every prepare invalidates the cache; existing stage barriers publish each generation to workers. Memory cost: 128 bytes per group of four convex constraints.
+- Skip relative-orientation calculations for spherical joints when no enabled angular spring or limit uses them. The angular motor uses velocity and remains active independently.
+- Replace the two generic skew-matrix products with the same nonzero products, retaining the original rounding, signs and addition order. Multiplication count falls from 54 to 36 per body. Negation remains inside products because round-half-up is not odd at ties.
+
+The inverse scale remains 40 fractional bits and every nonzero joint solve retains its 256-bit calculation. No vendor file changes. A forced-inlining experiment slowed the stacking scenes and is excluded.
+
+## Correctness
+
+The full [CI matrix](https://github.com/mas-bandwidth/fixed3d/actions/runs/34166282099) passed on code commit `542fa35`, including TSan, MSan, wide positions and the static/dynamic sample builds. All 24 local suites pass in Debug, optimized scalar, NEON, wide positions and ASan+UBSan. Existing determinism references remain unchanged, including workers 1-5 and the asteroid-response tests. The new skew-product test matches the generic two-matrix expression across 6,144 cases spanning six scales, tiny and large inverse entries, zero factors and half-quantum signs.
+
+An independent executable linked against each library compares full transform and velocity hashes over 20 scenarios: 36 rotating cubes, sides 1 or 250, workers 1 or 4, substeps 1/2/4/8 or varying per frame, and warm-start toggles. All 4,800 per-frame hashes agree. Output SHA256: `de8a36a2165eb2062329cc432d0357f9709785152d0d5a9fea6d8461bbd82d04`.
+
+The [state-hash harness](../tools/benchmark/contact_state_hash.c) can be linked against either pinned library; compare its complete stdout byte-for-byte.
+
+Twenty sample scenes at 120 frames, twice per binary, give 80 exact decoded RGBA matches before/after. The capture tool's `float` slot contains the preceding fixed binary here. This preserves the preceding pass's float visual comparison, whose dynamic poses differ between engines. Images complement numerical tests and do not prove complete physical equivalence.
+
+## Reproduce
+
+```sh
+cmake -S . -B build-perf -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DBOX3D_SAMPLES=OFF -DBOX3D_UNIT_TESTS=ON -DBOX3D_BENCHMARKS=ON \
+  -DBOX3D_NEON=OFF -DBOX3D_COMPILE_WARNING_AS_ERROR=ON
+cmake --build build-perf --parallel 8
+./build-perf/bin/benchmark -t=4 -w=4 -r=1 -b=joint_grid
+```
+
+On macOS/Linux, build the optional state comparator against each library:
+
+```sh
+cc -O2 -std=gnu17 -Iinclude -Iextern/fixed/include \
+  tools/benchmark/contact_state_hash.c build-perf/src/libbox3d.a \
+  -lm -lpthread -o contact-state-hash
+./contact-state-hash > contact-states.txt
+```
+
+Build each pinned revision separately. Set `BOX3D_NEON=ON` for ARM narrow-phase SIMD. Omit `-b` for all scenes. Alternate processes and retain every result; the JSON records initial and follow-up trials.

--- a/benchmark/2026-09-07-integrated-performance.json
+++ b/benchmark/2026-09-07-integrated-performance.json
@@ -1,0 +1,4465 @@
+{
+  "library_sweep": {
+    "method": "Two runs per scene and binary, old/new/neon/float/float/neon/new/old order, four workers, continuous collision enabled, median runtime.",
+    "fixed_source": "48f8acf1c64113e6e00e12d5e8a70070bfdec365",
+    "old_source": "044aee0f5861c8da9de3b313788efaae1335fe68",
+    "float_source": "47d7f7cc7e091142c08d11dc7d2e493c5d34f536",
+    "configuration": "Apple M3 Ultra, arm64, Apple Clang, RelWithDebInfo, O2 and thin LTO; scalar defaults, optional BOX3D_NEON=ON; float default NEON.",
+    "platform": "macOS-26.6.2-arm64-arm-64bit-Mach-O",
+    "started": "2026-09-07T17:32:37-0400",
+    "binaries": {
+      "old_scalar": {
+        "sha256": "4a9da5c6f7f5d2bdd7a332f5ba6253aaf8ef5b8c9792d490154787da590f7c75"
+      },
+      "new_scalar": {
+        "sha256": "50ebf495cb0afc025f2ab9fbef1c819ad69afe96be7efcbcf5f869a220ab501b"
+      },
+      "new_neon": {
+        "sha256": "f29cd6839a69e3d5de3eedd7e4dad7c4cd4b7101a0701de511b1351cfda43530"
+      },
+      "float": {
+        "sha256": "a57073956c8f051652832d47f71cddf3254c0c3c4ca40e4f0baeb0a19b97f8f9"
+      }
+    },
+    "rows": [
+      {
+        "scene": "convex_pile",
+        "runs": [
+          {
+            "binary": "old_scalar",
+            "ms": 12665.4,
+            "counters": "body 5121 / shape 5121 / contact 51109 / joint 0 / stack 6262912"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 10858.0,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 7009.05,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776"
+          },
+          {
+            "binary": "float",
+            "ms": 3574.23,
+            "counters": "body 5121 / shape 5121 / contact 50764 / joint 0 / stack 2662928"
+          },
+          {
+            "binary": "float",
+            "ms": 3552.0,
+            "counters": "body 5121 / shape 5121 / contact 50764 / joint 0 / stack 2662928"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 6988.07,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 10762.0,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776"
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 12619.1,
+            "counters": "body 5121 / shape 5121 / contact 51109 / joint 0 / stack 6262912"
+          }
+        ],
+        "medians_ms": {
+          "old_scalar": 12642.25,
+          "new_scalar": 10810.0,
+          "new_neon": 6998.5599999999995,
+          "float": 3563.115
+        }
+      },
+      {
+        "scene": "joint_grid",
+        "runs": [
+          {
+            "binary": "old_scalar",
+            "ms": 916.521,
+            "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 912.324,
+            "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 914.853,
+            "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+          },
+          {
+            "binary": "float",
+            "ms": 277.168,
+            "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+          },
+          {
+            "binary": "float",
+            "ms": 274.95,
+            "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 918.886,
+            "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 921.512,
+            "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 914.493,
+            "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+          }
+        ],
+        "medians_ms": {
+          "old_scalar": 915.5070000000001,
+          "new_scalar": 916.9179999999999,
+          "new_neon": 916.8695,
+          "float": 276.05899999999997
+        }
+      },
+      {
+        "scene": "junkyard",
+        "runs": [
+          {
+            "binary": "old_scalar",
+            "ms": 10106.2,
+            "counters": "body 10586 / shape 10590 / contact 195276 / joint 0 / stack 28929152"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 9159.24,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 28761008"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 8709.4,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 28761008"
+          },
+          {
+            "binary": "float",
+            "ms": 3961.53,
+            "counters": "body 10586 / shape 10590 / contact 193415 / joint 0 / stack 11295504"
+          },
+          {
+            "binary": "float",
+            "ms": 3911.65,
+            "counters": "body 10586 / shape 10590 / contact 193415 / joint 0 / stack 11295504"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 8768.09,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 28761008"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 9208.71,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 28761008"
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 10211.5,
+            "counters": "body 10586 / shape 10590 / contact 195276 / joint 0 / stack 28929152"
+          }
+        ],
+        "medians_ms": {
+          "old_scalar": 10158.85,
+          "new_scalar": 9183.974999999999,
+          "new_neon": 8738.744999999999,
+          "float": 3936.59
+        }
+      },
+      {
+        "scene": "large_pyramid",
+        "runs": [
+          {
+            "binary": "old_scalar",
+            "ms": 1730.37,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 1674.58,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 1685.56,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256"
+          },
+          {
+            "binary": "float",
+            "ms": 511.465,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 6366112"
+          },
+          {
+            "binary": "float",
+            "ms": 545.761,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 6366112"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 1664.55,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 1663.35,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256"
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 1757.55,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256"
+          }
+        ],
+        "medians_ms": {
+          "old_scalar": 1743.96,
+          "new_scalar": 1668.965,
+          "new_neon": 1675.0549999999998,
+          "float": 528.6129999999999
+        }
+      },
+      {
+        "scene": "large_world",
+        "runs": [
+          {
+            "binary": "old_scalar",
+            "ms": 26.3142,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 24.1513,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 24.1668,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "float",
+            "ms": 11.7046,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "float",
+            "ms": 10.9814,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 24.0917,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 24.5921,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 24.5749,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          }
+        ],
+        "medians_ms": {
+          "old_scalar": 25.44455,
+          "new_scalar": 24.371699999999997,
+          "new_neon": 24.12925,
+          "float": 11.343
+        }
+      },
+      {
+        "scene": "many_pyramids",
+        "runs": [
+          {
+            "binary": "old_scalar",
+            "ms": 1701.7,
+            "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 30691376"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 1647.06,
+            "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 30691376"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 1651.44,
+            "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 30691376"
+          },
+          {
+            "binary": "float",
+            "ms": 499.686,
+            "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 12102992"
+          },
+          {
+            "binary": "float",
+            "ms": 506.454,
+            "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 12102992"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 1652.06,
+            "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 30691376"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 1656.29,
+            "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 30691376"
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 1706.23,
+            "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 30691376"
+          }
+        ],
+        "medians_ms": {
+          "old_scalar": 1703.9650000000001,
+          "new_scalar": 1651.675,
+          "new_neon": 1651.75,
+          "float": 503.07
+        }
+      },
+      {
+        "scene": "rain",
+        "runs": [
+          {
+            "binary": "old_scalar",
+            "ms": 1397.98,
+            "counters": "body 4300 / shape 4400 / contact 7813 / joint 4200 / stack 1863344"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 1335.64,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 1350.09,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+          },
+          {
+            "binary": "float",
+            "ms": 570.974,
+            "counters": "body 4300 / shape 4400 / contact 7898 / joint 4200 / stack 1535568"
+          },
+          {
+            "binary": "float",
+            "ms": 566.094,
+            "counters": "body 4300 / shape 4400 / contact 7898 / joint 4200 / stack 1535568"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 1338.75,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 1335.8,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 1405.93,
+            "counters": "body 4300 / shape 4400 / contact 7813 / joint 4200 / stack 1863344"
+          }
+        ],
+        "medians_ms": {
+          "old_scalar": 1401.955,
+          "new_scalar": 1335.72,
+          "new_neon": 1344.42,
+          "float": 568.5340000000001
+        }
+      },
+      {
+        "scene": "trees100",
+        "runs": [
+          {
+            "binary": "old_scalar",
+            "ms": 206.07,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 148.166,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 148.46,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "float",
+            "ms": 82.0632,
+            "counters": "body 51 / shape 1101 / contact 1102 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "float",
+            "ms": 82.9924,
+            "counters": "body 51 / shape 1101 / contact 1102 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 155.449,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 152.482,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 200.06,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+          }
+        ],
+        "medians_ms": {
+          "old_scalar": 203.065,
+          "new_scalar": 150.324,
+          "new_neon": 151.9545,
+          "float": 82.5278
+        }
+      },
+      {
+        "scene": "trees50",
+        "runs": [
+          {
+            "binary": "old_scalar",
+            "ms": 312.152,
+            "counters": "body 51 / shape 1101 / contact 1114 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 209.565,
+            "counters": "body 51 / shape 1101 / contact 1114 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 210.304,
+            "counters": "body 51 / shape 1101 / contact 1114 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "float",
+            "ms": 110.436,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "float",
+            "ms": 112.017,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 214.628,
+            "counters": "body 51 / shape 1101 / contact 1114 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 210.547,
+            "counters": "body 51 / shape 1101 / contact 1114 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 316.398,
+            "counters": "body 51 / shape 1101 / contact 1114 / joint 0 / stack 572528"
+          }
+        ],
+        "medians_ms": {
+          "old_scalar": 314.275,
+          "new_scalar": 210.05599999999998,
+          "new_neon": 212.466,
+          "float": 111.2265
+        }
+      },
+      {
+        "scene": "trees25",
+        "runs": [
+          {
+            "binary": "old_scalar",
+            "ms": 660.989,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 387.426,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 377.168,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "float",
+            "ms": 217.563,
+            "counters": "body 51 / shape 1101 / contact 1112 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "float",
+            "ms": 217.882,
+            "counters": "body 51 / shape 1101 / contact 1112 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 383.167,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 385.659,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 673.382,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+          }
+        ],
+        "medians_ms": {
+          "old_scalar": 667.1855,
+          "new_scalar": 386.5425,
+          "new_neon": 380.1675,
+          "float": 217.7225
+        }
+      },
+      {
+        "scene": "washer",
+        "runs": [
+          {
+            "binary": "old_scalar",
+            "ms": 15520.9,
+            "counters": "body 8002 / shape 8041 / contact 39517 / joint 0 / stack 18594752"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 13906.7,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 18551760"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 13774.1,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 18551760"
+          },
+          {
+            "binary": "float",
+            "ms": 6899.57,
+            "counters": "body 8002 / shape 8041 / contact 40444 / joint 0 / stack 7289728"
+          },
+          {
+            "binary": "float",
+            "ms": 7000.19,
+            "counters": "body 8002 / shape 8041 / contact 40444 / joint 0 / stack 7289728"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 13799.0,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 18551760"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 13888.0,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 18551760"
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 15535.1,
+            "counters": "body 8002 / shape 8041 / contact 39517 / joint 0 / stack 18594752"
+          }
+        ],
+        "medians_ms": {
+          "old_scalar": 15528.0,
+          "new_scalar": 13897.35,
+          "new_neon": 13786.55,
+          "float": 6949.879999999999
+        }
+      }
+    ],
+    "finished": "2026-09-07T17:37:21-0400"
+  },
+  "final_sweep": {
+    "method": "Two runs per scene and binary, old/pre-solver/final/neon/float/float/neon/final/pre-solver/old order, four workers, continuous collision enabled, median runtime. Scenes with an initial within-binary spread over 5% received three additional balanced runs of every binary; their final medians include all five trials, with no discarded observations.",
+    "fixed_source": "8f52c1898dc0c26c009b9f5c16554587d1448c26",
+    "pre_solver_source": "48f8acf1c64113e6e00e12d5e8a70070bfdec365",
+    "old_source": "044aee0f5861c8da9de3b313788efaae1335fe68",
+    "float_source": "47d7f7cc7e091142c08d11dc7d2e493c5d34f536",
+    "configuration": "Apple M3 Ultra, arm64, Apple Clang, RelWithDebInfo, O2 and thin LTO; scalar defaults, optional BOX3D_NEON=ON; float default NEON.",
+    "platform": "macOS-26.6.2-arm64-arm-64bit-Mach-O",
+    "started": "2026-09-07T17:57:37-0400",
+    "binaries": {
+      "old_scalar": {
+        "sha256": "4a9da5c6f7f5d2bdd7a332f5ba6253aaf8ef5b8c9792d490154787da590f7c75"
+      },
+      "pre_solver_scalar": {
+        "sha256": "50ebf495cb0afc025f2ab9fbef1c819ad69afe96be7efcbcf5f869a220ab501b"
+      },
+      "new_scalar": {
+        "sha256": "d572871f6bc1a8f4636b4f02feffb35ab7d412491fdb84beae04a2ecb441ff8d"
+      },
+      "new_neon": {
+        "sha256": "51f6c0f5e3fb21f690da4a7127c2aadbea01d6ba47ee8b4baa2b127c5ba728c0"
+      },
+      "float": {
+        "sha256": "a57073956c8f051652832d47f71cddf3254c0c3c4ca40e4f0baeb0a19b97f8f9"
+      }
+    },
+    "rows": [
+      {
+        "scene": "convex_pile",
+        "runs": [
+          {
+            "binary": "old_scalar",
+            "ms": 12621.8,
+            "counters": "body 5121 / shape 5121 / contact 51109 / joint 0 / stack 6262912"
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 10736.3,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 10768.2,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 7020.12,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776"
+          },
+          {
+            "binary": "float",
+            "ms": 3989.49,
+            "counters": "body 5121 / shape 5121 / contact 50764 / joint 0 / stack 2662928"
+          },
+          {
+            "binary": "float",
+            "ms": 3665.76,
+            "counters": "body 5121 / shape 5121 / contact 50764 / joint 0 / stack 2662928"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 6901.28,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 10916.9,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776"
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 10621.4,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776"
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 12383.9,
+            "counters": "body 5121 / shape 5121 / contact 51109 / joint 0 / stack 6262912"
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 12682.8,
+            "counters": "body 5121 / shape 5121 / contact 51109 / joint 0 / stack 6262912",
+            "recheck": 0
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 10814.4,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776",
+            "recheck": 0
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 10828.7,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776",
+            "recheck": 0
+          },
+          {
+            "binary": "new_neon",
+            "ms": 7115.32,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776",
+            "recheck": 0
+          },
+          {
+            "binary": "float",
+            "ms": 3557.82,
+            "counters": "body 5121 / shape 5121 / contact 50764 / joint 0 / stack 2662928",
+            "recheck": 0
+          },
+          {
+            "binary": "float",
+            "ms": 3574.49,
+            "counters": "body 5121 / shape 5121 / contact 50764 / joint 0 / stack 2662928",
+            "recheck": 1
+          },
+          {
+            "binary": "new_neon",
+            "ms": 7172.27,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776",
+            "recheck": 1
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 10802.7,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776",
+            "recheck": 1
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 10879.0,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776",
+            "recheck": 1
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 13077.1,
+            "counters": "body 5121 / shape 5121 / contact 51109 / joint 0 / stack 6262912",
+            "recheck": 1
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 10886.8,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776",
+            "recheck": 2
+          },
+          {
+            "binary": "new_neon",
+            "ms": 6999.51,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776",
+            "recheck": 2
+          },
+          {
+            "binary": "float",
+            "ms": 3566.21,
+            "counters": "body 5121 / shape 5121 / contact 50764 / joint 0 / stack 2662928",
+            "recheck": 2
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 12672.9,
+            "counters": "body 5121 / shape 5121 / contact 51109 / joint 0 / stack 6262912",
+            "recheck": 2
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 10784.8,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776",
+            "recheck": 2
+          }
+        ],
+        "medians_ms": {
+          "old_scalar": 12672.9,
+          "pre_solver_scalar": 10784.8,
+          "new_scalar": 10828.7,
+          "new_neon": 7020.12,
+          "float": 3574.49
+        }
+      },
+      {
+        "scene": "joint_grid",
+        "runs": [
+          {
+            "binary": "old_scalar",
+            "ms": 903.984,
+            "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 913.434,
+            "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 721.016,
+            "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 718.764,
+            "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+          },
+          {
+            "binary": "float",
+            "ms": 265.319,
+            "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+          },
+          {
+            "binary": "float",
+            "ms": 269.332,
+            "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 719.172,
+            "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 718.347,
+            "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 898.745,
+            "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 898.811,
+            "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+          }
+        ],
+        "medians_ms": {
+          "old_scalar": 901.3975,
+          "pre_solver_scalar": 906.0895,
+          "new_scalar": 719.6814999999999,
+          "new_neon": 718.9680000000001,
+          "float": 267.32550000000003
+        }
+      },
+      {
+        "scene": "junkyard",
+        "runs": [
+          {
+            "binary": "old_scalar",
+            "ms": 9547.71,
+            "counters": "body 10586 / shape 10590 / contact 195276 / joint 0 / stack 28929152"
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 8477.47,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 28761008"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 8468.91,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 28761008"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 7921.69,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 28761008"
+          },
+          {
+            "binary": "float",
+            "ms": 3484.0,
+            "counters": "body 10586 / shape 10590 / contact 193415 / joint 0 / stack 11295504"
+          },
+          {
+            "binary": "float",
+            "ms": 3576.09,
+            "counters": "body 10586 / shape 10590 / contact 193415 / joint 0 / stack 11295504"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 7984.84,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 28761008"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 8295.67,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 28761008"
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 8253.81,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 28761008"
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 9407.34,
+            "counters": "body 10586 / shape 10590 / contact 195276 / joint 0 / stack 28929152"
+          }
+        ],
+        "medians_ms": {
+          "old_scalar": 9477.525,
+          "pre_solver_scalar": 8365.64,
+          "new_scalar": 8382.29,
+          "new_neon": 7953.264999999999,
+          "float": 3530.045
+        }
+      },
+      {
+        "scene": "large_pyramid",
+        "runs": [
+          {
+            "binary": "old_scalar",
+            "ms": 1678.1,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256"
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 1615.95,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 1551.57,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 1618.67,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256"
+          },
+          {
+            "binary": "float",
+            "ms": 467.887,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 6366112"
+          },
+          {
+            "binary": "float",
+            "ms": 468.602,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 6366112"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 1575.39,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 1549.8,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256"
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 1564.68,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256"
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 1628.79,
+            "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16154256"
+          }
+        ],
+        "medians_ms": {
+          "old_scalar": 1653.445,
+          "pre_solver_scalar": 1590.315,
+          "new_scalar": 1550.685,
+          "new_neon": 1597.0300000000002,
+          "float": 468.2445
+        }
+      },
+      {
+        "scene": "large_world",
+        "runs": [
+          {
+            "binary": "old_scalar",
+            "ms": 23.0838,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 23.4849,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 24.2885,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 24.3295,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "float",
+            "ms": 10.8865,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "float",
+            "ms": 11.8978,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 24.1592,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 23.7441,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 23.5553,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 24.3311,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 25.9187,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 0
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 24.2049,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 0
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 23.916,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 0
+          },
+          {
+            "binary": "new_neon",
+            "ms": 24.7034,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 0
+          },
+          {
+            "binary": "float",
+            "ms": 12.4353,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 0
+          },
+          {
+            "binary": "float",
+            "ms": 13.5731,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 1
+          },
+          {
+            "binary": "new_neon",
+            "ms": 25.5945,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 1
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 25.3837,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 1
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 24.7802,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 1
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 24.9021,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 1
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 24.7189,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 2
+          },
+          {
+            "binary": "new_neon",
+            "ms": 26.1698,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 2
+          },
+          {
+            "binary": "float",
+            "ms": 13.1308,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 2
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 27.6227,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 2
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 25.1549,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000",
+            "recheck": 2
+          }
+        ],
+        "medians_ms": {
+          "old_scalar": 24.9021,
+          "pre_solver_scalar": 24.2049,
+          "new_scalar": 24.2885,
+          "new_neon": 24.7034,
+          "float": 12.4353
+        }
+      },
+      {
+        "scene": "many_pyramids",
+        "runs": [
+          {
+            "binary": "old_scalar",
+            "ms": 1629.63,
+            "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 30691376"
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 1558.93,
+            "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 30691376"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 1586.56,
+            "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 30691376"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 1613.67,
+            "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 30691376"
+          },
+          {
+            "binary": "float",
+            "ms": 477.084,
+            "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 12102992"
+          },
+          {
+            "binary": "float",
+            "ms": 467.685,
+            "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 12102992"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 1563.37,
+            "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 30691376"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 1553.94,
+            "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 30691376"
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 1555.53,
+            "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 30691376"
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 1615.84,
+            "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 30691376"
+          }
+        ],
+        "medians_ms": {
+          "old_scalar": 1622.7350000000001,
+          "pre_solver_scalar": 1557.23,
+          "new_scalar": 1570.25,
+          "new_neon": 1588.52,
+          "float": 472.3845
+        }
+      },
+      {
+        "scene": "rain",
+        "runs": [
+          {
+            "binary": "old_scalar",
+            "ms": 1407.74,
+            "counters": "body 4300 / shape 4400 / contact 7813 / joint 4200 / stack 1863344"
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 1380.2,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 1383.9,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 1291.08,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+          },
+          {
+            "binary": "float",
+            "ms": 562.97,
+            "counters": "body 4300 / shape 4400 / contact 7898 / joint 4200 / stack 1535568"
+          },
+          {
+            "binary": "float",
+            "ms": 549.117,
+            "counters": "body 4300 / shape 4400 / contact 7898 / joint 4200 / stack 1535568"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 1273.94,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 1425.96,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 1723.18,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 1460.8,
+            "counters": "body 4300 / shape 4400 / contact 7813 / joint 4200 / stack 1863344"
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 1428.48,
+            "counters": "body 4300 / shape 4400 / contact 7813 / joint 4200 / stack 1863344",
+            "recheck": 0
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 1420.21,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680",
+            "recheck": 0
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 1360.68,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680",
+            "recheck": 0
+          },
+          {
+            "binary": "new_neon",
+            "ms": 1359.99,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680",
+            "recheck": 0
+          },
+          {
+            "binary": "float",
+            "ms": 566.606,
+            "counters": "body 4300 / shape 4400 / contact 7898 / joint 4200 / stack 1535568",
+            "recheck": 0
+          },
+          {
+            "binary": "float",
+            "ms": 575.827,
+            "counters": "body 4300 / shape 4400 / contact 7898 / joint 4200 / stack 1535568",
+            "recheck": 1
+          },
+          {
+            "binary": "new_neon",
+            "ms": 1351.7,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680",
+            "recheck": 1
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 1352.03,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680",
+            "recheck": 1
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 1520.56,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680",
+            "recheck": 1
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 1447.47,
+            "counters": "body 4300 / shape 4400 / contact 7813 / joint 4200 / stack 1863344",
+            "recheck": 1
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 1376.59,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680",
+            "recheck": 2
+          },
+          {
+            "binary": "new_neon",
+            "ms": 1367.13,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680",
+            "recheck": 2
+          },
+          {
+            "binary": "float",
+            "ms": 566.124,
+            "counters": "body 4300 / shape 4400 / contact 7898 / joint 4200 / stack 1535568",
+            "recheck": 2
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 1420.02,
+            "counters": "body 4300 / shape 4400 / contact 7813 / joint 4200 / stack 1863344",
+            "recheck": 2
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 1348.53,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680",
+            "recheck": 2
+          }
+        ],
+        "medians_ms": {
+          "old_scalar": 1428.48,
+          "pre_solver_scalar": 1420.21,
+          "new_scalar": 1376.59,
+          "new_neon": 1351.7,
+          "float": 566.124
+        }
+      },
+      {
+        "scene": "trees100",
+        "runs": [
+          {
+            "binary": "old_scalar",
+            "ms": 191.716,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 146.796,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 144.558,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 146.936,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "float",
+            "ms": 84.6574,
+            "counters": "body 51 / shape 1101 / contact 1102 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "float",
+            "ms": 89.5498,
+            "counters": "body 51 / shape 1101 / contact 1102 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 165.303,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 158.3,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 161.068,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 206.388,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 193.899,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528",
+            "recheck": 0
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 150.299,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528",
+            "recheck": 0
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 151.638,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528",
+            "recheck": 0
+          },
+          {
+            "binary": "new_neon",
+            "ms": 150.333,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528",
+            "recheck": 0
+          },
+          {
+            "binary": "float",
+            "ms": 85.2813,
+            "counters": "body 51 / shape 1101 / contact 1102 / joint 0 / stack 572528",
+            "recheck": 0
+          },
+          {
+            "binary": "float",
+            "ms": 83.7666,
+            "counters": "body 51 / shape 1101 / contact 1102 / joint 0 / stack 572528",
+            "recheck": 1
+          },
+          {
+            "binary": "new_neon",
+            "ms": 146.031,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528",
+            "recheck": 1
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 155.438,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528",
+            "recheck": 1
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 146.866,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528",
+            "recheck": 1
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 191.287,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528",
+            "recheck": 1
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 150.434,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528",
+            "recheck": 2
+          },
+          {
+            "binary": "new_neon",
+            "ms": 146.533,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528",
+            "recheck": 2
+          },
+          {
+            "binary": "float",
+            "ms": 81.5125,
+            "counters": "body 51 / shape 1101 / contact 1102 / joint 0 / stack 572528",
+            "recheck": 2
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 195.075,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528",
+            "recheck": 2
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 156.983,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528",
+            "recheck": 2
+          }
+        ],
+        "medians_ms": {
+          "old_scalar": 193.899,
+          "pre_solver_scalar": 150.299,
+          "new_scalar": 151.638,
+          "new_neon": 146.936,
+          "float": 84.6574
+        }
+      },
+      {
+        "scene": "trees50",
+        "runs": [
+          {
+            "binary": "old_scalar",
+            "ms": 309.544,
+            "counters": "body 51 / shape 1101 / contact 1114 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 207.943,
+            "counters": "body 51 / shape 1101 / contact 1114 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 210.337,
+            "counters": "body 51 / shape 1101 / contact 1114 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 209.132,
+            "counters": "body 51 / shape 1101 / contact 1114 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "float",
+            "ms": 105.835,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "float",
+            "ms": 107.596,
+            "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 207.391,
+            "counters": "body 51 / shape 1101 / contact 1114 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 210.484,
+            "counters": "body 51 / shape 1101 / contact 1114 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 211.34,
+            "counters": "body 51 / shape 1101 / contact 1114 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 322.955,
+            "counters": "body 51 / shape 1101 / contact 1114 / joint 0 / stack 572528"
+          }
+        ],
+        "medians_ms": {
+          "old_scalar": 316.2495,
+          "pre_solver_scalar": 209.6415,
+          "new_scalar": 210.4105,
+          "new_neon": 208.2615,
+          "float": 106.71549999999999
+        }
+      },
+      {
+        "scene": "trees25",
+        "runs": [
+          {
+            "binary": "old_scalar",
+            "ms": 663.576,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 388.796,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 391.878,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 397.018,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "float",
+            "ms": 235.902,
+            "counters": "body 51 / shape 1101 / contact 1112 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "float",
+            "ms": 230.718,
+            "counters": "body 51 / shape 1101 / contact 1112 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 396.803,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 406.89,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 401.295,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 665.623,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+          }
+        ],
+        "medians_ms": {
+          "old_scalar": 664.5995,
+          "pre_solver_scalar": 395.0455,
+          "new_scalar": 399.384,
+          "new_neon": 396.91049999999996,
+          "float": 233.31
+        }
+      },
+      {
+        "scene": "washer",
+        "runs": [
+          {
+            "binary": "old_scalar",
+            "ms": 15355.6,
+            "counters": "body 8002 / shape 8041 / contact 39517 / joint 0 / stack 18594752"
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 13571.2,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 18551760"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 13415.1,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 18551760"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 13803.1,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 18551760"
+          },
+          {
+            "binary": "float",
+            "ms": 6720.28,
+            "counters": "body 8002 / shape 8041 / contact 40444 / joint 0 / stack 7289728"
+          },
+          {
+            "binary": "float",
+            "ms": 6820.5,
+            "counters": "body 8002 / shape 8041 / contact 40444 / joint 0 / stack 7289728"
+          },
+          {
+            "binary": "new_neon",
+            "ms": 13809.3,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 18551760"
+          },
+          {
+            "binary": "new_scalar",
+            "ms": 13973.0,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 18551760"
+          },
+          {
+            "binary": "pre_solver_scalar",
+            "ms": 13981.8,
+            "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 18551760"
+          },
+          {
+            "binary": "old_scalar",
+            "ms": 15278.1,
+            "counters": "body 8002 / shape 8041 / contact 39517 / joint 0 / stack 18594752"
+          }
+        ],
+        "medians_ms": {
+          "old_scalar": 15316.85,
+          "pre_solver_scalar": 13776.5,
+          "new_scalar": 13694.05,
+          "new_neon": 13806.2,
+          "float": 6770.389999999999
+        }
+      }
+    ],
+    "finished": "2026-09-07T18:03:34-0400",
+    "rechecks": [
+      {
+        "scene": "convex_pile",
+        "reason": "Initial pair spread exceeded 5%",
+        "triggering_binaries": [
+          "float"
+        ]
+      },
+      {
+        "scene": "large_world",
+        "reason": "Initial pair spread exceeded 5%",
+        "triggering_binaries": [
+          "old_scalar",
+          "float"
+        ]
+      },
+      {
+        "scene": "rain",
+        "reason": "Initial pair spread exceeded 5%",
+        "triggering_binaries": [
+          "pre_solver_scalar"
+        ]
+      },
+      {
+        "scene": "trees100",
+        "reason": "Initial pair spread exceeded 5%",
+        "triggering_binaries": [
+          "old_scalar",
+          "pre_solver_scalar",
+          "new_scalar",
+          "new_neon",
+          "float"
+        ]
+      }
+    ],
+    "rechecks_finished": "2026-09-07T18:08:14-0400"
+  },
+  "joint_isolation": [
+    {
+      "scene": "joint_grid",
+      "runs": [
+        {
+          "binary": "before",
+          "ms": 916.721
+        },
+        {
+          "binary": "full",
+          "ms": 829.738
+        },
+        {
+          "binary": "zero",
+          "ms": 841.209
+        },
+        {
+          "binary": "zero",
+          "ms": 829.711
+        },
+        {
+          "binary": "full",
+          "ms": 831.069
+        },
+        {
+          "binary": "before",
+          "ms": 918.683
+        },
+        {
+          "binary": "before",
+          "ms": 912.729
+        },
+        {
+          "binary": "full",
+          "ms": 832.911
+        },
+        {
+          "binary": "zero",
+          "ms": 832.41
+        }
+      ],
+      "medians_ms": {
+        "before": 916.721,
+        "full": 831.069,
+        "zero": 832.41
+      }
+    },
+    {
+      "scene": "rain",
+      "runs": [
+        {
+          "binary": "before",
+          "ms": 1333.25
+        },
+        {
+          "binary": "full",
+          "ms": 1305.18
+        },
+        {
+          "binary": "zero",
+          "ms": 1327.64
+        },
+        {
+          "binary": "zero",
+          "ms": 1364.48
+        },
+        {
+          "binary": "full",
+          "ms": 1302.25
+        },
+        {
+          "binary": "before",
+          "ms": 1332.82
+        },
+        {
+          "binary": "before",
+          "ms": 1367.94
+        },
+        {
+          "binary": "full",
+          "ms": 1355.42
+        },
+        {
+          "binary": "zero",
+          "ms": 1335.8
+        }
+      ],
+      "medians_ms": {
+        "before": 1333.25,
+        "full": 1305.18,
+        "zero": 1335.8
+      }
+    }
+  ],
+  "joint_matrix_skip": [
+    {
+      "scene": "joint_grid",
+      "runs": [
+        {
+          "binary": "before",
+          "ms": 907.381
+        },
+        {
+          "binary": "zero",
+          "ms": 825.596
+        },
+        {
+          "binary": "skip",
+          "ms": 734.874
+        },
+        {
+          "binary": "skip",
+          "ms": 741.553
+        },
+        {
+          "binary": "zero",
+          "ms": 841.262
+        },
+        {
+          "binary": "before",
+          "ms": 913.374
+        },
+        {
+          "binary": "before",
+          "ms": 911.219
+        },
+        {
+          "binary": "zero",
+          "ms": 839.575
+        },
+        {
+          "binary": "skip",
+          "ms": 741.154
+        }
+      ],
+      "medians_ms": {
+        "before": 911.219,
+        "zero": 839.575,
+        "skip": 741.154
+      }
+    },
+    {
+      "scene": "rain",
+      "runs": [
+        {
+          "binary": "before",
+          "ms": 1413.15
+        },
+        {
+          "binary": "zero",
+          "ms": 1375.42
+        },
+        {
+          "binary": "skip",
+          "ms": 1369.48
+        },
+        {
+          "binary": "skip",
+          "ms": 1334.24
+        },
+        {
+          "binary": "zero",
+          "ms": 1333.14
+        },
+        {
+          "binary": "before",
+          "ms": 1339.55
+        },
+        {
+          "binary": "before",
+          "ms": 1386.84
+        },
+        {
+          "binary": "zero",
+          "ms": 1390.0
+        },
+        {
+          "binary": "skip",
+          "ms": 1406.79
+        }
+      ],
+      "medians_ms": {
+        "before": 1386.84,
+        "zero": 1375.42,
+        "skip": 1369.48
+      }
+    }
+  ],
+  "support_aabb_experiment": {
+    "method": "Three runs per binary, before/after/after/before/before/after, four workers; source-only hull support scan candidate.",
+    "sha256": {
+      "before": "50ebf495cb0afc025f2ab9fbef1c819ad69afe96be7efcbcf5f869a220ab501b",
+      "after": "ae6b48fe6bb71a4b6c343111704b6953e89bf097b98976b960fde19548c736c5"
+    },
+    "rows": [
+      {
+        "scene": "convex_pile",
+        "runs": [
+          {
+            "binary": "before",
+            "ms": 10721.1,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776"
+          },
+          {
+            "binary": "after",
+            "ms": 10481.6,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776"
+          },
+          {
+            "binary": "after",
+            "ms": 10473.6,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776"
+          },
+          {
+            "binary": "before",
+            "ms": 10768.4,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776"
+          },
+          {
+            "binary": "before",
+            "ms": 10797.7,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776"
+          },
+          {
+            "binary": "after",
+            "ms": 10424.6,
+            "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6219776"
+          }
+        ],
+        "medians_ms": {
+          "before": 10768.4,
+          "after": 10473.6
+        },
+        "runtime_change_percent": -2.7376397607815406
+      },
+      {
+        "scene": "junkyard",
+        "runs": [
+          {
+            "binary": "before",
+            "ms": 8993.52,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 28761008"
+          },
+          {
+            "binary": "after",
+            "ms": 8983.24,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 28761008"
+          },
+          {
+            "binary": "after",
+            "ms": 8988.07,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 28761008"
+          },
+          {
+            "binary": "before",
+            "ms": 9016.9,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 28761008"
+          },
+          {
+            "binary": "before",
+            "ms": 9039.42,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 28761008"
+          },
+          {
+            "binary": "after",
+            "ms": 9033.73,
+            "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 28761008"
+          }
+        ],
+        "medians_ms": {
+          "before": 9016.9,
+          "after": 8988.07
+        },
+        "runtime_change_percent": -0.3197329459126763
+      },
+      {
+        "scene": "trees25",
+        "runs": [
+          {
+            "binary": "before",
+            "ms": 393.665,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "after",
+            "ms": 394.507,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "after",
+            "ms": 388.781,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "before",
+            "ms": 398.324,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "before",
+            "ms": 410.788,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+          },
+          {
+            "binary": "after",
+            "ms": 408.697,
+            "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+          }
+        ],
+        "medians_ms": {
+          "before": 398.324,
+          "after": 394.507
+        },
+        "runtime_change_percent": -0.9582651308984613
+      },
+      {
+        "scene": "rain",
+        "runs": [
+          {
+            "binary": "before",
+            "ms": 1366.29,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+          },
+          {
+            "binary": "after",
+            "ms": 1343.5,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+          },
+          {
+            "binary": "after",
+            "ms": 1333.3,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+          },
+          {
+            "binary": "before",
+            "ms": 1360.64,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+          },
+          {
+            "binary": "before",
+            "ms": 1375.62,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+          },
+          {
+            "binary": "after",
+            "ms": 1353.26,
+            "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1731680"
+          }
+        ],
+        "medians_ms": {
+          "before": 1366.29,
+          "after": 1343.5
+        },
+        "runtime_change_percent": -1.6680206983876067
+      },
+      {
+        "scene": "large_world",
+        "runs": [
+          {
+            "binary": "before",
+            "ms": 24.618,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "after",
+            "ms": 24.2854,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "after",
+            "ms": 24.755,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "before",
+            "ms": 28.7899,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "before",
+            "ms": 25.3817,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          },
+          {
+            "binary": "after",
+            "ms": 24.6091,
+            "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+          }
+        ],
+        "medians_ms": {
+          "before": 25.3817,
+          "after": 24.6091
+        },
+        "runtime_change_percent": -3.043925347789933
+      }
+    ]
+  },
+  "support_vertex_bound_experiment": [
+    {
+      "scene": "convex_pile",
+      "runs": [
+        {
+          "binary": "before",
+          "ms": 10817.7
+        },
+        {
+          "binary": "after",
+          "ms": 10635.4
+        },
+        {
+          "binary": "after",
+          "ms": 10634.2
+        },
+        {
+          "binary": "before",
+          "ms": 10797.0
+        },
+        {
+          "binary": "before",
+          "ms": 10738.3
+        },
+        {
+          "binary": "after",
+          "ms": 10601.4
+        }
+      ],
+      "medians_ms": {
+        "before": 10797.0,
+        "after": 10634.2
+      }
+    },
+    {
+      "scene": "junkyard",
+      "runs": [
+        {
+          "binary": "before",
+          "ms": 9240.33
+        },
+        {
+          "binary": "after",
+          "ms": 9105.5
+        },
+        {
+          "binary": "after",
+          "ms": 9173.67
+        },
+        {
+          "binary": "before",
+          "ms": 9261.41
+        },
+        {
+          "binary": "before",
+          "ms": 9239.8
+        },
+        {
+          "binary": "after",
+          "ms": 9127.87
+        }
+      ],
+      "medians_ms": {
+        "before": 9240.33,
+        "after": 9127.87
+      }
+    }
+  ],
+  "profiles": {
+    "new_scalar-convex_pile": "Sort by top of stack, same collapsed (when >= 5):\n        b3QueryEdgeDirections  (in benchmark-new_scalar)        18250\n        b3QueryFaceDirections  (in benchmark-new_scalar)        4686\n        b3DynamicTree_Query  (in benchmark-new_scalar)        1366\n        b3CollideHulls  (in benchmark-new_scalar)        961\n        b3SolveContacts_Convex  (in benchmark-new_scalar)        928\n        b3InvMulWorldTransforms  (in benchmark-new_scalar)        717\n        semaphore_wait_trap  (in libsystem_kernel.dylib)        627\n        b3TestEdgePair  (in benchmark-new_scalar)        613\n        b3ExecuteBlock  (in benchmark-new_scalar)        470\n        b3PrepareContacts_Convex  (in benchmark-new_scalar)        460\n        b3UpdateConvexContact  (in benchmark-new_scalar)        392\n        b3CollideTask  (in benchmark-new_scalar)        354\n        swtch_pri  (in libsystem_kernel.dylib)        311\n        __udivmodti4  (in libcompiler_rt.dylib)        277\n        <deduplicated_symbol>  (in benchmark-new_scalar)        242\n        b3PairQueryCallback  (in benchmark-new_scalar)        210\n        b3ClipPolygon  (in benchmark-new_scalar)        204\n        b3BuildFaceAContact  (in benchmark-new_scalar)        198\n        b3WarmStartContacts_Convex  (in benchmark-new_scalar)        188\n        b3GatherBodies  (in benchmark-new_scalar)        169\n        b3FindIncidentFace  (in benchmark-new_scalar)        117\n        b3FinalizeBodiesTask  (in benchmark-new_scalar)        109\n        b3MakeMatrixFromQuatW  (in benchmark-new_scalar)        109\n        b3DynamicTree_EnlargeProxy  (in benchmark-new_scalar)        69\n        b3UpdateContact  (in benchmark-new_scalar)        62\n        b3InvMulSubMVW  (in benchmark-new_scalar)        51\n        b3StoreImpulses_Convex  (in benchmark-new_scalar)        49\n        b3SolverTask  (in benchmark-new_scalar)        45\n        b3InvMulAddMVW  (in benchmark-new_scalar)        40\n        fixNormalizeQuat  (in benchmark-new_scalar)        40\n        b3MulMM  (in benchmark-new_scalar)        38\n        __divti3  (in libcompiler_rt.dylib)        36\n        b3DynamicTree_Rebuild  (in benchmark-new_scalar)        32\n        b3AABB_Transform  (in benchmark-new_scalar)        31\n        b3BuildFaceBContact  (in benchmark-new_scalar)        30\n        b3PartitionMid  (in benchmark-new_scalar)        27\n        b3RelVelocityW  (in benchmark-new_scalar)        26\n        DYLD-STUB$$__divti3  (in benchmark-new_scalar)        20\n        b3SolveContinuous  (in benchmark-new_scalar)        19\n        b3World_Step  (in benchmark-new_scalar)        18\n        b3RemoveKey  (in benchmark-new_scalar)        14\n        mach_absolute_time  (in libsystem_kernel.dylib)        14\n        _platform_memmove  (in libsystem_platform.dylib)        13\n        b3AddKey  (in benchmark-new_scalar)        12\n        b3CreateContact  (in benchmark-new_scalar)        7\n        b3SqrtW  (in benchmark-new_scalar)        6\n        ___chkstk_darwin  (in libsystem_pthread.dylib)        5\n        b3ExecuteStage  (in benchmark-new_scalar)        5\n        b3FindPairsTask  (in benchmark-new_scalar)        5\n        b3UpdateBroadPhasePairs  (in benchmark-new_scalar)        5",
+    "new_neon-convex_pile": "Sort by top of stack, same collapsed (when >= 5):\n        b3QueryEdgeDirections  (in benchmark-new_neon)        11251\n        b3FindHullSupportVertex  (in benchmark-new_neon)        4411\n        b3DynamicTree_Query  (in benchmark-new_neon)        2177\n        b3TestEdgePair  (in benchmark-new_neon)        2056\n        b3SolveContacts_Convex  (in benchmark-new_neon)        1391\n        b3QueryFaceDirections  (in benchmark-new_neon)        1169\n        b3InvMulWorldTransforms  (in benchmark-new_neon)        1047\n        semaphore_wait_trap  (in libsystem_kernel.dylib)        1023\n        b3ExecuteBlock  (in benchmark-new_neon)        987\n        b3PrepareContacts_Convex  (in benchmark-new_neon)        734\n        b3UpdateConvexContact  (in benchmark-new_neon)        551\n        b3CollideTask  (in benchmark-new_neon)        547\n        swtch_pri  (in libsystem_kernel.dylib)        512\n        b3CollideHulls  (in benchmark-new_neon)        475\n        __udivmodti4  (in libcompiler_rt.dylib)        444\n        <deduplicated_symbol>  (in benchmark-new_neon)        432\n        b3ClipPolygon  (in benchmark-new_neon)        330\n        b3BuildFaceAContact  (in benchmark-new_neon)        326\n        b3WarmStartContacts_Convex  (in benchmark-new_neon)        309\n        b3PairQueryCallback  (in benchmark-new_neon)        305\n        b3GatherBodies  (in benchmark-new_neon)        256\n        b3MakeMatrixFromQuatW  (in benchmark-new_neon)        184\n        b3FinalizeBodiesTask  (in benchmark-new_neon)        175\n        b3FindIncidentFace  (in benchmark-new_neon)        172\n        b3DynamicTree_EnlargeProxy  (in benchmark-new_neon)        126\n        b3InvMulSubMVW  (in benchmark-new_neon)        108\n        b3UpdateContact  (in benchmark-new_neon)        90\n        b3InvMulAddMVW  (in benchmark-new_neon)        84\n        b3SolverTask  (in benchmark-new_neon)        84\n        b3StoreImpulses_Convex  (in benchmark-new_neon)        73\n        b3MulMM  (in benchmark-new_neon)        67\n        b3AABB_Transform  (in benchmark-new_neon)        61\n        b3PartitionMid  (in benchmark-new_neon)        58\n        DYLD-STUB$$__divti3  (in benchmark-new_neon)        56\n        __divti3  (in libcompiler_rt.dylib)        54\n        fixNormalizeQuat  (in benchmark-new_neon)        53\n        b3DynamicTree_Rebuild  (in benchmark-new_neon)        49\n        b3RelVelocityW  (in benchmark-new_neon)        46\n        b3BuildFaceBContact  (in benchmark-new_neon)        40\n        b3RemoveKey  (in benchmark-new_neon)        25\n        b3World_Step  (in benchmark-new_neon)        24\n        mach_absolute_time  (in libsystem_kernel.dylib)        23\n        _platform_memmove  (in libsystem_platform.dylib)        18\n        b3SolveContinuous  (in benchmark-new_neon)        17\n        b3Perp  (in benchmark-new_neon)        16\n        b3AddKey  (in benchmark-new_neon)        15\n        b3UpdateBroadPhasePairs  (in benchmark-new_neon)        14\n        b3CreateContact  (in benchmark-new_neon)        13\n        b3Solve  (in benchmark-new_neon)        13\n        b3ExecuteStage  (in benchmark-new_neon)        11\n        b3SqrtW  (in benchmark-new_neon)        11\n        b3AllocateNode  (in benchmark-new_neon)        9\n        ___chkstk_darwin  (in libsystem_pthread.dylib)        8\n        semaphore_signal_trap  (in libsystem_kernel.dylib)        8\n        __psynch_mutexwait  (in libsystem_kernel.dylib)        6\n        b3LinkContact  (in benchmark-new_neon)        5",
+    "new_neon-rain": "Sort by top of stack, same collapsed (when >= 5):\n        b3SolveSphericalJoint  (in benchmark-new_neon)        7004\n        b3SolveRevoluteJoint  (in benchmark-new_neon)        3121\n        b3MulMM  (in benchmark-new_neon)        2283\n        fixDivShifted256  (in benchmark-new_neon)        2231\n        b3ExecuteBlock  (in benchmark-new_neon)        2125\n        swtch_pri  (in libsystem_kernel.dylib)        1978\n        __udivmodti4  (in libcompiler_rt.dylib)        1376\n        b3DynamicTree_Query  (in benchmark-new_neon)        1351\n        semaphore_wait_trap  (in libsystem_kernel.dylib)        1260\n        b3SolveContacts_Mesh  (in benchmark-new_neon)        897\n        b3WarmStartSphericalJoint  (in benchmark-new_neon)        750\n        b3SolveContacts_Convex  (in benchmark-new_neon)        668\n        b3CollideTask  (in benchmark-new_neon)        508\n        b3PrepareSphericalJoint  (in benchmark-new_neon)        506\n        b3SolverTask  (in benchmark-new_neon)        470\n        b3InvMulWorldTransforms  (in benchmark-new_neon)        441\n        b3PairQueryCallback  (in benchmark-new_neon)        436\n        b3FinalizeBodiesTask  (in benchmark-new_neon)        401\n        b3PrepareContacts_Convex  (in benchmark-new_neon)        296\n        b3GatherBodies  (in benchmark-new_neon)        283\n        fixDivShiftedWide  (in benchmark-new_neon)        283\n        b3WarmStartRevoluteJoint  (in benchmark-new_neon)        274\n        b3WarmStartContacts_Mesh  (in benchmark-new_neon)        242\n        mach_absolute_time  (in libsystem_kernel.dylib)        207\n        b3MakeMatrixFromQuatW  (in benchmark-new_neon)        179\n        b3DynamicTree_EnlargeProxy  (in benchmark-new_neon)        178\n        b3WarmStartContacts_Convex  (in benchmark-new_neon)        177\n        fixNormalizeQuat  (in benchmark-new_neon)        166\n        b3PrepareRevoluteJoint  (in benchmark-new_neon)        135\n        b3SolveContinuous  (in benchmark-new_neon)        135\n        b3PartitionMid  (in benchmark-new_neon)        114\n        b3ComputeCapsuleAABB  (in benchmark-new_neon)        113\n        b3InvMulSubMVW  (in benchmark-new_neon)        107\n        DYLD-STUB$$__udivti3  (in benchmark-new_neon)        106\n        b3InvMulAddMVW  (in benchmark-new_neon)        102\n        b3PrepareContacts_Mesh  (in benchmark-new_neon)        98\n        b3ExecuteStage  (in benchmark-new_neon)        97\n        b3ShapeDistance  (in benchmark-new_neon)        90\n        b3ComputeMeshManifolds  (in benchmark-new_neon)        87\n        b3SolveJoint  (in benchmark-new_neon)        87\n        b3DynamicTree_Rebuild  (in benchmark-new_neon)        80\n        b3TestBoundsTriangleOverlap  (in benchmark-new_neon)        66\n        b3SegmentDistance  (in benchmark-new_neon)        60\n        <deduplicated_symbol>  (in benchmark-new_neon)        57\n        b3CollideCapsules  (in benchmark-new_neon)        57\n        b3QueryMesh  (in benchmark-new_neon)        55\n        DYLD-STUB$$__divti3  (in benchmark-new_neon)        52\n        b3UpdateConvexContact  (in benchmark-new_neon)        52\n        __divti3  (in libcompiler_rt.dylib)        48\n        b3InvertAcrossScales  (in benchmark-new_neon)        46\n        b3ShouldBodiesCollide  (in benchmark-new_neon)        45\n        b3RelVelocityW  (in benchmark-new_neon)        43\n        b3StoreImpulses_Convex  (in benchmark-new_neon)        38\n        b3PrepareJoint  (in benchmark-new_neon)        32\n        b3SqrtW  (in benchmark-new_neon)        31\n        b3GetSweepTransform  (in benchmark-new_neon)        30\n        b3UpdateContact  (in benchmark-new_neon)        27\n        b3BarycentricCoordsTri  (in benchmark-new_neon)        26\n        b3Solve  (in benchmark-new_neon)        26\n        cthread_yield  (in libsystem_pthread.dylib)        23\n        b3TimeOfImpact  (in benchmark-new_neon)        20\n        b3ComputeSweptCapsuleAABB  (in benchmark-new_neon)        19\n        b3WarmStartJoint  (in benchmark-new_neon)        19\n        semaphore_signal_trap  (in libsystem_kernel.dylib)        19\n        b3CollideTriangleAndCapsule  (in benchmark-new_neon)        18\n        DYLD-STUB$$sched_yield  (in benchmark-new_neon)        17\n        ___chkstk_darwin  (in libsystem_pthread.dylib)        17\n        b3ClipSegmentToTriangleFace  (in benchmark-new_neon)        17\n        b3Perp  (in benchmark-new_neon)        17\n        b3ShapeTimeOfImpact  (in benchmark-new_neon)        17\n        _platform_memmove  (in libsystem_platform.dylib)        14\n        b3GetProxySupport  (in benchmark-new_neon)        14\n        b3StoreImpulses_Mesh  (in benchmark-new_neon)        14\n        b3UpdateBroadPhasePairs  (in benchmark-new_neon)        13\n        b3World_Step  (in benchmark-new_neon)        13\n        b3CreateContact  (in benchmark-new_neon)        12\n        b3AABB_Transform  (in benchmark-new_neon)        11\n        b3ComputeShapeAABB  (in benchmark-new_neon)        11\n        DYLD-STUB$$swtch_pri  (in libsystem_pthread.dylib)        9\n        _platform_memset  (in libsystem_platform.dylib)        9\n        b3AllocateNode  (in benchmark-new_neon)        9\n        b3InsertLeaf  (in benchmark-new_neon)        9\n        b3RemoveKey  (in benchmark-new_neon)        9\n        __psynch_mutexwait  (in libsystem_kernel.dylib)        7\n        b3AddKey  (in benchmark-new_neon)        6\n        b3FindPairsTask  (in benchmark-new_neon)        6\n        b3GetMeshTriangle  (in benchmark-new_neon)        6\n        b3BarycentricCoordsTet  (in benchmark-new_neon)        5\n        b3ComputeWitnessPoints  (in benchmark-new_neon)        5"
+  },
+  "visual_exact": {
+    "created_utc": "2026-09-07T22:03:36.665542+00:00",
+    "frames": 120,
+    "nominal_hz": 60,
+    "repeat": 2,
+    "match": "^(Joints/|Collision/(Shape Distance|Distance Debug)$|Stacking/Box Stack$|Determinism/Falling Ragdolls$)",
+    "no_axes": true,
+    "builds": {
+      "fixed": {
+        "binary_sha256": "b41b0bbbe498058ab9abc4baf4fd2f09d3d1f086ebc4c53d86b82ef6baf41149",
+        "samples": {
+          "Benchmark/Candy Cups": 0,
+          "Benchmark/Chains": 1,
+          "Benchmark/Convex Pile": 2,
+          "Benchmark/Destruction": 3,
+          "Benchmark/Explosion": 4,
+          "Benchmark/Falling Boxes": 5,
+          "Benchmark/Falling Trees": 6,
+          "Benchmark/Height Field": 7,
+          "Benchmark/Hull": 8,
+          "Benchmark/Joint Grid": 9,
+          "Benchmark/Junkyard": 10,
+          "Benchmark/Large Pyramid": 11,
+          "Benchmark/Large World": 12,
+          "Benchmark/Many Pyramids": 13,
+          "Benchmark/Rain": 14,
+          "Benchmark/Sensor": 15,
+          "Benchmark/Washer": 16,
+          "Benchmark/Wide Pyramid": 17,
+          "Bodies/Body Type": 18,
+          "Bodies/Cast": 19,
+          "Bodies/Disable": 20,
+          "Bodies/Fixed Rotation": 21,
+          "Bodies/Gyroscopic Precession": 22,
+          "Bodies/Gyroscopic Torque": 23,
+          "Bodies/Kinematic": 24,
+          "Bodies/Lock Mixing": 25,
+          "Bodies/Spinning Book": 26,
+          "Bodies/Weeble": 27,
+          "Character/CapsulePlane": 28,
+          "Character/Mover": 29,
+          "Character/MoverOverlap": 30,
+          "Character/Rigid Body": 31,
+          "Collision/Capsule Cast Ray": 32,
+          "Collision/Cast World": 33,
+          "Collision/Distance Debug": 34,
+          "Collision/Initial Overlap": 35,
+          "Collision/Long Ray Cast": 36,
+          "Collision/Mesh Scale": 37,
+          "Collision/Overlap World": 38,
+          "Collision/Ray Curtain": 39,
+          "Collision/Shape Cast": 40,
+          "Collision/Shape Cast Debug": 41,
+          "Collision/Shape Distance": 42,
+          "Collision/Time of Impact": 43,
+          "Compound/Hulls": 44,
+          "Compound/Mesh Tile": 45,
+          "Compound/Simple": 46,
+          "Compound/Spheres": 47,
+          "Compound/Tile Floor": 48,
+          "Compound/Village": 49,
+          "Continuous/Bounce House": 50,
+          "Continuous/Bullet vs Stack": 51,
+          "Continuous/Hump Mesh": 52,
+          "Continuous/Is Fast": 53,
+          "Continuous/Mesh Drop": 54,
+          "Continuous/Needle Mesh": 55,
+          "Continuous/Spinning Stick": 56,
+          "Continuous/Stall": 57,
+          "Continuous/Thin Wall": 58,
+          "Determinism/Falling Ragdolls": 59,
+          "Determinism/Mesh Drop": 60,
+          "Determinism/Query Spawn": 61,
+          "Determinism/Wave Pile": 62,
+          "Events/Hit": 63,
+          "Events/Joint": 64,
+          "Events/Move": 65,
+          "Events/Persistent Contact": 66,
+          "Events/Sensor Hits": 67,
+          "Events/Sensor Visit": 68,
+          "Geometry/Box Hull": 69,
+          "Geometry/Capsule Mass": 70,
+          "Geometry/Hull": 71,
+          "Geometry/Hull Reduction": 72,
+          "Geometry/Hull Transform": 73,
+          "Issues/Capsule Mesh": 74,
+          "Issues/Convex Jitter": 75,
+          "Issues/Crash": 76,
+          "Issues/GMod Wheel Stack": 77,
+          "Issues/Hull Crash": 78,
+          "Issues/Multiple Prismatic": 79,
+          "Issues/Restitution Overshoot": 80,
+          "Issues/Slide Twist Off Center Shape": 81,
+          "Issues/s&box Ghost Collisions": 82,
+          "Issues/s&box mover": 83,
+          "Joints/Ball and Chain": 84,
+          "Joints/Bridge": 85,
+          "Joints/Distance Joint": 86,
+          "Joints/Door": 87,
+          "Joints/Driving": 88,
+          "Joints/Filter": 89,
+          "Joints/Gear Lift": 90,
+          "Joints/Motion Locks": 91,
+          "Joints/Motor Joint": 92,
+          "Joints/Parallel Spring": 93,
+          "Joints/Prismatic": 94,
+          "Joints/Revolute": 95,
+          "Joints/Spherical": 96,
+          "Joints/Top Down Friction": 97,
+          "Joints/Weld": 98,
+          "Joints/Wheel": 99,
+          "Manifold/Capsule vs Capsule": 100,
+          "Manifold/Capsule vs Hull": 101,
+          "Manifold/Capsule vs Sphere": 102,
+          "Manifold/Hull vs Hull": 103,
+          "Manifold/Hull vs Sphere": 104,
+          "Manifold/Sphere vs Sphere": 105,
+          "Manifold/Triangle vs Capsule": 106,
+          "Manifold/Triangle vs Hull": 107,
+          "Manifold/Triangle vs Sphere": 108,
+          "Mesh/Big Box": 109,
+          "Mesh/Box": 110,
+          "Mesh/Creation Benchmark": 111,
+          "Mesh/Grid": 112,
+          "Mesh/Height Field": 113,
+          "Mesh/Hollow Box": 114,
+          "Mesh/Reflection": 115,
+          "Mesh/Viewer": 116,
+          "Mesh/Voxel": 117,
+          "Ragdoll/Box": 118,
+          "Ragdoll/Incline": 119,
+          "Ragdoll/Mesh": 120,
+          "Ragdoll/Pile": 121,
+          "Replay/Viewer": 122,
+          "Robustness/HighMassRatio1": 123,
+          "Robustness/Overflow Color Pile": 124,
+          "Robustness/Overlap Recovery": 125,
+          "Robustness/Tiny Pyramid": 126,
+          "Shapes/Conveyor Belt": 127,
+          "Shapes/Conveyor Mesh": 128,
+          "Shapes/High Resistance": 129,
+          "Shapes/Inclined Plane": 130,
+          "Shapes/Isotropic Friction": 131,
+          "Shapes/Restitution": 132,
+          "Shapes/Rolling Resistance": 133,
+          "Shapes/Slide Twist": 134,
+          "Shapes/Static Invoke": 135,
+          "Shapes/Wind": 136,
+          "Shapes/Wind Drop": 137,
+          "Shapes/Wind Flap": 138,
+          "Stacking/Arch": 139,
+          "Stacking/Box Stack": 140,
+          "Stacking/Capsule Stack": 141,
+          "Stacking/Card House": 142,
+          "Stacking/Cylinder": 143,
+          "Stacking/Cylinder Stack": 144,
+          "Stacking/Dominoes": 145,
+          "Stacking/Double Domino": 146,
+          "Stacking/Edge Crossing": 147,
+          "Stacking/Jenga Stack": 148,
+          "Stacking/Pyramid2D": 149,
+          "Stacking/Single Box": 150,
+          "Stacking/Sphere Stack": 151,
+          "Stacking/Wedge": 152,
+          "Tree/Benchmark": 153,
+          "World/Far Mesh Drop": 154,
+          "World/Far Pyramid": 155,
+          "World/Far Ragdolls": 156,
+          "World/Far Stack": 157
+        }
+      },
+      "float": {
+        "binary_sha256": "869b63e3e0300b14101a5df2c3716a8b5df8a439e6bf854731c308b0d5892977",
+        "samples": {
+          "Benchmark/Candy Cups": 0,
+          "Benchmark/Chains": 1,
+          "Benchmark/Convex Pile": 2,
+          "Benchmark/Destruction": 3,
+          "Benchmark/Explosion": 4,
+          "Benchmark/Falling Boxes": 5,
+          "Benchmark/Falling Trees": 6,
+          "Benchmark/Height Field": 7,
+          "Benchmark/Hull": 8,
+          "Benchmark/Joint Grid": 9,
+          "Benchmark/Junkyard": 10,
+          "Benchmark/Large Pyramid": 11,
+          "Benchmark/Large World": 12,
+          "Benchmark/Many Pyramids": 13,
+          "Benchmark/Rain": 14,
+          "Benchmark/Sensor": 15,
+          "Benchmark/Washer": 16,
+          "Benchmark/Wide Pyramid": 17,
+          "Bodies/Body Type": 18,
+          "Bodies/Cast": 19,
+          "Bodies/Disable": 20,
+          "Bodies/Fixed Rotation": 21,
+          "Bodies/Gyroscopic Precession": 22,
+          "Bodies/Gyroscopic Torque": 23,
+          "Bodies/Kinematic": 24,
+          "Bodies/Lock Mixing": 25,
+          "Bodies/Spinning Book": 26,
+          "Bodies/Weeble": 27,
+          "Character/CapsulePlane": 28,
+          "Character/Mover": 29,
+          "Character/MoverOverlap": 30,
+          "Character/Rigid Body": 31,
+          "Collision/Capsule Cast Ray": 32,
+          "Collision/Cast World": 33,
+          "Collision/Distance Debug": 34,
+          "Collision/Initial Overlap": 35,
+          "Collision/Long Ray Cast": 36,
+          "Collision/Mesh Scale": 37,
+          "Collision/Overlap World": 38,
+          "Collision/Ray Curtain": 39,
+          "Collision/Shape Cast": 40,
+          "Collision/Shape Cast Debug": 41,
+          "Collision/Shape Distance": 42,
+          "Collision/Time of Impact": 43,
+          "Compound/Hulls": 44,
+          "Compound/Mesh Tile": 45,
+          "Compound/Simple": 46,
+          "Compound/Spheres": 47,
+          "Compound/Tile Floor": 48,
+          "Compound/Village": 49,
+          "Continuous/Bounce House": 50,
+          "Continuous/Bullet vs Stack": 51,
+          "Continuous/Hump Mesh": 52,
+          "Continuous/Is Fast": 53,
+          "Continuous/Mesh Drop": 54,
+          "Continuous/Needle Mesh": 55,
+          "Continuous/Spinning Stick": 56,
+          "Continuous/Stall": 57,
+          "Continuous/Thin Wall": 58,
+          "Determinism/Falling Ragdolls": 59,
+          "Determinism/Mesh Drop": 60,
+          "Determinism/Query Spawn": 61,
+          "Determinism/Wave Pile": 62,
+          "Events/Hit": 63,
+          "Events/Joint": 64,
+          "Events/Move": 65,
+          "Events/Persistent Contact": 66,
+          "Events/Sensor Hits": 67,
+          "Events/Sensor Visit": 68,
+          "Geometry/Box Hull": 69,
+          "Geometry/Capsule Mass": 70,
+          "Geometry/Hull": 71,
+          "Geometry/Hull Reduction": 72,
+          "Geometry/Hull Transform": 73,
+          "Issues/Capsule Mesh": 74,
+          "Issues/Convex Jitter": 75,
+          "Issues/Crash": 76,
+          "Issues/GMod Wheel Stack": 77,
+          "Issues/Hull Crash": 78,
+          "Issues/Multiple Prismatic": 79,
+          "Issues/Restitution Overshoot": 80,
+          "Issues/Slide Twist Off Center Shape": 81,
+          "Issues/s&box Ghost Collisions": 82,
+          "Issues/s&box mover": 83,
+          "Joints/Ball and Chain": 84,
+          "Joints/Bridge": 85,
+          "Joints/Distance Joint": 86,
+          "Joints/Door": 87,
+          "Joints/Driving": 88,
+          "Joints/Filter": 89,
+          "Joints/Gear Lift": 90,
+          "Joints/Motion Locks": 91,
+          "Joints/Motor Joint": 92,
+          "Joints/Parallel Spring": 93,
+          "Joints/Prismatic": 94,
+          "Joints/Revolute": 95,
+          "Joints/Spherical": 96,
+          "Joints/Top Down Friction": 97,
+          "Joints/Weld": 98,
+          "Joints/Wheel": 99,
+          "Manifold/Capsule vs Capsule": 100,
+          "Manifold/Capsule vs Hull": 101,
+          "Manifold/Capsule vs Sphere": 102,
+          "Manifold/Hull vs Hull": 103,
+          "Manifold/Hull vs Sphere": 104,
+          "Manifold/Sphere vs Sphere": 105,
+          "Manifold/Triangle vs Capsule": 106,
+          "Manifold/Triangle vs Hull": 107,
+          "Manifold/Triangle vs Sphere": 108,
+          "Mesh/Big Box": 109,
+          "Mesh/Box": 110,
+          "Mesh/Creation Benchmark": 111,
+          "Mesh/Grid": 112,
+          "Mesh/Height Field": 113,
+          "Mesh/Hollow Box": 114,
+          "Mesh/Reflection": 115,
+          "Mesh/Viewer": 116,
+          "Mesh/Voxel": 117,
+          "Ragdoll/Box": 118,
+          "Ragdoll/Incline": 119,
+          "Ragdoll/Mesh": 120,
+          "Ragdoll/Pile": 121,
+          "Replay/Viewer": 122,
+          "Robustness/HighMassRatio1": 123,
+          "Robustness/Overflow Color Pile": 124,
+          "Robustness/Overlap Recovery": 125,
+          "Robustness/Tiny Pyramid": 126,
+          "Shapes/Conveyor Belt": 127,
+          "Shapes/Conveyor Mesh": 128,
+          "Shapes/High Resistance": 129,
+          "Shapes/Inclined Plane": 130,
+          "Shapes/Isotropic Friction": 131,
+          "Shapes/Restitution": 132,
+          "Shapes/Rolling Resistance": 133,
+          "Shapes/Slide Twist": 134,
+          "Shapes/Static Invoke": 135,
+          "Shapes/Wind": 136,
+          "Shapes/Wind Drop": 137,
+          "Shapes/Wind Flap": 138,
+          "Stacking/Arch": 139,
+          "Stacking/Box Stack": 140,
+          "Stacking/Capsule Stack": 141,
+          "Stacking/Card House": 142,
+          "Stacking/Cylinder": 143,
+          "Stacking/Cylinder Stack": 144,
+          "Stacking/Dominoes": 145,
+          "Stacking/Double Domino": 146,
+          "Stacking/Edge Crossing": 147,
+          "Stacking/Jenga Stack": 148,
+          "Stacking/Pyramid2D": 149,
+          "Stacking/Single Box": 150,
+          "Stacking/Sphere Stack": 151,
+          "Stacking/Wedge": 152,
+          "Tree/Benchmark": 153,
+          "World/Far Mesh Drop": 154,
+          "World/Far Pyramid": 155,
+          "World/Far Ragdolls": 156,
+          "World/Far Stack": 157
+        }
+      }
+    },
+    "pixel_hash": "SHA256 of ASCII RGBA:WIDTHxHEIGHT followed by NUL and decoded RGBA bytes",
+    "rows": [
+      {
+        "sample": "Collision/Distance Debug",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Collision_Distance_Debug-67957c757033-0.png",
+              "pixel_sha256": "c2efb9df2a8a59212e25b2c48f2039cf0321e0a27168fbbddc0f0e3def136c6e",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Collision_Distance_Debug-67957c757033-1.png",
+              "pixel_sha256": "c2efb9df2a8a59212e25b2c48f2039cf0321e0a27168fbbddc0f0e3def136c6e",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Collision_Distance_Debug-67957c757033-0.png",
+              "pixel_sha256": "c2efb9df2a8a59212e25b2c48f2039cf0321e0a27168fbbddc0f0e3def136c6e",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Collision_Distance_Debug-67957c757033-1.png",
+              "pixel_sha256": "c2efb9df2a8a59212e25b2c48f2039cf0321e0a27168fbbddc0f0e3def136c6e",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Collision_Distance_Debug-67957c757033-thumb.png",
+        "float_thumbnail": "float/Collision_Distance_Debug-67957c757033-thumb.png"
+      },
+      {
+        "sample": "Collision/Shape Distance",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Collision_Shape_Distance-1efae0869794-0.png",
+              "pixel_sha256": "163cefe5ee4bde624ec79301a89dd8fec266f59d7c793e228aecc0943bd93834",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Collision_Shape_Distance-1efae0869794-1.png",
+              "pixel_sha256": "163cefe5ee4bde624ec79301a89dd8fec266f59d7c793e228aecc0943bd93834",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Collision_Shape_Distance-1efae0869794-0.png",
+              "pixel_sha256": "163cefe5ee4bde624ec79301a89dd8fec266f59d7c793e228aecc0943bd93834",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Collision_Shape_Distance-1efae0869794-1.png",
+              "pixel_sha256": "163cefe5ee4bde624ec79301a89dd8fec266f59d7c793e228aecc0943bd93834",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Collision_Shape_Distance-1efae0869794-thumb.png",
+        "float_thumbnail": "float/Collision_Shape_Distance-1efae0869794-thumb.png"
+      },
+      {
+        "sample": "Determinism/Falling Ragdolls",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Determinism_Falling_Ragdolls-1278b0375383-0.png",
+              "pixel_sha256": "6c45500976867ff315314530a73f1c3060728e1e86c8acfd1132525efede766c",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Determinism_Falling_Ragdolls-1278b0375383-1.png",
+              "pixel_sha256": "6c45500976867ff315314530a73f1c3060728e1e86c8acfd1132525efede766c",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Determinism_Falling_Ragdolls-1278b0375383-0.png",
+              "pixel_sha256": "6c45500976867ff315314530a73f1c3060728e1e86c8acfd1132525efede766c",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Determinism_Falling_Ragdolls-1278b0375383-1.png",
+              "pixel_sha256": "6c45500976867ff315314530a73f1c3060728e1e86c8acfd1132525efede766c",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Determinism_Falling_Ragdolls-1278b0375383-thumb.png",
+        "float_thumbnail": "float/Determinism_Falling_Ragdolls-1278b0375383-thumb.png"
+      },
+      {
+        "sample": "Joints/Ball and Chain",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Ball_and_Chain-aa4a237dd0eb-0.png",
+              "pixel_sha256": "05414d397b19f3818b2b30e7150404d29e49fe679d1867077d14baf587fc6a89",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Ball_and_Chain-aa4a237dd0eb-1.png",
+              "pixel_sha256": "05414d397b19f3818b2b30e7150404d29e49fe679d1867077d14baf587fc6a89",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Ball_and_Chain-aa4a237dd0eb-0.png",
+              "pixel_sha256": "05414d397b19f3818b2b30e7150404d29e49fe679d1867077d14baf587fc6a89",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Ball_and_Chain-aa4a237dd0eb-1.png",
+              "pixel_sha256": "05414d397b19f3818b2b30e7150404d29e49fe679d1867077d14baf587fc6a89",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Ball_and_Chain-aa4a237dd0eb-thumb.png",
+        "float_thumbnail": "float/Joints_Ball_and_Chain-aa4a237dd0eb-thumb.png"
+      },
+      {
+        "sample": "Joints/Bridge",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Bridge-87a11cde2063-0.png",
+              "pixel_sha256": "2f00f9b401f3788fe9cee5550e08e2ecf50c4f0d746c9e13fa369aa99750ecf9",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Bridge-87a11cde2063-1.png",
+              "pixel_sha256": "2f00f9b401f3788fe9cee5550e08e2ecf50c4f0d746c9e13fa369aa99750ecf9",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Bridge-87a11cde2063-0.png",
+              "pixel_sha256": "2f00f9b401f3788fe9cee5550e08e2ecf50c4f0d746c9e13fa369aa99750ecf9",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Bridge-87a11cde2063-1.png",
+              "pixel_sha256": "2f00f9b401f3788fe9cee5550e08e2ecf50c4f0d746c9e13fa369aa99750ecf9",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Bridge-87a11cde2063-thumb.png",
+        "float_thumbnail": "float/Joints_Bridge-87a11cde2063-thumb.png"
+      },
+      {
+        "sample": "Joints/Distance Joint",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Distance_Joint-5583ed521efa-0.png",
+              "pixel_sha256": "77961532f714e0538b52a22e1ad79ff77ad359b9ef58cb053c37d88a286440ff",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Distance_Joint-5583ed521efa-1.png",
+              "pixel_sha256": "77961532f714e0538b52a22e1ad79ff77ad359b9ef58cb053c37d88a286440ff",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Distance_Joint-5583ed521efa-0.png",
+              "pixel_sha256": "77961532f714e0538b52a22e1ad79ff77ad359b9ef58cb053c37d88a286440ff",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Distance_Joint-5583ed521efa-1.png",
+              "pixel_sha256": "77961532f714e0538b52a22e1ad79ff77ad359b9ef58cb053c37d88a286440ff",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Distance_Joint-5583ed521efa-thumb.png",
+        "float_thumbnail": "float/Joints_Distance_Joint-5583ed521efa-thumb.png"
+      },
+      {
+        "sample": "Joints/Door",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Door-098cd82e95dd-0.png",
+              "pixel_sha256": "d9143295e53c2f76dc142f9bc0ea433892525e8dbec974ad299d16000f73df1c",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Door-098cd82e95dd-1.png",
+              "pixel_sha256": "d9143295e53c2f76dc142f9bc0ea433892525e8dbec974ad299d16000f73df1c",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Door-098cd82e95dd-0.png",
+              "pixel_sha256": "d9143295e53c2f76dc142f9bc0ea433892525e8dbec974ad299d16000f73df1c",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Door-098cd82e95dd-1.png",
+              "pixel_sha256": "d9143295e53c2f76dc142f9bc0ea433892525e8dbec974ad299d16000f73df1c",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Door-098cd82e95dd-thumb.png",
+        "float_thumbnail": "float/Joints_Door-098cd82e95dd-thumb.png"
+      },
+      {
+        "sample": "Joints/Driving",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Driving-3bc709ba0287-0.png",
+              "pixel_sha256": "4a8f5f97ea9093bf284f83f9002fa53036730f67d3e5c81e01ba058f71dbee9c",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Driving-3bc709ba0287-1.png",
+              "pixel_sha256": "4a8f5f97ea9093bf284f83f9002fa53036730f67d3e5c81e01ba058f71dbee9c",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Driving-3bc709ba0287-0.png",
+              "pixel_sha256": "4a8f5f97ea9093bf284f83f9002fa53036730f67d3e5c81e01ba058f71dbee9c",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Driving-3bc709ba0287-1.png",
+              "pixel_sha256": "4a8f5f97ea9093bf284f83f9002fa53036730f67d3e5c81e01ba058f71dbee9c",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Driving-3bc709ba0287-thumb.png",
+        "float_thumbnail": "float/Joints_Driving-3bc709ba0287-thumb.png"
+      },
+      {
+        "sample": "Joints/Filter",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Filter-48a5e9fe7a24-0.png",
+              "pixel_sha256": "76aee13b7d45545dbcb260337f3bf72cba63cbffe4c3707fd3a37adaf14fc829",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Filter-48a5e9fe7a24-1.png",
+              "pixel_sha256": "76aee13b7d45545dbcb260337f3bf72cba63cbffe4c3707fd3a37adaf14fc829",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Filter-48a5e9fe7a24-0.png",
+              "pixel_sha256": "76aee13b7d45545dbcb260337f3bf72cba63cbffe4c3707fd3a37adaf14fc829",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Filter-48a5e9fe7a24-1.png",
+              "pixel_sha256": "76aee13b7d45545dbcb260337f3bf72cba63cbffe4c3707fd3a37adaf14fc829",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Filter-48a5e9fe7a24-thumb.png",
+        "float_thumbnail": "float/Joints_Filter-48a5e9fe7a24-thumb.png"
+      },
+      {
+        "sample": "Joints/Gear Lift",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Gear_Lift-c5959c1c2f53-0.png",
+              "pixel_sha256": "d06db1c00d432c4f6ad073a26d13b9254bf8ac4fc9215bc6c788d8930682fb5c",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Gear_Lift-c5959c1c2f53-1.png",
+              "pixel_sha256": "d06db1c00d432c4f6ad073a26d13b9254bf8ac4fc9215bc6c788d8930682fb5c",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Gear_Lift-c5959c1c2f53-0.png",
+              "pixel_sha256": "d06db1c00d432c4f6ad073a26d13b9254bf8ac4fc9215bc6c788d8930682fb5c",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Gear_Lift-c5959c1c2f53-1.png",
+              "pixel_sha256": "d06db1c00d432c4f6ad073a26d13b9254bf8ac4fc9215bc6c788d8930682fb5c",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Gear_Lift-c5959c1c2f53-thumb.png",
+        "float_thumbnail": "float/Joints_Gear_Lift-c5959c1c2f53-thumb.png"
+      },
+      {
+        "sample": "Joints/Motion Locks",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Motion_Locks-c61733b12ea3-0.png",
+              "pixel_sha256": "0e97c91e801cd1d011ffaad5c846920f869af58d0091aeb10f8356fe12d32a24",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Motion_Locks-c61733b12ea3-1.png",
+              "pixel_sha256": "0e97c91e801cd1d011ffaad5c846920f869af58d0091aeb10f8356fe12d32a24",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Motion_Locks-c61733b12ea3-0.png",
+              "pixel_sha256": "0e97c91e801cd1d011ffaad5c846920f869af58d0091aeb10f8356fe12d32a24",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Motion_Locks-c61733b12ea3-1.png",
+              "pixel_sha256": "0e97c91e801cd1d011ffaad5c846920f869af58d0091aeb10f8356fe12d32a24",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Motion_Locks-c61733b12ea3-thumb.png",
+        "float_thumbnail": "float/Joints_Motion_Locks-c61733b12ea3-thumb.png"
+      },
+      {
+        "sample": "Joints/Motor Joint",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Motor_Joint-868ec4be5e8b-0.png",
+              "pixel_sha256": "e4094ab8ec57c6f0ef248d3e9efd0c955629b5d0c7e560a63f9e91609eef1477",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Motor_Joint-868ec4be5e8b-1.png",
+              "pixel_sha256": "e4094ab8ec57c6f0ef248d3e9efd0c955629b5d0c7e560a63f9e91609eef1477",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Motor_Joint-868ec4be5e8b-0.png",
+              "pixel_sha256": "e4094ab8ec57c6f0ef248d3e9efd0c955629b5d0c7e560a63f9e91609eef1477",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Motor_Joint-868ec4be5e8b-1.png",
+              "pixel_sha256": "e4094ab8ec57c6f0ef248d3e9efd0c955629b5d0c7e560a63f9e91609eef1477",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Motor_Joint-868ec4be5e8b-thumb.png",
+        "float_thumbnail": "float/Joints_Motor_Joint-868ec4be5e8b-thumb.png"
+      },
+      {
+        "sample": "Joints/Parallel Spring",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Parallel_Spring-7f32c3ef0cd1-0.png",
+              "pixel_sha256": "62a15f34cea73b733b83cd71cd78ddbc3d5bb0d6eae292e6e7d20f420c004cc8",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Parallel_Spring-7f32c3ef0cd1-1.png",
+              "pixel_sha256": "62a15f34cea73b733b83cd71cd78ddbc3d5bb0d6eae292e6e7d20f420c004cc8",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Parallel_Spring-7f32c3ef0cd1-0.png",
+              "pixel_sha256": "62a15f34cea73b733b83cd71cd78ddbc3d5bb0d6eae292e6e7d20f420c004cc8",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Parallel_Spring-7f32c3ef0cd1-1.png",
+              "pixel_sha256": "62a15f34cea73b733b83cd71cd78ddbc3d5bb0d6eae292e6e7d20f420c004cc8",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Parallel_Spring-7f32c3ef0cd1-thumb.png",
+        "float_thumbnail": "float/Joints_Parallel_Spring-7f32c3ef0cd1-thumb.png"
+      },
+      {
+        "sample": "Joints/Prismatic",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Prismatic-bf5747dbac19-0.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Prismatic-bf5747dbac19-1.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Prismatic-bf5747dbac19-0.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Prismatic-bf5747dbac19-1.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Prismatic-bf5747dbac19-thumb.png",
+        "float_thumbnail": "float/Joints_Prismatic-bf5747dbac19-thumb.png"
+      },
+      {
+        "sample": "Joints/Revolute",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Revolute-452789cf75e8-0.png",
+              "pixel_sha256": "6f2e38375e1871d7d578062bc87b837f04a8dad102ab2fb1a8615a42b8140179",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Revolute-452789cf75e8-1.png",
+              "pixel_sha256": "6f2e38375e1871d7d578062bc87b837f04a8dad102ab2fb1a8615a42b8140179",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Revolute-452789cf75e8-0.png",
+              "pixel_sha256": "6f2e38375e1871d7d578062bc87b837f04a8dad102ab2fb1a8615a42b8140179",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Revolute-452789cf75e8-1.png",
+              "pixel_sha256": "6f2e38375e1871d7d578062bc87b837f04a8dad102ab2fb1a8615a42b8140179",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Revolute-452789cf75e8-thumb.png",
+        "float_thumbnail": "float/Joints_Revolute-452789cf75e8-thumb.png"
+      },
+      {
+        "sample": "Joints/Spherical",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Spherical-a8058e2d9295-0.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Spherical-a8058e2d9295-1.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Spherical-a8058e2d9295-0.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Spherical-a8058e2d9295-1.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Spherical-a8058e2d9295-thumb.png",
+        "float_thumbnail": "float/Joints_Spherical-a8058e2d9295-thumb.png"
+      },
+      {
+        "sample": "Joints/Top Down Friction",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Top_Down_Friction-659f78e954b8-0.png",
+              "pixel_sha256": "f80d6ee44e9d0d1ac6eca5ae3e3d1989d26d222b049033deb550e04520d69b7f",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Top_Down_Friction-659f78e954b8-1.png",
+              "pixel_sha256": "f80d6ee44e9d0d1ac6eca5ae3e3d1989d26d222b049033deb550e04520d69b7f",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Top_Down_Friction-659f78e954b8-0.png",
+              "pixel_sha256": "f80d6ee44e9d0d1ac6eca5ae3e3d1989d26d222b049033deb550e04520d69b7f",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Top_Down_Friction-659f78e954b8-1.png",
+              "pixel_sha256": "f80d6ee44e9d0d1ac6eca5ae3e3d1989d26d222b049033deb550e04520d69b7f",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Top_Down_Friction-659f78e954b8-thumb.png",
+        "float_thumbnail": "float/Joints_Top_Down_Friction-659f78e954b8-thumb.png"
+      },
+      {
+        "sample": "Joints/Weld",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Weld-6500556cbe84-0.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Weld-6500556cbe84-1.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Weld-6500556cbe84-0.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Weld-6500556cbe84-1.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Weld-6500556cbe84-thumb.png",
+        "float_thumbnail": "float/Joints_Weld-6500556cbe84-thumb.png"
+      },
+      {
+        "sample": "Joints/Wheel",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Wheel-491be789035e-0.png",
+              "pixel_sha256": "daa34c5af43995dd80d3c21e570e7571fc2e9bfa058934059dc9543bccfaa70b",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Wheel-491be789035e-1.png",
+              "pixel_sha256": "daa34c5af43995dd80d3c21e570e7571fc2e9bfa058934059dc9543bccfaa70b",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Wheel-491be789035e-0.png",
+              "pixel_sha256": "daa34c5af43995dd80d3c21e570e7571fc2e9bfa058934059dc9543bccfaa70b",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Wheel-491be789035e-1.png",
+              "pixel_sha256": "daa34c5af43995dd80d3c21e570e7571fc2e9bfa058934059dc9543bccfaa70b",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Wheel-491be789035e-thumb.png",
+        "float_thumbnail": "float/Joints_Wheel-491be789035e-thumb.png"
+      },
+      {
+        "sample": "Stacking/Box Stack",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Stacking_Box_Stack-8f5eaf073c5e-0.png",
+              "pixel_sha256": "28aaa8686b52e698ac18cb06ca8f08e380dfefb28d57b707cb972322f209ed86",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Stacking_Box_Stack-8f5eaf073c5e-1.png",
+              "pixel_sha256": "28aaa8686b52e698ac18cb06ca8f08e380dfefb28d57b707cb972322f209ed86",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Stacking_Box_Stack-8f5eaf073c5e-0.png",
+              "pixel_sha256": "28aaa8686b52e698ac18cb06ca8f08e380dfefb28d57b707cb972322f209ed86",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Stacking_Box_Stack-8f5eaf073c5e-1.png",
+              "pixel_sha256": "28aaa8686b52e698ac18cb06ca8f08e380dfefb28d57b707cb972322f209ed86",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": true,
+        "mean_absolute_rgb_difference": 0.0,
+        "changed_pixel_percent": 0.0,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Stacking_Box_Stack-8f5eaf073c5e-thumb.png",
+        "float_thumbnail": "float/Stacking_Box_Stack-8f5eaf073c5e-thumb.png"
+      }
+    ]
+  },
+  "visual_float": {
+    "created_utc": "2026-09-07T22:04:17.397499+00:00",
+    "frames": 120,
+    "nominal_hz": 60,
+    "repeat": 2,
+    "match": "^(Joints/(?!Fold Out$)|Collision/(Shape Distance|Distance Debug)$|Stacking/Box Stack$|Determinism/Falling Ragdolls$)",
+    "no_axes": true,
+    "builds": {
+      "fixed": {
+        "binary_sha256": "b41b0bbbe498058ab9abc4baf4fd2f09d3d1f086ebc4c53d86b82ef6baf41149",
+        "samples": {
+          "Benchmark/Candy Cups": 0,
+          "Benchmark/Chains": 1,
+          "Benchmark/Convex Pile": 2,
+          "Benchmark/Destruction": 3,
+          "Benchmark/Explosion": 4,
+          "Benchmark/Falling Boxes": 5,
+          "Benchmark/Falling Trees": 6,
+          "Benchmark/Height Field": 7,
+          "Benchmark/Hull": 8,
+          "Benchmark/Joint Grid": 9,
+          "Benchmark/Junkyard": 10,
+          "Benchmark/Large Pyramid": 11,
+          "Benchmark/Large World": 12,
+          "Benchmark/Many Pyramids": 13,
+          "Benchmark/Rain": 14,
+          "Benchmark/Sensor": 15,
+          "Benchmark/Washer": 16,
+          "Benchmark/Wide Pyramid": 17,
+          "Bodies/Body Type": 18,
+          "Bodies/Cast": 19,
+          "Bodies/Disable": 20,
+          "Bodies/Fixed Rotation": 21,
+          "Bodies/Gyroscopic Precession": 22,
+          "Bodies/Gyroscopic Torque": 23,
+          "Bodies/Kinematic": 24,
+          "Bodies/Lock Mixing": 25,
+          "Bodies/Spinning Book": 26,
+          "Bodies/Weeble": 27,
+          "Character/CapsulePlane": 28,
+          "Character/Mover": 29,
+          "Character/MoverOverlap": 30,
+          "Character/Rigid Body": 31,
+          "Collision/Capsule Cast Ray": 32,
+          "Collision/Cast World": 33,
+          "Collision/Distance Debug": 34,
+          "Collision/Initial Overlap": 35,
+          "Collision/Long Ray Cast": 36,
+          "Collision/Mesh Scale": 37,
+          "Collision/Overlap World": 38,
+          "Collision/Ray Curtain": 39,
+          "Collision/Shape Cast": 40,
+          "Collision/Shape Cast Debug": 41,
+          "Collision/Shape Distance": 42,
+          "Collision/Time of Impact": 43,
+          "Compound/Hulls": 44,
+          "Compound/Mesh Tile": 45,
+          "Compound/Simple": 46,
+          "Compound/Spheres": 47,
+          "Compound/Tile Floor": 48,
+          "Compound/Village": 49,
+          "Continuous/Bounce House": 50,
+          "Continuous/Bullet vs Stack": 51,
+          "Continuous/Hump Mesh": 52,
+          "Continuous/Is Fast": 53,
+          "Continuous/Mesh Drop": 54,
+          "Continuous/Needle Mesh": 55,
+          "Continuous/Spinning Stick": 56,
+          "Continuous/Stall": 57,
+          "Continuous/Thin Wall": 58,
+          "Determinism/Falling Ragdolls": 59,
+          "Determinism/Mesh Drop": 60,
+          "Determinism/Query Spawn": 61,
+          "Determinism/Wave Pile": 62,
+          "Events/Hit": 63,
+          "Events/Joint": 64,
+          "Events/Move": 65,
+          "Events/Persistent Contact": 66,
+          "Events/Sensor Hits": 67,
+          "Events/Sensor Visit": 68,
+          "Geometry/Box Hull": 69,
+          "Geometry/Capsule Mass": 70,
+          "Geometry/Hull": 71,
+          "Geometry/Hull Reduction": 72,
+          "Geometry/Hull Transform": 73,
+          "Issues/Capsule Mesh": 74,
+          "Issues/Convex Jitter": 75,
+          "Issues/Crash": 76,
+          "Issues/GMod Wheel Stack": 77,
+          "Issues/Hull Crash": 78,
+          "Issues/Multiple Prismatic": 79,
+          "Issues/Restitution Overshoot": 80,
+          "Issues/Slide Twist Off Center Shape": 81,
+          "Issues/s&box Ghost Collisions": 82,
+          "Issues/s&box mover": 83,
+          "Joints/Ball and Chain": 84,
+          "Joints/Bridge": 85,
+          "Joints/Distance Joint": 86,
+          "Joints/Door": 87,
+          "Joints/Driving": 88,
+          "Joints/Filter": 89,
+          "Joints/Gear Lift": 90,
+          "Joints/Motion Locks": 91,
+          "Joints/Motor Joint": 92,
+          "Joints/Parallel Spring": 93,
+          "Joints/Prismatic": 94,
+          "Joints/Revolute": 95,
+          "Joints/Spherical": 96,
+          "Joints/Top Down Friction": 97,
+          "Joints/Weld": 98,
+          "Joints/Wheel": 99,
+          "Manifold/Capsule vs Capsule": 100,
+          "Manifold/Capsule vs Hull": 101,
+          "Manifold/Capsule vs Sphere": 102,
+          "Manifold/Hull vs Hull": 103,
+          "Manifold/Hull vs Sphere": 104,
+          "Manifold/Sphere vs Sphere": 105,
+          "Manifold/Triangle vs Capsule": 106,
+          "Manifold/Triangle vs Hull": 107,
+          "Manifold/Triangle vs Sphere": 108,
+          "Mesh/Big Box": 109,
+          "Mesh/Box": 110,
+          "Mesh/Creation Benchmark": 111,
+          "Mesh/Grid": 112,
+          "Mesh/Height Field": 113,
+          "Mesh/Hollow Box": 114,
+          "Mesh/Reflection": 115,
+          "Mesh/Viewer": 116,
+          "Mesh/Voxel": 117,
+          "Ragdoll/Box": 118,
+          "Ragdoll/Incline": 119,
+          "Ragdoll/Mesh": 120,
+          "Ragdoll/Pile": 121,
+          "Replay/Viewer": 122,
+          "Robustness/HighMassRatio1": 123,
+          "Robustness/Overflow Color Pile": 124,
+          "Robustness/Overlap Recovery": 125,
+          "Robustness/Tiny Pyramid": 126,
+          "Shapes/Conveyor Belt": 127,
+          "Shapes/Conveyor Mesh": 128,
+          "Shapes/High Resistance": 129,
+          "Shapes/Inclined Plane": 130,
+          "Shapes/Isotropic Friction": 131,
+          "Shapes/Restitution": 132,
+          "Shapes/Rolling Resistance": 133,
+          "Shapes/Slide Twist": 134,
+          "Shapes/Static Invoke": 135,
+          "Shapes/Wind": 136,
+          "Shapes/Wind Drop": 137,
+          "Shapes/Wind Flap": 138,
+          "Stacking/Arch": 139,
+          "Stacking/Box Stack": 140,
+          "Stacking/Capsule Stack": 141,
+          "Stacking/Card House": 142,
+          "Stacking/Cylinder": 143,
+          "Stacking/Cylinder Stack": 144,
+          "Stacking/Dominoes": 145,
+          "Stacking/Double Domino": 146,
+          "Stacking/Edge Crossing": 147,
+          "Stacking/Jenga Stack": 148,
+          "Stacking/Pyramid2D": 149,
+          "Stacking/Single Box": 150,
+          "Stacking/Sphere Stack": 151,
+          "Stacking/Wedge": 152,
+          "Tree/Benchmark": 153,
+          "World/Far Mesh Drop": 154,
+          "World/Far Pyramid": 155,
+          "World/Far Ragdolls": 156,
+          "World/Far Stack": 157
+        }
+      },
+      "float": {
+        "binary_sha256": "1790e067c3150bb1713c1a13edbafd2f5c6fee5fcc036ada2b715c7795c21bb8",
+        "samples": {
+          "Benchmark/Candy Cups": 0,
+          "Benchmark/Chains": 1,
+          "Benchmark/Convex Pile": 2,
+          "Benchmark/Destruction": 3,
+          "Benchmark/Explosion": 4,
+          "Benchmark/Falling Boxes": 5,
+          "Benchmark/Falling Trees": 6,
+          "Benchmark/Height Field": 7,
+          "Benchmark/Hull": 8,
+          "Benchmark/Joint Grid": 9,
+          "Benchmark/Junkyard": 10,
+          "Benchmark/Large Pyramid": 11,
+          "Benchmark/Large World": 12,
+          "Benchmark/Many Pyramids": 13,
+          "Benchmark/Rain": 14,
+          "Benchmark/Sensor": 15,
+          "Benchmark/Washer": 16,
+          "Benchmark/Wide Pyramid": 17,
+          "Bodies/Body Type": 18,
+          "Bodies/Cast": 19,
+          "Bodies/Class Ring": 20,
+          "Bodies/Disable": 21,
+          "Bodies/Fixed Rotation": 22,
+          "Bodies/Gyroscopic Precession": 23,
+          "Bodies/Gyroscopic Torque": 24,
+          "Bodies/Kinematic": 25,
+          "Bodies/Lock Mixing": 26,
+          "Bodies/Offset Kinematic": 27,
+          "Bodies/Spinning Book": 28,
+          "Bodies/Weeble": 29,
+          "Character/CapsulePlane": 30,
+          "Character/Geometric Mover": 31,
+          "Character/MoverOverlap": 32,
+          "Character/Rigid Body": 33,
+          "Collision/Capsule Cast Ray": 34,
+          "Collision/Cast World": 35,
+          "Collision/Distance Debug": 36,
+          "Collision/Initial Overlap": 37,
+          "Collision/Long Ray Cast": 38,
+          "Collision/Mesh Scale": 39,
+          "Collision/Overlap World": 40,
+          "Collision/Ray Curtain": 41,
+          "Collision/Shape Cast": 42,
+          "Collision/Shape Cast Debug": 43,
+          "Collision/Shape Distance": 44,
+          "Collision/Time of Impact": 45,
+          "Compound/Hulls": 46,
+          "Compound/Mesh Tile": 47,
+          "Compound/Simple": 48,
+          "Compound/Spheres": 49,
+          "Compound/Tile Floor": 50,
+          "Compound/Village": 51,
+          "Continuous/Bounce House": 52,
+          "Continuous/Bullet vs Stack": 53,
+          "Continuous/Hump Mesh": 54,
+          "Continuous/Is Fast": 55,
+          "Continuous/Mesh Drop": 56,
+          "Continuous/Needle Mesh": 57,
+          "Continuous/Spinning Stick": 58,
+          "Continuous/Stall": 59,
+          "Continuous/Thin Wall": 60,
+          "Determinism/Falling Ragdolls": 61,
+          "Determinism/Mesh Drop": 62,
+          "Determinism/Query Spawn": 63,
+          "Determinism/Wave Pile": 64,
+          "Events/Contact": 65,
+          "Events/Hit": 66,
+          "Events/Joint": 67,
+          "Events/Move": 68,
+          "Events/Persistent Contact": 69,
+          "Events/Sensor Hits": 70,
+          "Events/Sensor Visit": 71,
+          "Geometry/Box Hull": 72,
+          "Geometry/Capsule Mass": 73,
+          "Geometry/Hull": 74,
+          "Geometry/Hull Reduction": 75,
+          "Geometry/Hull Transform": 76,
+          "Issues/Capsule Mesh": 77,
+          "Issues/Convex Jitter": 78,
+          "Issues/Crash": 79,
+          "Issues/GMod Wheel Stack": 80,
+          "Issues/Heightfield": 81,
+          "Issues/Huge Box": 82,
+          "Issues/Hull Crash": 83,
+          "Issues/Multiple Prismatic": 84,
+          "Issues/Restitution Overshoot": 85,
+          "Issues/Slide Twist Off Center Shape": 86,
+          "Issues/s&box Ghost Collisions": 87,
+          "Issues/s&box mover": 88,
+          "Joints/Ball and Chain": 89,
+          "Joints/Bridge": 90,
+          "Joints/Distance Joint": 91,
+          "Joints/Door": 92,
+          "Joints/Driving": 93,
+          "Joints/Filter": 94,
+          "Joints/Fold Out": 95,
+          "Joints/Gear Lift": 96,
+          "Joints/Motion Locks": 97,
+          "Joints/Motor Joint": 98,
+          "Joints/Parallel Spring": 99,
+          "Joints/Prismatic": 100,
+          "Joints/Revolute": 101,
+          "Joints/Spherical": 102,
+          "Joints/Top Down Friction": 103,
+          "Joints/Weld": 104,
+          "Joints/Wheel": 105,
+          "Manifold/Capsule vs Capsule": 106,
+          "Manifold/Capsule vs Hull": 107,
+          "Manifold/Capsule vs Sphere": 108,
+          "Manifold/Hull vs Hull": 109,
+          "Manifold/Hull vs Sphere": 110,
+          "Manifold/Sphere vs Sphere": 111,
+          "Manifold/Triangle vs Capsule": 112,
+          "Manifold/Triangle vs Hull": 113,
+          "Manifold/Triangle vs Sphere": 114,
+          "Mesh/Big Box": 115,
+          "Mesh/Box": 116,
+          "Mesh/Creation Benchmark": 117,
+          "Mesh/Grid": 118,
+          "Mesh/Height Field": 119,
+          "Mesh/Hollow Box": 120,
+          "Mesh/Reflection": 121,
+          "Mesh/Viewer": 122,
+          "Mesh/Voxel": 123,
+          "Ragdoll/Box": 124,
+          "Ragdoll/Incline": 125,
+          "Ragdoll/Mesh": 126,
+          "Ragdoll/Pile": 127,
+          "Replay/Viewer": 128,
+          "Robustness/HighMassRatio1": 129,
+          "Robustness/Overflow Color Pile": 130,
+          "Robustness/Overlap Recovery": 131,
+          "Robustness/Tiny Pyramid": 132,
+          "Shapes/Conveyor Belt": 133,
+          "Shapes/Conveyor Mesh": 134,
+          "Shapes/High Resistance": 135,
+          "Shapes/Inclined Plane": 136,
+          "Shapes/Isotropic Friction": 137,
+          "Shapes/Restitution": 138,
+          "Shapes/Rolling Resistance": 139,
+          "Shapes/Slide Twist": 140,
+          "Shapes/Static Invoke": 141,
+          "Shapes/Wind": 142,
+          "Shapes/Wind Drop": 143,
+          "Shapes/Wind Flap": 144,
+          "Stacking/Arch": 145,
+          "Stacking/Box Stack": 146,
+          "Stacking/Capsule Stack": 147,
+          "Stacking/Card House": 148,
+          "Stacking/Cylinder": 149,
+          "Stacking/Cylinder Stack": 150,
+          "Stacking/Dominoes": 151,
+          "Stacking/Double Domino": 152,
+          "Stacking/Edge Crossing": 153,
+          "Stacking/Jenga Stack": 154,
+          "Stacking/Pyramid2D": 155,
+          "Stacking/Single Box": 156,
+          "Stacking/Sphere Stack": 157,
+          "Stacking/Wedge": 158,
+          "Tree/Benchmark": 159,
+          "World/Far Mesh Drop": 160,
+          "World/Far Pyramid": 161,
+          "World/Far Ragdolls": 162,
+          "World/Far Stack": 163
+        }
+      }
+    },
+    "pixel_hash": "SHA256 of ASCII RGBA:WIDTHxHEIGHT followed by NUL and decoded RGBA bytes",
+    "rows": [
+      {
+        "sample": "Collision/Distance Debug",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Collision_Distance_Debug-67957c757033-0.png",
+              "pixel_sha256": "c2efb9df2a8a59212e25b2c48f2039cf0321e0a27168fbbddc0f0e3def136c6e",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Collision_Distance_Debug-67957c757033-1.png",
+              "pixel_sha256": "c2efb9df2a8a59212e25b2c48f2039cf0321e0a27168fbbddc0f0e3def136c6e",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Collision_Distance_Debug-67957c757033-0.png",
+              "pixel_sha256": "df58925bd0912110d82f037726933c571cdc9ac3877dc2b16e11b6c1598db305",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Collision_Distance_Debug-67957c757033-1.png",
+              "pixel_sha256": "df58925bd0912110d82f037726933c571cdc9ac3877dc2b16e11b6c1598db305",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": false,
+        "mean_absolute_rgb_difference": 0.008345349472736624,
+        "changed_pixel_percent": 1.2003882137345712,
+        "mean_luminance_difference_64x36": 0.0008680555555555555,
+        "fixed_thumbnail": "fixed/Collision_Distance_Debug-67957c757033-thumb.png",
+        "float_thumbnail": "float/Collision_Distance_Debug-67957c757033-thumb.png"
+      },
+      {
+        "sample": "Collision/Shape Distance",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Collision_Shape_Distance-1efae0869794-0.png",
+              "pixel_sha256": "163cefe5ee4bde624ec79301a89dd8fec266f59d7c793e228aecc0943bd93834",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Collision_Shape_Distance-1efae0869794-1.png",
+              "pixel_sha256": "163cefe5ee4bde624ec79301a89dd8fec266f59d7c793e228aecc0943bd93834",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Collision_Shape_Distance-1efae0869794-0.png",
+              "pixel_sha256": "3b65990f349b988861a9e882722f0f5107866d16ed7abeb41df967827e7084a0",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Collision_Shape_Distance-1efae0869794-1.png",
+              "pixel_sha256": "3b65990f349b988861a9e882722f0f5107866d16ed7abeb41df967827e7084a0",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": false,
+        "mean_absolute_rgb_difference": 0.0013246688528806584,
+        "changed_pixel_percent": 0.20953896604938294,
+        "mean_luminance_difference_64x36": 0.00043402777777777775,
+        "fixed_thumbnail": "fixed/Collision_Shape_Distance-1efae0869794-thumb.png",
+        "float_thumbnail": "float/Collision_Shape_Distance-1efae0869794-thumb.png"
+      },
+      {
+        "sample": "Determinism/Falling Ragdolls",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Determinism_Falling_Ragdolls-1278b0375383-0.png",
+              "pixel_sha256": "6c45500976867ff315314530a73f1c3060728e1e86c8acfd1132525efede766c",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Determinism_Falling_Ragdolls-1278b0375383-1.png",
+              "pixel_sha256": "6c45500976867ff315314530a73f1c3060728e1e86c8acfd1132525efede766c",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Determinism_Falling_Ragdolls-1278b0375383-0.png",
+              "pixel_sha256": "1aa7bb8bae2213969d82440ad225028a02fa36afdfeacbbf85feba4a76c1ceb7",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Determinism_Falling_Ragdolls-1278b0375383-1.png",
+              "pixel_sha256": "1aa7bb8bae2213969d82440ad225028a02fa36afdfeacbbf85feba4a76c1ceb7",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": false,
+        "mean_absolute_rgb_difference": 0.4173740113811728,
+        "changed_pixel_percent": 1.8416039737654266,
+        "mean_luminance_difference_64x36": 0.2209201388888889,
+        "fixed_thumbnail": "fixed/Determinism_Falling_Ragdolls-1278b0375383-thumb.png",
+        "float_thumbnail": "float/Determinism_Falling_Ragdolls-1278b0375383-thumb.png"
+      },
+      {
+        "sample": "Joints/Ball and Chain",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Ball_and_Chain-aa4a237dd0eb-0.png",
+              "pixel_sha256": "05414d397b19f3818b2b30e7150404d29e49fe679d1867077d14baf587fc6a89",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Ball_and_Chain-aa4a237dd0eb-1.png",
+              "pixel_sha256": "05414d397b19f3818b2b30e7150404d29e49fe679d1867077d14baf587fc6a89",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Ball_and_Chain-aa4a237dd0eb-0.png",
+              "pixel_sha256": "f56839e3f477d57141e1b715a1bdf34dcd96224df1f91766720b58a5e2a703db",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Ball_and_Chain-aa4a237dd0eb-1.png",
+              "pixel_sha256": "f56839e3f477d57141e1b715a1bdf34dcd96224df1f91766720b58a5e2a703db",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": false,
+        "mean_absolute_rgb_difference": 0.017110781571502056,
+        "changed_pixel_percent": 0.5363980516975286,
+        "mean_luminance_difference_64x36": 0.003472222222222222,
+        "fixed_thumbnail": "fixed/Joints_Ball_and_Chain-aa4a237dd0eb-thumb.png",
+        "float_thumbnail": "float/Joints_Ball_and_Chain-aa4a237dd0eb-thumb.png"
+      },
+      {
+        "sample": "Joints/Bridge",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Bridge-87a11cde2063-0.png",
+              "pixel_sha256": "2f00f9b401f3788fe9cee5550e08e2ecf50c4f0d746c9e13fa369aa99750ecf9",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Bridge-87a11cde2063-1.png",
+              "pixel_sha256": "2f00f9b401f3788fe9cee5550e08e2ecf50c4f0d746c9e13fa369aa99750ecf9",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Bridge-87a11cde2063-0.png",
+              "pixel_sha256": "d7879aa25e99f1e5e5e8a3ca35a83f91dedf2be8c85048019b315f36bcc03ed4",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Bridge-87a11cde2063-1.png",
+              "pixel_sha256": "d7879aa25e99f1e5e5e8a3ca35a83f91dedf2be8c85048019b315f36bcc03ed4",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": false,
+        "mean_absolute_rgb_difference": 0.15525696051954732,
+        "changed_pixel_percent": 5.377748842592589,
+        "mean_luminance_difference_64x36": 0.045572916666666664,
+        "fixed_thumbnail": "fixed/Joints_Bridge-87a11cde2063-thumb.png",
+        "float_thumbnail": "float/Joints_Bridge-87a11cde2063-thumb.png"
+      },
+      {
+        "sample": "Joints/Distance Joint",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Distance_Joint-5583ed521efa-0.png",
+              "pixel_sha256": "77961532f714e0538b52a22e1ad79ff77ad359b9ef58cb053c37d88a286440ff",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Distance_Joint-5583ed521efa-1.png",
+              "pixel_sha256": "77961532f714e0538b52a22e1ad79ff77ad359b9ef58cb053c37d88a286440ff",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Distance_Joint-5583ed521efa-0.png",
+              "pixel_sha256": "a3b25cc642aea63d67db3adfbdf56e8de784ad0d1c4bbf3d693bd8aa7fca4ca3",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Distance_Joint-5583ed521efa-1.png",
+              "pixel_sha256": "a3b25cc642aea63d67db3adfbdf56e8de784ad0d1c4bbf3d693bd8aa7fca4ca3",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": false,
+        "mean_absolute_rgb_difference": 0.0004031233924897119,
+        "changed_pixel_percent": 0.03439670138888351,
+        "mean_luminance_difference_64x36": 0.0,
+        "fixed_thumbnail": "fixed/Joints_Distance_Joint-5583ed521efa-thumb.png",
+        "float_thumbnail": "float/Joints_Distance_Joint-5583ed521efa-thumb.png"
+      },
+      {
+        "sample": "Joints/Door",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Door-098cd82e95dd-0.png",
+              "pixel_sha256": "d9143295e53c2f76dc142f9bc0ea433892525e8dbec974ad299d16000f73df1c",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Door-098cd82e95dd-1.png",
+              "pixel_sha256": "d9143295e53c2f76dc142f9bc0ea433892525e8dbec974ad299d16000f73df1c",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Door-098cd82e95dd-0.png",
+              "pixel_sha256": "2c4c800bd5cc9d1ea3ad5b984ed279503b381c96d1d9353c52ccd068d399b032",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Door-098cd82e95dd-1.png",
+              "pixel_sha256": "2c4c800bd5cc9d1ea3ad5b984ed279503b381c96d1d9353c52ccd068d399b032",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": false,
+        "mean_absolute_rgb_difference": 0.012743899498456791,
+        "changed_pixel_percent": 1.8916136188271593,
+        "mean_luminance_difference_64x36": 0.004340277777777778,
+        "fixed_thumbnail": "fixed/Joints_Door-098cd82e95dd-thumb.png",
+        "float_thumbnail": "float/Joints_Door-098cd82e95dd-thumb.png"
+      },
+      {
+        "sample": "Joints/Driving",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Driving-3bc709ba0287-0.png",
+              "pixel_sha256": "4a8f5f97ea9093bf284f83f9002fa53036730f67d3e5c81e01ba058f71dbee9c",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Driving-3bc709ba0287-1.png",
+              "pixel_sha256": "4a8f5f97ea9093bf284f83f9002fa53036730f67d3e5c81e01ba058f71dbee9c",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Driving-3bc709ba0287-0.png",
+              "pixel_sha256": "8d0a786305faf12e402fa7a11a8a85fd7212a46edac60af74bb702841446c158",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Driving-3bc709ba0287-1.png",
+              "pixel_sha256": "8d0a786305faf12e402fa7a11a8a85fd7212a46edac60af74bb702841446c158",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": false,
+        "mean_absolute_rgb_difference": 0.32033854166666664,
+        "changed_pixel_percent": 22.123697916666664,
+        "mean_luminance_difference_64x36": 0.20616319444444445,
+        "fixed_thumbnail": "fixed/Joints_Driving-3bc709ba0287-thumb.png",
+        "float_thumbnail": "float/Joints_Driving-3bc709ba0287-thumb.png"
+      },
+      {
+        "sample": "Joints/Filter",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Filter-48a5e9fe7a24-0.png",
+              "pixel_sha256": "76aee13b7d45545dbcb260337f3bf72cba63cbffe4c3707fd3a37adaf14fc829",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Filter-48a5e9fe7a24-1.png",
+              "pixel_sha256": "76aee13b7d45545dbcb260337f3bf72cba63cbffe4c3707fd3a37adaf14fc829",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Filter-48a5e9fe7a24-0.png",
+              "pixel_sha256": "a0c8510caae93256d1212df70921c9007a51aef6266fa7ed496b18493f3f5c1e",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Filter-48a5e9fe7a24-1.png",
+              "pixel_sha256": "a0c8510caae93256d1212df70921c9007a51aef6266fa7ed496b18493f3f5c1e",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": false,
+        "mean_absolute_rgb_difference": 0.013724681712962964,
+        "changed_pixel_percent": 1.9721498842592555,
+        "mean_luminance_difference_64x36": 0.006076388888888889,
+        "fixed_thumbnail": "fixed/Joints_Filter-48a5e9fe7a24-thumb.png",
+        "float_thumbnail": "float/Joints_Filter-48a5e9fe7a24-thumb.png"
+      },
+      {
+        "sample": "Joints/Gear Lift",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Gear_Lift-c5959c1c2f53-0.png",
+              "pixel_sha256": "d06db1c00d432c4f6ad073a26d13b9254bf8ac4fc9215bc6c788d8930682fb5c",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Gear_Lift-c5959c1c2f53-1.png",
+              "pixel_sha256": "d06db1c00d432c4f6ad073a26d13b9254bf8ac4fc9215bc6c788d8930682fb5c",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Gear_Lift-c5959c1c2f53-0.png",
+              "pixel_sha256": "de119c52a7ec604499ce7e58467f7dc4a3ef3a887c6bbdb4f73a62c4f3a52d83",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Gear_Lift-c5959c1c2f53-1.png",
+              "pixel_sha256": "de119c52a7ec604499ce7e58467f7dc4a3ef3a887c6bbdb4f73a62c4f3a52d83",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": false,
+        "mean_absolute_rgb_difference": 1.2052471948945473,
+        "changed_pixel_percent": 5.7177010995370425,
+        "mean_luminance_difference_64x36": 0.5946180555555556,
+        "fixed_thumbnail": "fixed/Joints_Gear_Lift-c5959c1c2f53-thumb.png",
+        "float_thumbnail": "float/Joints_Gear_Lift-c5959c1c2f53-thumb.png"
+      },
+      {
+        "sample": "Joints/Motion Locks",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Motion_Locks-c61733b12ea3-0.png",
+              "pixel_sha256": "0e97c91e801cd1d011ffaad5c846920f869af58d0091aeb10f8356fe12d32a24",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Motion_Locks-c61733b12ea3-1.png",
+              "pixel_sha256": "0e97c91e801cd1d011ffaad5c846920f869af58d0091aeb10f8356fe12d32a24",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Motion_Locks-c61733b12ea3-0.png",
+              "pixel_sha256": "f983f87df296c23c28d0cdd19c10d48764a16c8d895e5eec96e0d14a3d15c4ac",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Motion_Locks-c61733b12ea3-1.png",
+              "pixel_sha256": "f983f87df296c23c28d0cdd19c10d48764a16c8d895e5eec96e0d14a3d15c4ac",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": false,
+        "mean_absolute_rgb_difference": 0.06999557934670782,
+        "changed_pixel_percent": 2.110303337191355,
+        "mean_luminance_difference_64x36": 0.059027777777777776,
+        "fixed_thumbnail": "fixed/Joints_Motion_Locks-c61733b12ea3-thumb.png",
+        "float_thumbnail": "float/Joints_Motion_Locks-c61733b12ea3-thumb.png"
+      },
+      {
+        "sample": "Joints/Motor Joint",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Motor_Joint-868ec4be5e8b-0.png",
+              "pixel_sha256": "e4094ab8ec57c6f0ef248d3e9efd0c955629b5d0c7e560a63f9e91609eef1477",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Motor_Joint-868ec4be5e8b-1.png",
+              "pixel_sha256": "e4094ab8ec57c6f0ef248d3e9efd0c955629b5d0c7e560a63f9e91609eef1477",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Motor_Joint-868ec4be5e8b-0.png",
+              "pixel_sha256": "906822a5a1390f2f85b542dbb46433212233764edc075ff0c1ed7f1e125da5bf",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Motor_Joint-868ec4be5e8b-1.png",
+              "pixel_sha256": "906822a5a1390f2f85b542dbb46433212233764edc075ff0c1ed7f1e125da5bf",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": false,
+        "mean_absolute_rgb_difference": 0.0036596579218106996,
+        "changed_pixel_percent": 0.054205246913585636,
+        "mean_luminance_difference_64x36": 0.001736111111111111,
+        "fixed_thumbnail": "fixed/Joints_Motor_Joint-868ec4be5e8b-thumb.png",
+        "float_thumbnail": "float/Joints_Motor_Joint-868ec4be5e8b-thumb.png"
+      },
+      {
+        "sample": "Joints/Parallel Spring",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Parallel_Spring-7f32c3ef0cd1-0.png",
+              "pixel_sha256": "62a15f34cea73b733b83cd71cd78ddbc3d5bb0d6eae292e6e7d20f420c004cc8",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Parallel_Spring-7f32c3ef0cd1-1.png",
+              "pixel_sha256": "62a15f34cea73b733b83cd71cd78ddbc3d5bb0d6eae292e6e7d20f420c004cc8",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Parallel_Spring-7f32c3ef0cd1-0.png",
+              "pixel_sha256": "a652faf0de4e2f6b5740330ee6a0e405f4b3877d3f083fc9921d65543b7e585d",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Parallel_Spring-7f32c3ef0cd1-1.png",
+              "pixel_sha256": "a652faf0de4e2f6b5740330ee6a0e405f4b3877d3f083fc9921d65543b7e585d",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": false,
+        "mean_absolute_rgb_difference": 0.02560936696244856,
+        "changed_pixel_percent": 2.1588541666666683,
+        "mean_luminance_difference_64x36": 0.015190972222222222,
+        "fixed_thumbnail": "fixed/Joints_Parallel_Spring-7f32c3ef0cd1-thumb.png",
+        "float_thumbnail": "float/Joints_Parallel_Spring-7f32c3ef0cd1-thumb.png"
+      },
+      {
+        "sample": "Joints/Prismatic",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Prismatic-bf5747dbac19-0.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Prismatic-bf5747dbac19-1.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Prismatic-bf5747dbac19-0.png",
+              "pixel_sha256": "5bf4f700e5a3e74deb47296a3489563f585744508241c58395a22bb97a180202",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Prismatic-bf5747dbac19-1.png",
+              "pixel_sha256": "5bf4f700e5a3e74deb47296a3489563f585744508241c58395a22bb97a180202",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": false,
+        "mean_absolute_rgb_difference": 0.015264716756687243,
+        "changed_pixel_percent": 1.8878761574074088,
+        "mean_luminance_difference_64x36": 0.006510416666666667,
+        "fixed_thumbnail": "fixed/Joints_Prismatic-bf5747dbac19-thumb.png",
+        "float_thumbnail": "float/Joints_Prismatic-bf5747dbac19-thumb.png"
+      },
+      {
+        "sample": "Joints/Revolute",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Revolute-452789cf75e8-0.png",
+              "pixel_sha256": "6f2e38375e1871d7d578062bc87b837f04a8dad102ab2fb1a8615a42b8140179",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Revolute-452789cf75e8-1.png",
+              "pixel_sha256": "6f2e38375e1871d7d578062bc87b837f04a8dad102ab2fb1a8615a42b8140179",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Revolute-452789cf75e8-0.png",
+              "pixel_sha256": "eccd2ff58ae1efcd92f69b8c933872682899f513bdedeea13de12c63665369b6",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Revolute-452789cf75e8-1.png",
+              "pixel_sha256": "eccd2ff58ae1efcd92f69b8c933872682899f513bdedeea13de12c63665369b6",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": false,
+        "mean_absolute_rgb_difference": 0.015258728780864197,
+        "changed_pixel_percent": 1.8890335648148127,
+        "mean_luminance_difference_64x36": 0.006510416666666667,
+        "fixed_thumbnail": "fixed/Joints_Revolute-452789cf75e8-thumb.png",
+        "float_thumbnail": "float/Joints_Revolute-452789cf75e8-thumb.png"
+      },
+      {
+        "sample": "Joints/Spherical",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Spherical-a8058e2d9295-0.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Spherical-a8058e2d9295-1.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Spherical-a8058e2d9295-0.png",
+              "pixel_sha256": "5bf4f700e5a3e74deb47296a3489563f585744508241c58395a22bb97a180202",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Spherical-a8058e2d9295-1.png",
+              "pixel_sha256": "5bf4f700e5a3e74deb47296a3489563f585744508241c58395a22bb97a180202",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": false,
+        "mean_absolute_rgb_difference": 0.015264716756687243,
+        "changed_pixel_percent": 1.8878761574074088,
+        "mean_luminance_difference_64x36": 0.006510416666666667,
+        "fixed_thumbnail": "fixed/Joints_Spherical-a8058e2d9295-thumb.png",
+        "float_thumbnail": "float/Joints_Spherical-a8058e2d9295-thumb.png"
+      },
+      {
+        "sample": "Joints/Top Down Friction",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Top_Down_Friction-659f78e954b8-0.png",
+              "pixel_sha256": "f80d6ee44e9d0d1ac6eca5ae3e3d1989d26d222b049033deb550e04520d69b7f",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Top_Down_Friction-659f78e954b8-1.png",
+              "pixel_sha256": "f80d6ee44e9d0d1ac6eca5ae3e3d1989d26d222b049033deb550e04520d69b7f",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Top_Down_Friction-659f78e954b8-0.png",
+              "pixel_sha256": "73a794437132bd5e6c90260aecb7a246c8ada7dfe01c2d16768c9ac8f91d082b",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Top_Down_Friction-659f78e954b8-1.png",
+              "pixel_sha256": "73a794437132bd5e6c90260aecb7a246c8ada7dfe01c2d16768c9ac8f91d082b",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": false,
+        "mean_absolute_rgb_difference": 0.0567847382973251,
+        "changed_pixel_percent": 0.5552662037037082,
+        "mean_luminance_difference_64x36": 0.05946180555555555,
+        "fixed_thumbnail": "fixed/Joints_Top_Down_Friction-659f78e954b8-thumb.png",
+        "float_thumbnail": "float/Joints_Top_Down_Friction-659f78e954b8-thumb.png"
+      },
+      {
+        "sample": "Joints/Weld",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Weld-6500556cbe84-0.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Weld-6500556cbe84-1.png",
+              "pixel_sha256": "e3d22889461d941c34fb30419a35eeb1a1b56eddb92f3eb52f34668c94b6983a",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Weld-6500556cbe84-0.png",
+              "pixel_sha256": "5bf4f700e5a3e74deb47296a3489563f585744508241c58395a22bb97a180202",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Weld-6500556cbe84-1.png",
+              "pixel_sha256": "5bf4f700e5a3e74deb47296a3489563f585744508241c58395a22bb97a180202",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": false,
+        "mean_absolute_rgb_difference": 0.015264716756687243,
+        "changed_pixel_percent": 1.8878761574074088,
+        "mean_luminance_difference_64x36": 0.006510416666666667,
+        "fixed_thumbnail": "fixed/Joints_Weld-6500556cbe84-thumb.png",
+        "float_thumbnail": "float/Joints_Weld-6500556cbe84-thumb.png"
+      },
+      {
+        "sample": "Joints/Wheel",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Joints_Wheel-491be789035e-0.png",
+              "pixel_sha256": "daa34c5af43995dd80d3c21e570e7571fc2e9bfa058934059dc9543bccfaa70b",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Joints_Wheel-491be789035e-1.png",
+              "pixel_sha256": "daa34c5af43995dd80d3c21e570e7571fc2e9bfa058934059dc9543bccfaa70b",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Joints_Wheel-491be789035e-0.png",
+              "pixel_sha256": "a2051eab743384d56cf7f960817becc0131e5dcf5aa4bf6f64e2b74a4efe8bd4",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Joints_Wheel-491be789035e-1.png",
+              "pixel_sha256": "a2051eab743384d56cf7f960817becc0131e5dcf5aa4bf6f64e2b74a4efe8bd4",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": false,
+        "mean_absolute_rgb_difference": 0.02378126607510288,
+        "changed_pixel_percent": 1.7935353973765444,
+        "mean_luminance_difference_64x36": 0.020833333333333332,
+        "fixed_thumbnail": "fixed/Joints_Wheel-491be789035e-thumb.png",
+        "float_thumbnail": "float/Joints_Wheel-491be789035e-thumb.png"
+      },
+      {
+        "sample": "Stacking/Box Stack",
+        "captures": {
+          "fixed": [
+            {
+              "png": "fixed/Stacking_Box_Stack-8f5eaf073c5e-0.png",
+              "pixel_sha256": "28aaa8686b52e698ac18cb06ca8f08e380dfefb28d57b707cb972322f209ed86",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "fixed/Stacking_Box_Stack-8f5eaf073c5e-1.png",
+              "pixel_sha256": "28aaa8686b52e698ac18cb06ca8f08e380dfefb28d57b707cb972322f209ed86",
+              "width": 3840,
+              "height": 2160
+            }
+          ],
+          "float": [
+            {
+              "png": "float/Stacking_Box_Stack-8f5eaf073c5e-0.png",
+              "pixel_sha256": "b3f9ab2937765b2916543b2c2a91789e2daa075c829209218a121c2a908642b6",
+              "width": 3840,
+              "height": 2160
+            },
+            {
+              "png": "float/Stacking_Box_Stack-8f5eaf073c5e-1.png",
+              "pixel_sha256": "b3f9ab2937765b2916543b2c2a91789e2daa075c829209218a121c2a908642b6",
+              "width": 3840,
+              "height": 2160
+            }
+          ]
+        },
+        "errors": [],
+        "exact_pixel_match": false,
+        "mean_absolute_rgb_difference": 0.07667418177726337,
+        "changed_pixel_percent": 3.56493537808642,
+        "mean_luminance_difference_64x36": 0.03428819444444445,
+        "fixed_thumbnail": "fixed/Stacking_Box_Stack-8f5eaf073c5e-thumb.png",
+        "float_thumbnail": "float/Stacking_Box_Stack-8f5eaf073c5e-thumb.png"
+      }
+    ]
+  },
+  "nonzero_solve_source_proof": {
+    "base": "14bf27af0dfcc0649346e08b1129833a7e690c01",
+    "implementation": "8f52c1898dc0c26c009b9f5c16554587d1448c26",
+    "nonzero_solve_body_byte_identical": true,
+    "nonzero_solve_body_sha256": "3d006ea8c88a064d42db8ffb7b342de58a2afe6189e3886c5fe30798eacced08"
+  },
+  "configuration": "Apple M3 Ultra, macOS 26.6.2, Apple Clang 21.0.0, arm64, RelWithDebInfo/O2, thin LTO, four workers; scalar defaults and optional NEON; continuous collision on.",
+  "caution": "Shared workstation. Small timing differences are inconclusive. The fixed library repair changes trajectories; the zero-joint shortcut preserves exact state and image hashes.",
+  "summary": {
+    "scalar_float_runtime_ratio": 2.3554263004855285,
+    "neon_float_runtime_ratio": 2.2534069700441557,
+    "library_runtime_reduction_percent": 14.962969256229519,
+    "combined_runtime_reduction_percent": 16.1592730473727
+  }
+}

--- a/benchmark/2026-09-07-integrated-performance.md
+++ b/benchmark/2026-09-07-integrated-performance.md
@@ -13,7 +13,7 @@ Apple M3 Ultra, macOS 26.6.2, Apple Clang 21.0.0, arm64, RelWithDebInfo/O2, thin
 - Final scalar/NEON: `8f52c1898dc0c26c009b9f5c16554587d1448c26`, fixed `2f1ed91`.
 - Float Box3D: `47d7f7cc7e091142c08d11dc7d2e493c5d34f536`, default NEON.
 
-Two runs per scene and binary, old/pre-solver/final/neon/float/float/neon/final/pre-solver/old order, four workers, continuous collision enabled, median runtime. Scenes with an initial within-binary spread over 5% received three additional balanced runs of every binary; their final medians include all five trials, with no discarded observations. Separate processes and working directories preserve each run. No local builds, tests or captures ran during timing. The raw JSON preserves every observation, executable SHA256, final counters and any rechecks. This is a shared workstation; small differences and short-scene percentages are inconclusive.
+Two runs per scene and binary, old/pre-solver/final/neon/float/float/neon/final/pre-solver/old order, four workers, continuous collision enabled, median runtime. Scenes with an initial within-binary spread over 5% received three additional balanced runs of every binary; their final medians include all five trials, with no discarded observations. Separate processes and working directories preserve each run. No builds, tests or captures from this task ran during timing. The raw JSON preserves every observation, executable SHA256, final counters and any rechecks. This is a shared workstation; small differences and short-scene percentages are inconclusive.
 
 | Scene | Old library scalar (ms) | New library before joint shortcut (ms) | Final scalar (ms) | Final NEON (ms) | Float (ms) |
 |---|---:|---:|---:|---:|---:|

--- a/benchmark/2026-09-07-integrated-performance.md
+++ b/benchmark/2026-09-07-integrated-performance.md
@@ -1,0 +1,62 @@
+# Fixed3D integrated performance, 7 September 2026
+
+The new fixed library reduces geometric-mean runtime by **15.0%** in the independent library sweep. The exact-zero joint shortcut reduces Joint Grid from 911.2 to 741.2 ms (**18.7% less runtime**) in three grouped trials. The preceding scalar edge rejection change separately reduced Convex Pile by 11.3% on the old library.
+
+The final suite measures **2.36× float runtime in scalar mode** and **2.25× with NEON**, equivalent to 42.5% and 44.4% of float throughput. Final scalar runtime is about 16.2% lower than the old-library scalar build that already includes the collision optimization. These percentages describe different comparisons and must not be added.
+
+## Revisions and method
+
+Apple M3 Ultra, macOS 26.6.2, Apple Clang 21.0.0, arm64, RelWithDebInfo/O2, thin LTO, four workers; scalar defaults and optional NEON; continuous collision on.
+
+- Old library scalar: `044aee0`, fixed `a0fa624` (v1.4.0), including the numerical repairs and scalar edge optimization.
+- New library before joint shortcut: `48f8acf`, fixed `2f1ed91`.
+- Final scalar/NEON: `8f52c1898dc0c26c009b9f5c16554587d1448c26`, fixed `2f1ed91`.
+- Float Box3D: `47d7f7cc7e091142c08d11dc7d2e493c5d34f536`, default NEON.
+
+Two runs per scene and binary, old/pre-solver/final/neon/float/float/neon/final/pre-solver/old order, four workers, continuous collision enabled, median runtime. Scenes with an initial within-binary spread over 5% received three additional balanced runs of every binary; their final medians include all five trials, with no discarded observations. Separate processes and working directories preserve each run. No local builds, tests or captures ran during timing. The raw JSON preserves every observation, executable SHA256, final counters and any rechecks. This is a shared workstation; small differences and short-scene percentages are inconclusive.
+
+| Scene | Old library scalar (ms) | New library before joint shortcut (ms) | Final scalar (ms) | Final NEON (ms) | Float (ms) |
+|---|---:|---:|---:|---:|---:|
+| convex_pile | 12672.90 | 10784.80 | 10828.70 | 7020.12 | 3574.49 |
+| joint_grid | 901.40 | 906.09 | 719.68 | 718.97 | 267.33 |
+| junkyard | 9477.52 | 8365.64 | 8382.29 | 7953.26 | 3530.05 |
+| large_pyramid | 1653.44 | 1590.32 | 1550.68 | 1597.03 | 468.24 |
+| large_world | 24.90 | 24.20 | 24.29 | 24.70 | 12.44 |
+| many_pyramids | 1622.74 | 1557.23 | 1570.25 | 1588.52 | 472.38 |
+| rain | 1428.48 | 1420.21 | 1376.59 | 1351.70 | 566.12 |
+| trees100 | 193.90 | 150.30 | 151.64 | 146.94 | 84.66 |
+| trees50 | 316.25 | 209.64 | 210.41 | 208.26 | 106.72 |
+| trees25 | 664.60 | 395.05 | 399.38 | 396.91 | 233.31 |
+| washer | 15316.85 | 13776.50 | 13694.05 | 13806.20 | 6770.39 |
+
+End-of-run counters repeat exactly within each binary. The new-library scalar, final scalar and final NEON counters agree for all eleven scenes. The library update changes some contacts and trajectories; its speedup includes both faster arithmetic and changed simulation work. The joint shortcut preserves numerical behavior.
+
+## Reproduce
+
+```sh
+cmake -S . -B build-perf -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DBOX3D_SAMPLES=OFF -DBOX3D_UNIT_TESTS=ON -DBOX3D_BENCHMARKS=ON \
+  -DBOX3D_NEON=OFF -DBOX3D_COMPILE_WARNING_AS_ERROR=ON
+cmake --build build-perf --parallel 8
+./build-perf/bin/benchmark -t=4 -w=4 -r=1 -b=joint_grid
+```
+
+Build each pinned revision separately. Set `BOX3D_NEON=ON` for the ARM SIMD build. Omit `-b` for all scenes. Use separate working directories, alternate binaries, and retain all runs rather than choosing the fastest result.
+
+## Correctness and range
+
+All 24 local suites pass in Debug, optimized scalar, NEON, wide positions and ASan+UBSan. Existing determinism references are unchanged by the joint shortcut, including workers 1–5. New analytic cases cover singular systems, inverse values of only a few quanta, large intermediates requiring 256 bits, and positive/negative determinants. Geometry-based checks verify mass-proportional off-centre impulses on 1-, 10- and 250-unit cubes against quantization-derived bounds.
+
+Only an exactly zero right-hand side skips matrix construction/solving. Accumulated impulses, damping and force caps still update. Every nonzero solve keeps the original 256-bit calculation and 40-bit inverse scale. The comment in `src/inverse.h` records Space Game's asteroid failure and this range requirement. The CI wide-position job now selects the actual `BOX3D_LUDICROUS_MODE` option.
+
+Twenty sample scenes at 120 frames, twice per binary, give 80 exactly matching decoded RGBA captures before/after the joint shortcut. A separate 80-capture run against float also repeats exactly within each binary; cross-engine pixels differ in all 20 scenes, as expected. Gear Lift and Falling Ragdolls were visually inspected: their layouts agree, with differing dynamic poses. These captures complement the analytic tests; image differences are not used as a numerical tolerance or proof of complete physics equivalence.
+
+The nonzero solver body is byte-identical to the preceding implementation after the early zero return; its source hash is recorded in the JSON.
+
+## Profiling and experiments
+
+The new-library Convex Pile profile still concentrates in hull edge and face searches; Rain concentrates in joint solving and matrix products. Sampled solver inputs showed many exactly zero right-hand sides in Joint Grid. Avoiding both its matrix construction and solve produced the retained improvement.
+
+A bounded native-128 solve was tested separately. Joint Grid was effectively the same as the simple zero shortcut; Rain improved only about 2% in the recheck. That arithmetic variant was excluded. A support-search variant using actual-vertex bounds improved Convex Pile/Junkyard only around 1–1.5% and remains an unshipped experiment. Their measurements remain in the JSON. Existing NEON acceleration predates this work; enabling it is not a new implementation change.
+
+The [earlier collision report](2026-09-07-scalar-edge-reject.md) isolates that optimization. [Raw measurements and comparisons](2026-09-07-integrated-performance.json) contain both sweeps and the experiment records.

--- a/benchmark/2026-09-07-scalar-edge-reject.md
+++ b/benchmark/2026-09-07-scalar-edge-reject.md
@@ -74,6 +74,8 @@ captures reproduce exactly within and across the pre-optimization and final
 fixed builds. Decoded RGBA hashes and binary fingerprints are in the JSON.
 Both binaries are fixed builds; float-image equality is not required.
 
-The existing NEON and AVX-512 paths and build defaults are unchanged. The
-cross-platform matrix has not run for the stacked draft: its workflow currently
-targets pull requests into `main`.
+The existing NEON and AVX-512 paths and build defaults are unchanged. After
+integration with the repaired fixed library, the full cross-platform matrix
+passed on `48f8acf` (run 34163362247). PR #56 merged at `14bf27a`. The measurements
+above retain their original old-library pins; the
+[integrated report](2026-09-07-integrated-performance.md) measures the newer tree.

--- a/src/contact_solver.c
+++ b/src/contact_solver.c
@@ -1973,6 +1973,7 @@ typedef struct b3ContactConstraintPointWide
 	b3Vec3W iRnAs, iRnBs;
 
 	b3FloatW baseSeparations;
+	b3FloatW cachedSeparations;
 	b3FloatW normalImpulses;
 	b3FloatW totalNormalImpulses;
 	b3FloatW normalMasses;
@@ -2031,6 +2032,7 @@ typedef struct b3ContactConstraintWide
 	// exact zeros in every lane and contribute nothing, so skipping them is
 	// bit-identical and one-point-manifold scenes skip 3/4 of the point work.
 	int maxPointCount;
+	int separationGeneration;
 
 	b3ContactConstraintPointWide points[B3_MAX_MANIFOLD_POINTS];
 
@@ -2695,6 +2697,7 @@ void b3PrepareContacts_Convex( b3SolverBlock block, b3StepContext* context )
 				maxPointCount = b3MaxInt( maxPointCount, (int)laneCounts[lane] );
 			}
 			constraint->maxPointCount = maxPointCount;
+			constraint->separationGeneration = -1;
 
 			for ( int pointIndex = 0; pointIndex < maxPointCount; ++pointIndex )
 			{
@@ -3270,6 +3273,7 @@ void b3PrepareContacts_Convex( b3SolverBlock block, b3StepContext* context )
 			}
 
 			constraint->maxPointCount = maxPointCount;
+			constraint->separationGeneration = -1;
 		}
 
 		// Advance to next color
@@ -3376,13 +3380,26 @@ void b3SolveContacts_Convex( b3SolverBlock block, b3StepContext* context, bool u
 			impulseScale = b3ZeroW();
 		}
 
-		b3Vec3W dp = b3SubVW( bB.dp, bA.dp );
 		b3Vec3W normal = b3WidenVW( c->normal );
 
-		// The delta rotations are constant across the four manifold points, so build
-		// them as matrices once and rotate each anchor with three fused reductions
-		b3Matrix3W rotA = b3MakeMatrixFromQuatW( bA.dq );
-		b3Matrix3W rotB = b3MakeMatrixFromQuatW( bB.dq );
+		// Velocities change in solve/warm-start stages, but positions and rotations
+		// change only in the integration stage. Reuse the exact separation from
+		// relaxation in the next solve while that geometry is unchanged.
+		if ( c->separationGeneration != context->positionGeneration )
+		{
+			b3Vec3W dp = b3SubVW( bB.dp, bA.dp );
+			b3Matrix3W rotA = b3MakeMatrixFromQuatW( bA.dq );
+			b3Matrix3W rotB = b3MakeMatrixFromQuatW( bB.dq );
+			for ( int pointIndex = 0; pointIndex < c->maxPointCount; ++pointIndex )
+			{
+				b3ContactConstraintPointWide* cp = c->points + pointIndex;
+				b3Vec3W rsA = b3MulMV3W( rotA, b3WidenVW( cp->anchorAs ) );
+				b3Vec3W rsB = b3MulMV3W( rotB, b3WidenVW( cp->anchorBs ) );
+				b3Vec3W ds = b3AddVW( dp, b3SubVW( rsB, rsA ) );
+				cp->cachedSeparations = b3AddW( b3DotW( normal, ds ), cp->baseSeparations );
+			}
+			c->separationGeneration = context->positionGeneration;
+		}
 
 		b3FloatW totalNormalImpulse = b3ZeroW();
 		b3FloatW totalTwistLimit = b3ZeroW();
@@ -3394,18 +3411,7 @@ void b3SolveContacts_Convex( b3SolverBlock block, b3StepContext* context, bool u
 		{
 			b3ContactConstraintPointWide* cp = c->points + pointIndex;
 
-			// Fixed anchor points for applying impulses
-			b3Vec3W rA = b3WidenVW( cp->anchorAs );
-			b3Vec3W rB = b3WidenVW( cp->anchorBs );
-
-			// Moving anchors for current separation
-			b3Vec3W rsA = b3MulMV3W( rotA, rA );
-			b3Vec3W rsB = b3MulMV3W( rotB, rB );
-
-			// compute current separation
-			// this is subject to round-off error if the anchor is far from the body center of mass
-			b3Vec3W ds = b3AddVW( dp, b3SubVW( rsB, rsA ) );
-			b3FloatW s = b3AddW( b3DotW( normal, ds ), cp->baseSeparations );
+			b3FloatW s = cp->cachedSeparations;
 
 			// Apply speculative bias if separation is greater than zero, otherwise apply soft constraint bias
 			b3FloatW mask = b3GreaterThanW( s, b3ZeroW() );

--- a/src/inverse.h
+++ b/src/inverse.h
@@ -277,8 +277,20 @@ B3_INLINE b3Vec3 b3InvMulMV( b3Matrix3 m, b3Vec3 v )
 /// add: the right-hand side is already an ordinary value, so it contributes 16 of the
 /// scale itself. Carried at 256 bits because a cofactor of inverse-scaled entries reaches
 /// 2^107 for the smallest body this format admits, and the shift takes it past 128.
+// RANGE IS A BEHAVIORAL REQUIREMENT. Space Game's 250-unit asteroids stopped
+// responding to impulses when their inverse mass/inertia rounded to zero in
+// Q48.16. The 40-bit inverse scale preserves that response; small bodies also
+// need large inverse values, whose cofactors and shifted numerators need 256
+// bits. Do not reduce the scale or remove this wide path for speed. A faster
+// path must prove its bounds and fall back without discarding precision.
+// Background: https://github.com/spacegame-llc/space/pull/402
 B3_INLINE b3Vec3 b3Solve3AcrossScales( b3Matrix3 m, b3Vec3 a )
 {
+	if ( a.x == 0 && a.y == 0 && a.z == 0 )
+	{
+		return b3Vec3_zero;
+	}
+
 	fixInt128 c00 = fixCofactor128( m.cy.y, m.cz.z, m.cy.z, m.cz.y );
 	fixInt128 c01 = fixCofactor128( m.cy.z, m.cz.x, m.cy.x, m.cz.z );
 	fixInt128 c02 = fixCofactor128( m.cy.x, m.cz.y, m.cy.y, m.cz.x );

--- a/src/math_internal.h
+++ b/src/math_internal.h
@@ -465,6 +465,36 @@ static inline b3Matrix3 b3Skew( b3Vec3 v )
 	return out;
 }
 
+// skew(r) * m * skew(r), with the same product rounding and addition order
+// as two b3MulMM calls. Only multiplication by exact zero is removed. In
+// particular, keep negation inside each product: rounded(-a*b) can differ
+// from -rounded(a*b) at a half quantum. Full-width inverse entries stay wide.
+static inline b3Matrix3 b3SkewSandwich( b3Matrix3 m, b3Vec3 r )
+{
+	b3Matrix3 t;
+	t.cx.x = b3FixMul( m.cy.x, r.z ) + b3FixMul( m.cz.x, -r.y );
+	t.cx.y = b3FixMul( m.cy.y, r.z ) + b3FixMul( m.cz.y, -r.y );
+	t.cx.z = b3FixMul( m.cy.z, r.z ) + b3FixMul( m.cz.z, -r.y );
+	t.cy.x = b3FixMul( m.cx.x, -r.z ) + b3FixMul( m.cz.x, r.x );
+	t.cy.y = b3FixMul( m.cx.y, -r.z ) + b3FixMul( m.cz.y, r.x );
+	t.cy.z = b3FixMul( m.cx.z, -r.z ) + b3FixMul( m.cz.z, r.x );
+	t.cz.x = b3FixMul( m.cx.x, r.y ) + b3FixMul( m.cy.x, -r.x );
+	t.cz.y = b3FixMul( m.cx.y, r.y ) + b3FixMul( m.cy.y, -r.x );
+	t.cz.z = b3FixMul( m.cx.z, r.y ) + b3FixMul( m.cy.z, -r.x );
+
+	b3Matrix3 out;
+	out.cx.x = b3FixMul( -r.z, t.cx.y ) + b3FixMul( r.y, t.cx.z );
+	out.cx.y = b3FixMul( r.z, t.cx.x ) + b3FixMul( -r.x, t.cx.z );
+	out.cx.z = b3FixMul( -r.y, t.cx.x ) + b3FixMul( r.x, t.cx.y );
+	out.cy.x = b3FixMul( -r.z, t.cy.y ) + b3FixMul( r.y, t.cy.z );
+	out.cy.y = b3FixMul( r.z, t.cy.x ) + b3FixMul( -r.x, t.cy.z );
+	out.cy.z = b3FixMul( -r.y, t.cy.x ) + b3FixMul( r.x, t.cy.y );
+	out.cz.x = b3FixMul( -r.z, t.cz.y ) + b3FixMul( r.y, t.cz.z );
+	out.cz.y = b3FixMul( r.z, t.cz.x ) + b3FixMul( -r.x, t.cz.z );
+	out.cz.z = b3FixMul( -r.y, t.cz.x ) + b3FixMul( r.x, t.cz.y );
+	return out;
+}
+
 static inline b3Plane b3NormalizePlane( b3Plane plane )
 {
 	b3Fixed invLength = b3FixDiv( B3_FIX( 1.0f ) , b3Length( plane.normal ) );

--- a/src/motor_joint.c
+++ b/src/motor_joint.c
@@ -366,10 +366,8 @@ void b3SolveMotorJoint( b3JointSim* base, b3StepContext* context )
 		if ( rhs.x != 0 || rhs.y != 0 || rhs.z != 0 )
 		{
 			//// K = [(1/m1 + 1/m2) * eye(2) - skew(r1) * invI1 * skew(r1) - skew(r2) * invI2 * skew(r2)]
-			b3Matrix3 sA = b3Skew( rA );
-			b3Matrix3 sB = b3Skew( rB );
-			b3Matrix3 kA = b3MulMM( sA, b3MulMM( base->invIA, sA ) );
-			b3Matrix3 kB = b3MulMM( sB, b3MulMM( base->invIB, sB ) );
+			b3Matrix3 kA = b3SkewSandwich( base->invIA, rA );
+			b3Matrix3 kB = b3SkewSandwich( base->invIB, rB );
 			b3Matrix3 k = b3NegateMat3( b3AddMM( kA, kB ) );
 			k.cx.x += mA + mB;
 			k.cy.y += mA + mB;
@@ -407,10 +405,8 @@ void b3SolveMotorJoint( b3JointSim* base, b3StepContext* context )
 		if ( rhs.x != 0 || rhs.y != 0 || rhs.z != 0 )
 		{
 			//// K = [(1/m1 + 1/m2) * eye(2) - skew(r1) * invI1 * skew(r1) - skew(r2) * invI2 * skew(r2)]
-			b3Matrix3 sA = b3Skew( rA );
-			b3Matrix3 sB = b3Skew( rB );
-			b3Matrix3 kA = b3MulMM( sA, b3MulMM( base->invIA, sA ) );
-			b3Matrix3 kB = b3MulMM( sB, b3MulMM( base->invIB, sB ) );
+			b3Matrix3 kA = b3SkewSandwich( base->invIA, rA );
+			b3Matrix3 kB = b3SkewSandwich( base->invIB, rB );
 			b3Matrix3 k = b3NegateMat3( b3AddMM( kA, kB ) );
 			k.cx.x += mA + mB;
 			k.cy.y += mA + mB;

--- a/src/motor_joint.c
+++ b/src/motor_joint.c
@@ -360,17 +360,23 @@ void b3SolveMotorJoint( b3JointSim* base, b3StepContext* context )
 
 		b3Vec3 cdot = b3Sub( b3Add( vB, b3Cross( wB, rB ) ), b3Add( vA, b3Cross( wA, rA ) ) );
 
-		//// K = [(1/m1 + 1/m2) * eye(2) - skew(r1) * invI1 * skew(r1) - skew(r2) * invI2 * skew(r2)]
-		b3Matrix3 sA = b3Skew( rA );
-		b3Matrix3 sB = b3Skew( rB );
-		b3Matrix3 kA = b3MulMM( sA, b3MulMM( base->invIA, sA ) );
-		b3Matrix3 kB = b3MulMM( sB, b3MulMM( base->invIB, sB ) );
-		b3Matrix3 k = b3NegateMat3( b3AddMM( kA, kB ) );
-		k.cx.x += mA + mB;
-		k.cy.y += mA + mB;
-		k.cz.z += mA + mB;
+		b3Vec3 rhs = b3Add( cdot, bias );
+		b3Vec3 b = b3Vec3_zero;
+		// Zero RHS has an exact zero solution; accumulated impulses still apply below.
+		if ( rhs.x != 0 || rhs.y != 0 || rhs.z != 0 )
+		{
+			//// K = [(1/m1 + 1/m2) * eye(2) - skew(r1) * invI1 * skew(r1) - skew(r2) * invI2 * skew(r2)]
+			b3Matrix3 sA = b3Skew( rA );
+			b3Matrix3 sB = b3Skew( rB );
+			b3Matrix3 kA = b3MulMM( sA, b3MulMM( base->invIA, sA ) );
+			b3Matrix3 kB = b3MulMM( sB, b3MulMM( base->invIB, sB ) );
+			b3Matrix3 k = b3NegateMat3( b3AddMM( kA, kB ) );
+			k.cx.x += mA + mB;
+			k.cy.y += mA + mB;
+			k.cz.z += mA + mB;
 
-		b3Vec3 b = b3Solve3AcrossScales( k, b3Add( cdot, bias ) );
+			b = b3Solve3AcrossScales( k, rhs );
+		}
 
 		b3Vec3 oldImpulse = joint->linearSpringImpulse;
 		b3Vec3 impulse = b3MulSub( b3MulSV( -massScale, b ), impulseScale, oldImpulse );
@@ -395,17 +401,23 @@ void b3SolveMotorJoint( b3JointSim* base, b3StepContext* context )
 	{
 		b3Vec3 cdot = b3Sub( b3Add( vB, b3Cross( wB, rB ) ), b3Add( vA, b3Cross( wA, rA ) ) );
 		cdot = b3Sub( cdot, joint->linearVelocity );
-		//// K = [(1/m1 + 1/m2) * eye(2) - skew(r1) * invI1 * skew(r1) - skew(r2) * invI2 * skew(r2)]
-		b3Matrix3 sA = b3Skew( rA );
-		b3Matrix3 sB = b3Skew( rB );
-		b3Matrix3 kA = b3MulMM( sA, b3MulMM( base->invIA, sA ) );
-		b3Matrix3 kB = b3MulMM( sB, b3MulMM( base->invIB, sB ) );
-		b3Matrix3 k = b3NegateMat3( b3AddMM( kA, kB ) );
-		k.cx.x += mA + mB;
-		k.cy.y += mA + mB;
-		k.cz.z += mA + mB;
+		b3Vec3 rhs = cdot;
+		b3Vec3 b = b3Vec3_zero;
+		// Zero RHS has an exact zero solution; accumulated impulses still apply below.
+		if ( rhs.x != 0 || rhs.y != 0 || rhs.z != 0 )
+		{
+			//// K = [(1/m1 + 1/m2) * eye(2) - skew(r1) * invI1 * skew(r1) - skew(r2) * invI2 * skew(r2)]
+			b3Matrix3 sA = b3Skew( rA );
+			b3Matrix3 sB = b3Skew( rB );
+			b3Matrix3 kA = b3MulMM( sA, b3MulMM( base->invIA, sA ) );
+			b3Matrix3 kB = b3MulMM( sB, b3MulMM( base->invIB, sB ) );
+			b3Matrix3 k = b3NegateMat3( b3AddMM( kA, kB ) );
+			k.cx.x += mA + mB;
+			k.cy.y += mA + mB;
+			k.cz.z += mA + mB;
 
-		b3Vec3 b = b3Solve3AcrossScales( k, cdot );
+			b = b3Solve3AcrossScales( k, rhs );
+		}
 		b3Vec3 impulse = b3Neg( b );
 
 		b3Vec3 oldImpulse = joint->linearVelocityImpulse;

--- a/src/revolute_joint.c
+++ b/src/revolute_joint.c
@@ -583,10 +583,8 @@ void b3SolveRevoluteJoint( b3JointSim* base, b3StepContext* context, bool useBia
 		if ( rhs.x != 0 || rhs.y != 0 || rhs.z != 0 )
 		{
 			//// K = [(1/m1 + 1/m2) * eye(2) - skew(r1) * invI1 * skew(r1) - skew(r2) * invI2 * skew(r2)]
-			b3Matrix3 sA = b3Skew( rA );
-			b3Matrix3 sB = b3Skew( rB );
-			b3Matrix3 kA = b3MulMM( sA, b3MulMM( base->invIA, sA ) );
-			b3Matrix3 kB = b3MulMM( sB, b3MulMM( base->invIB, sB ) );
+			b3Matrix3 kA = b3SkewSandwich( base->invIA, rA );
+			b3Matrix3 kB = b3SkewSandwich( base->invIB, rB );
 			b3Matrix3 k = b3NegateMat3( b3AddMM( kA, kB ) );
 			k.cx.x += mA + mB;
 			k.cy.y += mA + mB;

--- a/src/revolute_joint.c
+++ b/src/revolute_joint.c
@@ -577,17 +577,23 @@ void b3SolveRevoluteJoint( b3JointSim* base, b3StepContext* context, bool useBia
 			impulseScale = base->constraintSoftness.impulseScale;
 		}
 
-		//// K = [(1/m1 + 1/m2) * eye(2) - skew(r1) * invI1 * skew(r1) - skew(r2) * invI2 * skew(r2)]
-		b3Matrix3 sA = b3Skew( rA );
-		b3Matrix3 sB = b3Skew( rB );
-		b3Matrix3 kA = b3MulMM( sA, b3MulMM( base->invIA, sA ) );
-		b3Matrix3 kB = b3MulMM( sB, b3MulMM( base->invIB, sB ) );
-		b3Matrix3 k = b3NegateMat3( b3AddMM( kA, kB ) );
-		k.cx.x += mA + mB;
-		k.cy.y += mA + mB;
-		k.cz.z += mA + mB;
+		b3Vec3 rhs = b3Add( cdot, bias );
+		b3Vec3 b = b3Vec3_zero;
+		// Zero RHS has an exact zero solution; accumulated impulses still apply below.
+		if ( rhs.x != 0 || rhs.y != 0 || rhs.z != 0 )
+		{
+			//// K = [(1/m1 + 1/m2) * eye(2) - skew(r1) * invI1 * skew(r1) - skew(r2) * invI2 * skew(r2)]
+			b3Matrix3 sA = b3Skew( rA );
+			b3Matrix3 sB = b3Skew( rB );
+			b3Matrix3 kA = b3MulMM( sA, b3MulMM( base->invIA, sA ) );
+			b3Matrix3 kB = b3MulMM( sB, b3MulMM( base->invIB, sB ) );
+			b3Matrix3 k = b3NegateMat3( b3AddMM( kA, kB ) );
+			k.cx.x += mA + mB;
+			k.cy.y += mA + mB;
+			k.cz.z += mA + mB;
 
-		b3Vec3 b = b3Solve3AcrossScales( k, b3Add( cdot, bias ) );
+			b = b3Solve3AcrossScales( k, rhs );
+		}
 
 		b3Vec3 impulse = b3Sub( b3MulSV( -massScale, b ), b3MulSV( impulseScale, joint->linearImpulse ) );
 		joint->linearImpulse = b3Add( joint->linearImpulse, impulse );

--- a/src/solver.c
+++ b/src/solver.c
@@ -1327,6 +1327,10 @@ static void b3SolverTask( void* taskContext )
 
 			profile->solveImpulses += b3GetMillisecondsAndReset( &ticks );
 
+			// The preceding stage has finished; publish the new geometry generation
+			// through the existing stage barrier before contacts run again.
+			context->positionGeneration += 1;
+
 			// Integrate positions
 			B3_ASSERT( stages[iterationStageIndex].type == b3_stageIntegratePositions );
 			syncBits = ( bodySyncIndex << 16 ) | iterationStageIndex;
@@ -1508,6 +1512,7 @@ void b3Solve( b3World* world, b3StepContext* stepContext )
 
 		stepContext->sims = awakeSet->bodySims.data;
 		stepContext->states = awakeSet->bodyStates.data;
+		stepContext->positionGeneration = 0;
 
 		// count contacts, joints, and colors
 		int activeColorCount = 0;

--- a/src/solver.h
+++ b/src/solver.h
@@ -198,6 +198,9 @@ typedef struct b3StepContext
 
 	int subStepCount;
 
+	// Geometry generation for per-constraint separation caches. Published by stage barriers.
+	int positionGeneration;
+
 	b3Softness contactSoftness;
 	b3Softness staticSoftness;
 

--- a/src/spherical_joint.c
+++ b/src/spherical_joint.c
@@ -449,10 +449,16 @@ void b3SolveSphericalJoint( b3JointSim* base, b3StepContext* context, bool useBi
 	b3Vec3 wB = stateB->angularVelocity;
 
 	bool fixedRotation = base->fixedRotation;
-	b3Quat quatA = b3MulQuat( stateA->deltaRotation, joint->frameA.q );
-	b3Quat quatB = b3MulQuat( stateB->deltaRotation, joint->frameB.q );
-
-	b3Quat relQ = b3InvMulQuat( quatA, quatB );
+	b3Quat quatA = b3Quat_identity;
+	b3Quat relQ = b3Quat_identity;
+	// A point-only joint has no angular error to evaluate. The angular motor
+	// uses relative velocity, so it does not need these orientations either.
+	if ( fixedRotation == false && ( joint->enableSpring || joint->enableTwistLimit || joint->enableConeLimit ) )
+	{
+		quatA = b3MulQuat( stateA->deltaRotation, joint->frameA.q );
+		b3Quat quatB = b3MulQuat( stateB->deltaRotation, joint->frameB.q );
+		relQ = b3InvMulQuat( quatA, quatB );
+	}
 
 	// Solve spring
 	if ( joint->enableSpring && fixedRotation == false )
@@ -630,10 +636,8 @@ void b3SolveSphericalJoint( b3JointSim* base, b3StepContext* context, bool useBi
 		if ( rhs.x != 0 || rhs.y != 0 || rhs.z != 0 )
 		{
 			//// K = [(1/m1 + 1/m2) * eye(2) - skew(r1) * invI1 * skew(r1) - skew(r2) * invI2 * skew(r2)]
-			b3Matrix3 sA = b3Skew( rA );
-			b3Matrix3 sB = b3Skew( rB );
-			b3Matrix3 kA = b3MulMM( sA, b3MulMM( base->invIA, sA ) );
-			b3Matrix3 kB = b3MulMM( sB, b3MulMM( base->invIB, sB ) );
+			b3Matrix3 kA = b3SkewSandwich( base->invIA, rA );
+			b3Matrix3 kB = b3SkewSandwich( base->invIB, rB );
 			b3Matrix3 k = b3NegateMat3( b3AddMM( kA, kB ) );
 			k.cx.x += mA + mB;
 			k.cy.y += mA + mB;

--- a/src/spherical_joint.c
+++ b/src/spherical_joint.c
@@ -624,17 +624,23 @@ void b3SolveSphericalJoint( b3JointSim* base, b3StepContext* context, bool useBi
 			impulseScale = base->constraintSoftness.impulseScale;
 		}
 
-		//// K = [(1/m1 + 1/m2) * eye(2) - skew(r1) * invI1 * skew(r1) - skew(r2) * invI2 * skew(r2)]
-		b3Matrix3 sA = b3Skew( rA );
-		b3Matrix3 sB = b3Skew( rB );
-		b3Matrix3 kA = b3MulMM( sA, b3MulMM( base->invIA, sA ) );
-		b3Matrix3 kB = b3MulMM( sB, b3MulMM( base->invIB, sB ) );
-		b3Matrix3 k = b3NegateMat3( b3AddMM( kA, kB ) );
-		k.cx.x += mA + mB;
-		k.cy.y += mA + mB;
-		k.cz.z += mA + mB;
+		b3Vec3 rhs = b3Add( cdot, bias );
+		b3Vec3 b = b3Vec3_zero;
+		// Zero RHS has an exact zero solution; accumulated impulses still apply below.
+		if ( rhs.x != 0 || rhs.y != 0 || rhs.z != 0 )
+		{
+			//// K = [(1/m1 + 1/m2) * eye(2) - skew(r1) * invI1 * skew(r1) - skew(r2) * invI2 * skew(r2)]
+			b3Matrix3 sA = b3Skew( rA );
+			b3Matrix3 sB = b3Skew( rB );
+			b3Matrix3 kA = b3MulMM( sA, b3MulMM( base->invIA, sA ) );
+			b3Matrix3 kB = b3MulMM( sB, b3MulMM( base->invIB, sB ) );
+			b3Matrix3 k = b3NegateMat3( b3AddMM( kA, kB ) );
+			k.cx.x += mA + mB;
+			k.cy.y += mA + mB;
+			k.cz.z += mA + mB;
 
-		b3Vec3 b = b3Solve3AcrossScales( k, b3Add( cdot, bias ) );
+			b = b3Solve3AcrossScales( k, rhs );
+		}
 
 		b3Vec3 impulse = b3MulSub( b3MulSV( -massScale, b ), impulseScale, joint->linearImpulse );
 		joint->linearImpulse = b3Add( joint->linearImpulse, impulse );

--- a/src/weld_joint.c
+++ b/src/weld_joint.c
@@ -275,10 +275,8 @@ void b3SolveWeldJoint( b3JointSim* base, b3StepContext* context, bool useBias )
 		if ( rhs.x != 0 || rhs.y != 0 || rhs.z != 0 )
 		{
 			//// K = [(1/m1 + 1/m2) * eye(2) - skew(r1) * invI1 * skew(r1) - skew(r2) * invI2 * skew(r2)]
-			b3Matrix3 sA = b3Skew( rA );
-			b3Matrix3 sB = b3Skew( rB );
-			b3Matrix3 kA = b3MulMM( sA, b3MulMM( base->invIA, sA ) );
-			b3Matrix3 kB = b3MulMM( sB, b3MulMM( base->invIB, sB ) );
+			b3Matrix3 kA = b3SkewSandwich( base->invIA, rA );
+			b3Matrix3 kB = b3SkewSandwich( base->invIB, rB );
 			b3Matrix3 k = b3NegateMat3( b3AddMM( kA, kB ) );
 			k.cx.x += mA + mB;
 			k.cy.y += mA + mB;

--- a/src/weld_joint.c
+++ b/src/weld_joint.c
@@ -269,17 +269,23 @@ void b3SolveWeldJoint( b3JointSim* base, b3StepContext* context, bool useBias )
 			impulseScale = joint->linearSpring.impulseScale;
 		}
 
-		//// K = [(1/m1 + 1/m2) * eye(2) - skew(r1) * invI1 * skew(r1) - skew(r2) * invI2 * skew(r2)]
-		b3Matrix3 sA = b3Skew( rA );
-		b3Matrix3 sB = b3Skew( rB );
-		b3Matrix3 kA = b3MulMM( sA, b3MulMM( base->invIA, sA ) );
-		b3Matrix3 kB = b3MulMM( sB, b3MulMM( base->invIB, sB ) );
-		b3Matrix3 k = b3NegateMat3( b3AddMM( kA, kB ) );
-		k.cx.x += mA + mB;
-		k.cy.y += mA + mB;
-		k.cz.z += mA + mB;
+		b3Vec3 rhs = b3Add( cdot, bias );
+		b3Vec3 b = b3Vec3_zero;
+		// Zero RHS has an exact zero solution; accumulated impulses still apply below.
+		if ( rhs.x != 0 || rhs.y != 0 || rhs.z != 0 )
+		{
+			//// K = [(1/m1 + 1/m2) * eye(2) - skew(r1) * invI1 * skew(r1) - skew(r2) * invI2 * skew(r2)]
+			b3Matrix3 sA = b3Skew( rA );
+			b3Matrix3 sB = b3Skew( rB );
+			b3Matrix3 kA = b3MulMM( sA, b3MulMM( base->invIA, sA ) );
+			b3Matrix3 kB = b3MulMM( sB, b3MulMM( base->invIB, sB ) );
+			b3Matrix3 k = b3NegateMat3( b3AddMM( kA, kB ) );
+			k.cx.x += mA + mB;
+			k.cy.y += mA + mB;
+			k.cz.z += mA + mB;
 
-		b3Vec3 b = b3Solve3AcrossScales( k, b3Add( cdot, bias ) );
+			b = b3Solve3AcrossScales( k, rhs );
+		}
 
 		b3Vec3 impulse = b3MulSub( b3MulSV( -massScale, b ), impulseScale, joint->linearImpulse );
 		joint->linearImpulse = b3Add( joint->linearImpulse, impulse );

--- a/test/test_body.c
+++ b/test/test_body.c
@@ -11,6 +11,8 @@
 #include "body.h"
 #include "physics_world.h"
 
+#include <math.h>
+
 
 // b3UpdateBodyMassData shifts each shape's inertia to the body center of mass with the parallel
 // axis theorem. When shapes sit far from the body origin the shift term dwarfs the central inertia,
@@ -494,6 +496,51 @@ static int InverseMassQuantumFloorFromShapes( void )
 	return 0;
 }
 
+static int AsteroidImpulseResponse( void )
+{
+	// Space Game's laser impulse has magnitude equal to the prop's mass. A
+	// density-one cube must therefore gain one unit/s of linear velocity,
+	// with off-centre spin bounded by inverse-inertia/output quantization.
+	const int sides[] = { 1, 10, 250 };
+	for ( int i = 0; i < ARRAY_COUNT( sides ); ++i )
+	{
+		double side = sides[i];
+		double mass = side * side * side;
+		double inertia = mass * side * side / 6.0;
+		b3WorldDef worldDef = b3DefaultWorldDef();
+		worldDef.gravity = b3Vec3_zero;
+		worldDef.enableSleep = false;
+		b3WorldId worldId = b3CreateWorld( &worldDef );
+		b3BodyDef bodyDef = b3DefaultBodyDef();
+		bodyDef.type = b3_dynamicBody;
+		b3BodyId bodyId = b3CreateBody( worldId, &bodyDef );
+		b3Fixed half = b3FixFromDouble( side / 2.0 );
+		b3BoxHull hull = b3MakeBoxHull( half, half, half );
+		b3ShapeDef shapeDef = b3DefaultShapeDef();
+		shapeDef.density = B3_FIXED_ONE;
+		b3CreateHullShape( bodyId, &shapeDef, &hull.base );
+		ENSURE( b3Body_GetInverseMassPrecise( bodyId ) > 0 );
+		b3Matrix3 invI = b3Body_GetWorldInverseRotationalInertiaPrecise( bodyId );
+		ENSURE( invI.cx.x > 0 && invI.cy.y > 0 && invI.cz.z > 0 );
+		b3Vec3 impulse = { 0, 0, -b3Body_GetMass( bodyId ) };
+		b3Pos point = b3ToPos( (b3Vec3){ half / 2, half / 4, half } );
+		b3Body_ApplyLinearImpulse( bodyId, impulse, point, false );
+		b3Vec3 v = b3Body_GetLinearVelocity( bodyId );
+		b3Vec3 w = b3Body_GetAngularVelocity( bodyId );
+		double quantum = 1.0 / 65536.0;
+		double inverseScale = 1099511627776.0; // 2^40 is part of the range contract.
+		ENSURE( fabs( b3FixToDouble( v.z ) + 1.0 ) <= mass / inverseScale + quantum );
+		ENSURE( v.x == 0 && v.y == 0 && w.z == 0 );
+		double tx = -mass * side / 8.0;
+		double ty = mass * side / 4.0;
+		ENSURE( fabs( b3FixToDouble( w.x ) - tx / inertia ) <= fabs( tx ) / inverseScale + 16 * quantum );
+		ENSURE( fabs( b3FixToDouble( w.y ) - ty / inertia ) <= fabs( ty ) / inverseScale + 16 * quantum );
+		ENSURE( w.x < 0 && w.y > 0 );
+		b3DestroyWorld( worldId );
+	}
+	return 0;
+}
+
 // THE INVERSE INERTIA SCALE ENVELOPE.
 //
 // Inertia grows as the fifth power of size, so a body 20 times larger has an inertia
@@ -751,6 +798,7 @@ int BodyTest( void )
 	RUN_SUBTEST( AngularImpulseInverseScale );
 	RUN_SUBTEST( InverseMassQuantumFloor );
 	RUN_SUBTEST( InverseInertiaScaleEnvelope );
+	RUN_SUBTEST( AsteroidImpulseResponse );
 	RUN_SUBTEST( InverseMassQuantumFloorFromShapes );
 	RUN_SUBTEST( FarSingleSphereMass );
 	RUN_SUBTEST( FarCubeSphereMass );

--- a/test/test_math.c
+++ b/test/test_math.c
@@ -358,6 +358,46 @@ static int Solve2InverseScaleTest( void )
 	return 0;
 }
 
+static int Solve3InverseScaleTest( void )
+{
+	// K = s * [[4,1,0],[1,3,1],[0,1,2]], b = s * [5,-3,5]
+	// has x = [2,-3,4]. The largest cases require 256-bit intermediates.
+	const int bits[] = { 24, 32, 40, 41, 54, 60 };
+	for ( int i = 0; i < ARRAY_COUNT( bits ); ++i )
+	{
+		for ( int sign = -1; sign <= 1; sign += 2 )
+		{
+			b3Fixed s = sign * ( (b3Fixed)1 << bits[i] );
+			b3Fixed r = sign * ( (b3Fixed)1 << ( bits[i] - B3_INVERSE_EXTRA_BITS ) );
+			b3Matrix3 m = { { 4 * s, s, 0 }, { s, 3 * s, s }, { 0, s, 2 * s } };
+			b3Vec3 x = b3Solve3AcrossScales( m, (b3Vec3){ 5 * r, -3 * r, 5 * r } );
+			ENSURE( x.x == B3_FIX( 2.0f ) && x.y == -B3_FIX( 3.0f ) && x.z == B3_FIX( 4.0f ) );
+			x = b3Solve3AcrossScales( m, b3Vec3_zero );
+			ENSURE( x.x == 0 && x.y == 0 && x.z == 0 );
+		}
+	}
+
+	// Asteroid-scale inverse values retain their low quanta. Converting them
+	// back to Q48.16 before solving would erase the response entirely.
+	b3Matrix3 small = { { 6, 0, 0 }, { 0, 70369, 0 }, { 0, 0, 6 } };
+	b3Vec3 x = b3Solve3AcrossScales( small, (b3Vec3){ 1, -1, 2 } );
+	ENSURE( x.x == ( (int64_t)1 << 40 ) / 6 );
+	ENSURE( x.y == -( ( (int64_t)1 << 40 ) / 70369 ) );
+	ENSURE( x.z == ( (int64_t)2 << 40 ) / 6 );
+
+	b3Fixed s = (b3Fixed)1 << 40;
+	b3Matrix3 diagonal = { { s, 0, 0 }, { 0, s, 0 }, { 0, 0, s } };
+	for ( int raw = 63; raw <= 65; ++raw )
+	{
+		x = b3Solve3AcrossScales( diagonal, (b3Vec3){ raw, -raw, raw } );
+		ENSURE( x.x == raw && x.y == -raw && x.z == raw );
+	}
+	b3Matrix3 singular = { { s, s, s }, { s, s, s }, { s, s, s } };
+	x = b3Solve3AcrossScales( singular, (b3Vec3){ B3_FIXED_ONE, -B3_FIXED_ONE, B3_FIXED_ONE } );
+	ENSURE( x.x == 0 && x.y == 0 && x.z == 0 );
+	return 0;
+}
+
 // Exercise the repaired contracts through the b3 forwarders and both AABB
 // representations, so a stale vendor pin or integration cannot hide behind
 // the upstream library's own tests.
@@ -397,6 +437,7 @@ static int VendoredFixedTest( void )
 int MathTest( void )
 {
 	RUN_SUBTEST( Solve2InverseScaleTest );
+	RUN_SUBTEST( Solve3InverseScaleTest );
 	RUN_SUBTEST( VendoredFixedTest );
 	// Compare the fixed-point trig against double precision references from libm.
 	// The fixed-point results carry the approximation error of the underlying

--- a/test/test_math.c
+++ b/test/test_math.c
@@ -358,6 +358,62 @@ static int Solve2InverseScaleTest( void )
 	return 0;
 }
 
+// Differentially preserve the original two full matrix products, including
+// half-quantum signs, tiny inverse entries and large inverse-scaled entries.
+static int SkewSandwichTest( void )
+{
+	const int matrixBits[] = { 6, 16, 24, 40, 54, 60 };
+	const int anchorBits[] = { 27, 24, 16, 20, 12, 8 };
+	uint64_t rng = UINT64_C( 0x257837492019bc43 );
+	for ( int scale = 0; scale < 6; ++scale )
+	{
+		for ( int trial = 0; trial < 1024; ++trial )
+		{
+			b3Fixed values[12];
+			for ( int j = 0; j < 12; ++j )
+			{
+				rng = rng * UINT64_C( 6364136223846793005 ) + UINT64_C( 1442695040888963407 );
+				int bits = j < 9 ? matrixBits[scale] : anchorBits[scale];
+				values[j] = (b3Fixed)( rng & ( ( UINT64_C( 1 ) << bits ) - 1 ) );
+				if ( rng >> 63 )
+				{
+					values[j] = -values[j];
+				}
+			}
+			// Include exact zeros and half-quantum products, whose negation must
+			// stay inside the multiply under round-half-up.
+			if ( trial % 8 == 0 )
+			{
+				values[9] = 0;
+			}
+			if ( trial % 8 == 1 )
+			{
+				values[0] = 1;
+				values[10] = B3_FIXED_HALF;
+			}
+			b3Matrix3 m = {
+				{ values[0], values[1], values[2] },
+				{ values[3], values[4], values[5] },
+				{ values[6], values[7], values[8] },
+			};
+			b3Vec3 r = { values[9], values[10], values[11] };
+			b3Matrix3 skew = b3Skew( r );
+			b3Matrix3 expected = b3MulMM( skew, b3MulMM( m, skew ) );
+			b3Matrix3 actual = b3SkewSandwich( m, r );
+			ENSURE( actual.cx.x == expected.cx.x );
+			ENSURE( actual.cx.y == expected.cx.y );
+			ENSURE( actual.cx.z == expected.cx.z );
+			ENSURE( actual.cy.x == expected.cy.x );
+			ENSURE( actual.cy.y == expected.cy.y );
+			ENSURE( actual.cy.z == expected.cy.z );
+			ENSURE( actual.cz.x == expected.cz.x );
+			ENSURE( actual.cz.y == expected.cz.y );
+			ENSURE( actual.cz.z == expected.cz.z );
+		}
+	}
+	return 0;
+}
+
 static int Solve3InverseScaleTest( void )
 {
 	// K = s * [[4,1,0],[1,3,1],[0,1,2]], b = s * [5,-3,5]
@@ -438,6 +494,7 @@ int MathTest( void )
 {
 	RUN_SUBTEST( Solve2InverseScaleTest );
 	RUN_SUBTEST( Solve3InverseScaleTest );
+	RUN_SUBTEST( SkewSandwichTest );
 	RUN_SUBTEST( VendoredFixedTest );
 	// Compare the fixed-point trig against double precision references from libm.
 	// The fixed-point results carry the approximation error of the underlying

--- a/tools/benchmark/contact_state_hash.c
+++ b/tools/benchmark/contact_state_hash.c
@@ -1,0 +1,80 @@
+// Compare complete body-state hashes every frame against a preserved library.
+// Exercises cache refresh with fixed/varying substeps, worker counts, warm-start
+// toggles, rotation and both ordinary and asteroid-scale contact geometry.
+#include "box3d/box3d.h"
+#include <inttypes.h>
+#include <stdio.h>
+
+static uint64_t HashValue( uint64_t hash, int64_t value )
+{
+    uint64_t bits = (uint64_t)value;
+    for ( int i = 0; i < 8; ++i )
+    {
+        hash = ( hash ^ ( bits & 255 ) ) * UINT64_C( 1099511628211 );
+        bits >>= 8;
+    }
+    return hash;
+}
+
+static uint64_t HashVector( uint64_t hash, b3Vec3 v )
+{
+    return HashValue( HashValue( HashValue( hash, v.x ), v.y ), v.z );
+}
+
+int main( void )
+{
+    const int substeps[] = { 1, 2, 4, 8 };
+    for ( int scaleIndex = 0; scaleIndex < 2; ++scaleIndex )
+    for ( int workerIndex = 0; workerIndex < 2; ++workerIndex )
+    for ( int mode = 0; mode < 5; ++mode )
+    {
+        b3Fixed size = b3FixFromInt( scaleIndex == 0 ? 1 : 250 );
+        b3WorldDef worldDef = b3DefaultWorldDef();
+        worldDef.workerCount = workerIndex == 0 ? 1 : 4;
+        worldDef.enableSleep = false;
+        b3WorldId world = b3CreateWorld( &worldDef );
+        b3BodyDef groundDef = b3DefaultBodyDef();
+        groundDef.position.y = -size;
+        b3BodyId ground = b3CreateBody( world, &groundDef );
+        b3ShapeDef shapeDef = b3DefaultShapeDef();
+        b3BoxHull floor = b3MakeBoxHull( size * 10, size, size * 10 );
+        b3CreateHullShape( ground, &shapeDef, &floor.base );
+        b3BoxHull cube = b3MakeCubeHull( size / 2 );
+        b3BodyId bodies[36];
+        for ( int i = 0; i < 36; ++i )
+        {
+            b3BodyDef bodyDef = b3DefaultBodyDef();
+            bodyDef.type = b3_dynamicBody;
+            bodyDef.position = (b3Pos){ ( i % 3 - 1 ) * size, size / 2 + ( i / 9 ) * size,
+                                                       ( i / 3 % 3 - 1 ) * size };
+            bodyDef.angularVelocity = (b3Vec3){ ( i % 3 - 1 ) * B3_FIX( 0.03f ),
+                                                        B3_FIX( 0.01f ), B3_FIX( -0.02f ) };
+            bodies[i] = b3CreateBody( world, &bodyDef );
+            b3CreateHullShape( bodies[i], &shapeDef, &cube.base );
+        }
+        for ( int frame = 0; frame < 240; ++frame )
+        {
+            if ( frame == 70 ) { b3World_EnableWarmStarting( world, false ); }
+            if ( frame == 130 ) { b3World_EnableWarmStarting( world, true ); }
+            if ( frame == 100 )
+            {
+                b3Body_SetLinearVelocity( bodies[28], (b3Vec3){ size / 5, size / 10, -size / 7 } );
+            }
+            int count = substeps[mode == 4 ? frame % 4 : mode];
+            b3World_Step( world, b3FixDiv( B3_FIXED_ONE, b3FixFromInt( 60 ) ), count );
+            uint64_t hash = UINT64_C( 14695981039346656037 );
+            for ( int i = 0; i < 36; ++i )
+            {
+                b3WorldTransform t = b3Body_GetTransform( bodies[i] );
+                hash = HashValue( HashValue( HashValue( hash, t.p.x ), t.p.y ), t.p.z );
+                hash = HashVector( hash, t.q.v );
+                hash = HashValue( hash, t.q.s );
+                hash = HashVector( hash, b3Body_GetLinearVelocity( bodies[i] ) );
+                hash = HashVector( hash, b3Body_GetAngularVelocity( bodies[i] ) );
+            }
+            printf( "%d %d %d %d %016" PRIx64 "\n", scaleIndex, workerIndex, mode, frame, hash );
+        }
+        b3DestroyWorld( world );
+    }
+    return 0;
+}


### PR DESCRIPTION
Contact separation was recomputed during each solve even when body positions and rotations had not changed since relaxation. This caches the exact per-point result within a world step and invalidates it at every position-integration stage using the existing worker barriers. Every prepare invalidates its cache. The cache adds 128 bytes per four-lane convex constraint.

Spherical joints evaluate relative orientation only when an enabled angular spring or limit needs it. Point-constraint matrix construction removes exact zero products from skew matrices while retaining the remaining multiplications, their rounding and signs. The 40-bit inverse scale and full 256-bit solve remain unchanged. This follows merged #58.

Final paired measurements on Apple M3 Ultra reduce geometric-mean runtime by 3.3% scalar and 3.9% NEON across eleven scenes. Joint Grid improves 11-12%; Many Pyramids improves 6-8%. Estimated current float throughput is 44.6% scalar and 47.0% NEON. All trials, binary hashes, noisy-scene rechecks and shared-workstation limitations are in `benchmark/2026-09-07-contact-joint-performance.md` and its JSON. README now shows these results.

Validation:

- Full CI matrix passed on code commit `542fa35` (run 34166282099), including TSan, MSan, wide positions and static/dynamic samples.
- All 24 suites passed locally in Debug, optimized scalar, NEON, wide positions and ASan+UBSan, with existing determinism references unchanged.
- 6,144 differential cases preserve the generic skew-matrix expression across six scales, tiny/large inverse entries, exact zeros and half-quantum signs.
- All 4,800 frame hashes match the preceding library, covering ordinary and 250-unit rotating cubes, fixed/varying substeps and warm-start toggles. The corresponding frames also agree across workers 1 and 4. The reusable state-hash tool is included and its documented build command was verified.
- All 80 captures across 20 scenes match exactly before/after. Forced inlining was slower in stacking scenes and is excluded.

The final follow-up commit changes documentation, measurement data and the independently tested comparison tool; library code is identical to the fully validated code commit.
