### PR TITLE
Cache spherical anchors and split fast and extended CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,11 +27,12 @@ jobs:
             os: ubuntu-latest
             config: Debug
             test: ./bin/test
-          # The full Debug+TSan suite took 100s in the measured pre-split run.
+          # Keep compiler coverage here; ThreadSanitizer exceeds the fast
+          # budget on variable runner loads and remains in Extended checks.
           - name: ubuntu-clang
             os: ubuntu-latest
             config: Debug
-            args: '-DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18 -DCMAKE_C_FLAGS="-fsanitize=thread -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-fsanitize=thread -fno-omit-frame-pointer" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread"'
+            args: '-DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18'
             test: ./bin/test
           # Keep wide-position goldens on every PR. The slower ASan+UBSan
           # version remains in Extended checks.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-# https://docs.github.com/en/actions
+# Fast PR checks. Full sanitizer/platform/sample coverage is in extended.yml.
 name: build_test
 
 on:
@@ -8,14 +8,16 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
-env:
-  BUILD_TYPE: Debug
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: ${{ matrix.timeout || 4 }}
+    # Target 1-2 minutes per run; leave a small runner-variance backstop.
+    timeout-minutes: 3
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     strategy:
       fail-fast: false
@@ -23,96 +25,21 @@ jobs:
         include:
           - name: ubuntu-gcc
             os: ubuntu-latest
+            config: Debug
             test: ./bin/test
+          # The full Debug+TSan suite took 100s in the measured pre-split run.
           - name: ubuntu-clang
             os: ubuntu-latest
+            config: Debug
             args: '-DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18 -DCMAKE_C_FLAGS="-fsanitize=thread -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-fsanitize=thread -fno-omit-frame-pointer" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread"'
             test: ./bin/test
-          - name: ubuntu-clang-msan
-            os: ubuntu-latest
-            # THE LIMIT THAT MATTERS IS THE ONE ON THE TEST COMMAND, not timeout-minutes.
-            # A job killed by timeout-minutes finishes CANCELLED, and cancelled is not
-            # failure: the run goes grey, `conclusion` reads "cancelled", and an entire
-            # sanitizer leg absents itself without anything going red. This job did that
-            # on main for several consecutive merges. `timeout` exits 124, which fails
-            # the step, which fails the job -- an overrun here is a red X that says
-            # "ubuntu-clang-msan did not finish", which is the honest report.
-            # timeout-minutes stays as a backstop for the case the inner bound cannot
-            # cover (a hung build step, a wedged runner) and is set above it on purpose.
-            # The result job at the end of this file is the third layer: it turns a
-            # cancelled leg anywhere in this matrix into a failing required check.
-            #
-            # 35m IS SET FROM THE OBSERVED SPREAD, not from one sample -- #34 picked 25
-            # from a single 14m02s run and the very next CI run failed at 25m18s. Five
-            # runs of this leg on the fixed v1.3.2 pin, test step only:
-            #
-            #   5m35s   21m47s   23m46s   23m59s   25m27s
-            #
-            # A 4.6x spread on identical code, and the last of those is a run with
-            # nothing else of mine in flight, so the slow mode is the runner and not
-            # contention. The fast sample is the outlier; roughly 24m is the honest
-            # expectation. 35m is about 1.4x the worst seen, which is the headroom a
-            # distribution this wide needs. timeout-minutes sits above it as the backstop.
-            #
-            # For contrast, the same step on the v1.3.1 pin ran 38m52s WITHOUT FINISHING.
-            # The cost is in the vendored library rather than here: mas-bandwidth/fixed
-            # v1.3.2 put fixMul back on native __int128 operators, worth ~40% of a plain
-            # Debug run and more than that under -fsanitize-memory-track-origins, which
-            # instruments exactly the per-call stack traffic that was being added.
-            # mas-bandwidth/fixed#18 stays open for the rest of it (the fixInt128
-            # reductions in fixed_vec.h); this limit can come down again when that lands.
-            timeout: 40
-            test-timeout: 35m
-            args: '-DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18 -DCMAKE_C_FLAGS="-fsanitize=memory -fsanitize-memory-track-origins=1 -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-fsanitize=memory -fsanitize-memory-track-origins=1 -fno-omit-frame-pointer" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=memory"'
-            test: ./bin/test
-            msan-options: abort_on_error=1:halt_on_error=1
-          - name: macos
-            os: macos-latest
-            # 1m56s on main, past the 4-minute default on the inverse-widening branch.
-            # The widening puts 256-bit arithmetic on solver paths, and ASan/UBSan
-            # instrument exactly that shape hardest -- an optimized build pays about 15%
-            # on the joint-heavy benchmarks, this one pays more than double. Raised so the
-            # job reports a result rather than a timeout; the cost itself is part of what
-            # that branch is being judged on, not something to hide behind a limit.
-            timeout: 12
-            args: -DBOX3D_SANITIZE=ON
-            test: ./bin/test
-          # Pure MSVC cannot build the fixed-point core (no __int128); all
-          # Windows coverage uses clang-cl. No Windows ASan: clang-cl rejects
-          # /MTd with -fsanitize=address, and macos/ubuntu cover sanitizers.
-          # Fixed3D is width-4 SIMD only, so this covers the clang-cl toolchain, not AVX2.
-          - name: windows-clang-cl
-            os: windows-latest
-            msvc: true
-            args: -T ClangCL
-            test: ./bin/Debug/test
-          - name: windows-arm64
-            os: windows-11-arm
-            # No ASan here: arm64 clang-cl rejects /MTd with -fsanitize=address
-            args: -A arm64 -T ClangCL -DBOX3D_DISABLE_SIMD=TRUE
-            test: ./bin/Debug/test
-          # GitHub runners are not guaranteed AVX-512 hardware, so this job
-          # promises compile coverage only and runs the suite opportunistically
-          # when the runner happens to support the ISA. RelWithDebInfo (the
-          # trailing -D wins over the env BUILD_TYPE) also exercises the LTO
-          # default on clang.
-          - name: ubuntu-clang-avx512
-            os: ubuntu-latest
-            args: '-DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18 -DBOX3D_AVX512=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo'
-            test: 'sh -c "if grep -q avx512dq /proc/cpuinfo; then ./bin/test; else echo runner lacks AVX-512, compile-only; fi"'
-          # 128-bit world positions: build the wide b3Pos path under Debug+VALIDATE
-          # and ASan/UBSan (the int128 boundary, wire, and lerp reformulation are
-          # exercised here) so it cannot silently regress as upstream ports land.
-          # Carries its own determinism golden; OFF coverage is every other job.
+          # Keep wide-position goldens on every PR. The slower ASan+UBSan
+          # version remains in Extended checks.
           - name: ubuntu-wide-positions
             os: ubuntu-latest
-            timeout: 10
-            args: '-DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18 -DBOX3D_LUDICROUS_MODE=ON -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"'
+            config: Debug
+            args: '-DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18 -DBOX3D_LUDICROUS_MODE=ON'
             test: ./bin/test
-          # Optimized runs. The determinism golden hashes are otherwise only checked at -O0,
-          # and -O2 is where a codegen difference in the integer math would first show up.
-          # Upstream adds these against float contraction; here the value is the same job at
-          # a different optimization level, on the two toolchains that carry the goldens.
           - name: windows-relwithdebinfo
             os: windows-latest
             msvc: true
@@ -122,193 +49,46 @@ jobs:
           - name: macos-relwithdebinfo
             os: macos-latest
             config: RelWithDebInfo
+            args: -DBOX3D_NEON=ON
             test: ./bin/test
     steps:
-    - uses: actions/checkout@v6
+      - uses: actions/checkout@v6
 
-    - name: Setup MSVC dev command prompt
-      if: ${{ matrix.msvc }}
-      uses: TheMrMilchmann/setup-msvc-dev@v4
-      with:
-        arch: x64
+      - name: Setup MSVC dev command prompt
+        if: ${{ matrix.msvc }}
+        uses: TheMrMilchmann/setup-msvc-dev@v4
+        with:
+          arch: x64
 
-    - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{ matrix.config || env.BUILD_TYPE }} -DBOX3D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX3D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON ${{ matrix.args }}
+      - name: Configure CMake
+        run: cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.config }} -DBOX3D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX3D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON ${{ matrix.args }}
 
-    - name: Build
-      run: cmake --build ${{github.workspace}}/build --config ${{ matrix.config || env.BUILD_TYPE }}
+      - name: Build
+        run: cmake --build build --config ${{ matrix.config }} --parallel 2
 
-    # `test-timeout`, where a matrix entry sets one, wraps the command in coreutils
-    # `timeout`. That is deliberately not the same thing as timeout-minutes: this one
-    # FAILS (exit 124) instead of cancelling, so a leg that cannot finish reports as a
-    # red X rather than as a grey run with no conclusion in it. --kill-after promotes
-    # the TERM to a KILL for a process that ignores it (a sanitizer mid-report can),
-    # and --verbose puts the reason in the log instead of leaving a bare 124.
-    - name: Test
-      working-directory: ${{github.workspace}}/build
-      env:
-        MSAN_OPTIONS: ${{ matrix['msan-options'] || '' }}
-        UBSAN_OPTIONS: print_stacktrace=1
-      run: ${{ matrix['test-timeout'] && format('timeout --verbose --kill-after=60s {0} ', matrix['test-timeout']) || '' }}${{ matrix.test }}
+      # Run all suites, including cross-worker and uncached-golden checks.
+      - name: Test
+        working-directory: build
+        run: ${{ matrix.test }}
 
-  # mingw needs some extra setup so keeping it separate from the matrix.
-  # Debug -O0 copies whole structs and hid the b3SurfaceMaterial padding dedup bug.
-  # RelWithDebInfo tests -O2 codegen while B3_ENABLE_ASSERT keeps asserts alive,
-  # heavy validation stays Debug only.
-  build-windows-mingw:
-    name: windows-mingw
-    runs-on: windows-latest
-    timeout-minutes: 4
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    defaults:
-      run:
-        shell: msys2 {0}
-    steps:
-    - uses: actions/checkout@v6
-
-    - name: Setup MSYS2 UCRT64
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: UCRT64
-        update: true
-        install: >-
-          mingw-w64-ucrt-x86_64-gcc
-          mingw-w64-ucrt-x86_64-cmake
-          mingw-w64-ucrt-x86_64-ninja
-
-    - name: Configure CMake
-      run: cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBOX3D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX3D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
-
-    - name: Build
-      run: cmake --build build --config RelWithDebInfo
-
-    - name: Test
-      working-directory: build
-      run: ./bin/test
-
-  # Build-only: running the wasm test needs a node + pthread/SharedArrayBuffer harness.
-  # This still catches compile breaks in the box3d library and the test target.
-  emscripten:
-    name: emscripten
-    runs-on: ubuntu-latest
-    timeout-minutes: 8
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    steps:
-    - uses: actions/checkout@v6
-
-    - uses: mymindstorm/setup-emsdk@v14
-
-    - name: Configure CMake
-      run: emcmake cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBOX3D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX3D_VALIDATE=ON
-
-    - name: Build
-      run: cmake --build build --config Debug
-
-  samples:
-    name: ${{ matrix.name }}
-    runs-on: ${{ matrix.os }}
-    # macOS runners: the Release sample build plus the 102-TU conversion audit runs
-    # ~8+ min and was intermittently killed at the old 8-minute cap (a 8m21s run
-    # tripped it). Headroom, not a hang — the audit is bounded and exits on findings.
-    timeout-minutes: 15
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: samples-ubuntu-gcc-static
-            os: ubuntu-latest
-            linux-deps: true
-            args: -DBUILD_SHARED_LIBS=OFF
-          - name: samples-macos-static
-            os: macos-latest
-            # This entry also runs the fixed/float conversion audit: it needs a
-            # clang compile database (AppleClang here), which the export flag emits.
-            args: -DBUILD_SHARED_LIBS=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-            conversion-audit: true
-          - name: samples-macos-dynamic
-            os: macos-latest
-            args: -DBUILD_SHARED_LIBS=ON
-          - name: samples-windows-static
-            os: windows-latest
-            msvc: true
-            args: -T ClangCL -DBUILD_SHARED_LIBS=OFF
-          - name: samples-windows-dynamic
-            os: windows-latest
-            msvc: true
-            args: -T ClangCL -DBUILD_SHARED_LIBS=ON
-    steps:
-    - uses: actions/checkout@v6
-
-    - name: Setup MSVC dev command prompt
-      if: ${{ matrix.msvc }}
-      uses: TheMrMilchmann/setup-msvc-dev@v4
-      with:
-        arch: x64
-
-    # sokol_app needs X11/Xi/Xcursor + GL, the file dialog needs GTK3.
-    - name: Install Linux sample dependencies
-      if: ${{ matrix['linux-deps'] }}
-      run: sudo apt-get update && sudo apt-get install -y libgl1-mesa-dev libx11-dev libxi-dev libxcursor-dev libgtk-3-dev
-
-    - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX3D_SAMPLES=ON -DBOX3D_UNIT_TESTS=OFF ${{ matrix.args }}
-
-    - name: Build
-      run: cmake --build ${{github.workspace}}/build --config Release
-
-    # Type-aware audit of every b3Fixed<->float/int conversion in consumer code
-    # (exits 1 on findings). Catches the silent-truncation bug classes that
-    # -Wfloat-conversion cannot see; clang-only, hence the macos entry.
-    - name: Conversion audit
-      if: ${{ matrix['conversion-audit'] }}
-      run: python3 tools/fixed-point/conversion_audit.py --db ${{github.workspace}}/build/compile_commands.json
-
-  # THE FAILURE STATE FOR THIS WORKFLOW.
-  #
-  # Every job above carries a timeout-minutes, and a job killed by one finishes
-  # CANCELLED. Cancelled is not failure: the run reports conclusion "cancelled", the
-  # commit gets a grey mark rather than a red one, and anything reading for
-  # `conclusion == 'failure'` sees nothing at all. So the loudest symptom a CI leg can
-  # have -- it did not finish -- was the quietest thing this workflow could report, and
-  # ubuntu-clang-msan sat past its limit on main for several consecutive merges without
-  # a red X anywhere.
-  #
-  # This job is the reader. It needs every other job, runs even when they fail, and
-  # fails unless each one succeeded or was legitimately skipped (the draft-PR guard).
-  # A cancelled leg becomes a failing check here, which is what "required check" can
-  # then be pointed at. If a HUMAN cancels the whole run, this job is cancelled with it
-  # and never runs, so that case stays what it is rather than turning into a false red.
   result:
     name: build_test result
     runs-on: ubuntu-latest
-    timeout-minutes: 2
-    needs: [test, build-windows-mingw, emscripten, samples]
+    timeout-minutes: 1
+    needs: [test]
     if: always()
     steps:
-      - name: Every job finished, and finished green
+      - name: Every fast check finished successfully
+        env:
+          TEST_RESULT: ${{ needs.test.result }}
+          IS_DRAFT: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft }}
         run: |
           set -euo pipefail
-          failed=0
-          for entry in \
-            "test=${{ needs.test.result }}" \
-            "build-windows-mingw=${{ needs['build-windows-mingw'].result }}" \
-            "emscripten=${{ needs.emscripten.result }}" \
-            "samples=${{ needs.samples.result }}"
-          do
-            name="${entry%%=*}"
-            result="${entry#*=}"
-            printf '%-22s %s\n' "$name" "$result"
-            case "$result" in
-              success|skipped) ;;
-              cancelled)
-                echo "::error::$name did not finish -- it hit its time limit and was cancelled. A leg that cannot finish is a failure, not a neutral result."
-                failed=1
-                ;;
-              *)
-                echo "::error::$name reported '$result'"
-                failed=1
-                ;;
-            esac
-          done
-          exit $failed
+          if [ "$TEST_RESULT" = success ]; then
+            exit 0
+          fi
+          if [ "$TEST_RESULT" = skipped ] && [ "$IS_DRAFT" = true ]; then
+            exit 0
+          fi
+          echo "::error::Fast checks reported '$TEST_RESULT'; failed, cancelled and unexpected skipped jobs do not pass."
+          exit 1

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -1,0 +1,307 @@
+# Full sanitizer, platform and sample coverage, run manually from Actions.
+# Keep long jobs here so pull-request feedback targets 1-2 minutes.
+# https://docs.github.com/en/actions
+name: Extended checks
+
+on:
+  workflow_dispatch:
+
+env:
+  BUILD_TYPE: Debug
+
+jobs:
+  test:
+    name: extended / ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: ${{ matrix.timeout || 4 }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ubuntu-gcc
+            os: ubuntu-latest
+            test: ./bin/test
+          - name: ubuntu-clang
+            os: ubuntu-latest
+            args: '-DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18 -DCMAKE_C_FLAGS="-fsanitize=thread -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-fsanitize=thread -fno-omit-frame-pointer" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread"'
+            test: ./bin/test
+          - name: ubuntu-clang-msan
+            os: ubuntu-latest
+            # THE LIMIT THAT MATTERS IS THE ONE ON THE TEST COMMAND, not timeout-minutes.
+            # A job killed by timeout-minutes finishes CANCELLED, and cancelled is not
+            # failure: the run goes grey, `conclusion` reads "cancelled", and an entire
+            # sanitizer leg absents itself without anything going red. This job did that
+            # on main for several consecutive merges. `timeout` exits 124, which fails
+            # the step, which fails the job -- an overrun here is a red X that says
+            # "ubuntu-clang-msan did not finish", which is the honest report.
+            # timeout-minutes stays as a backstop for the case the inner bound cannot
+            # cover (a hung build step, a wedged runner) and is set above it on purpose.
+            # The result job at the end of this file is the third layer: it turns a
+            # cancelled leg anywhere in this matrix into a failing extended-workflow result.
+            #
+            # 35m IS SET FROM THE OBSERVED SPREAD, not from one sample -- #34 picked 25
+            # from a single 14m02s run and the very next CI run failed at 25m18s. Five
+            # runs of this leg on the fixed v1.3.2 pin, test step only:
+            #
+            #   5m35s   21m47s   23m46s   23m59s   25m27s
+            #
+            # A 4.6x spread on identical code, and the last of those is a run with
+            # nothing else of mine in flight, so the slow mode is the runner and not
+            # contention. The fast sample is the outlier; roughly 24m is the honest
+            # expectation. 35m is about 1.4x the worst seen, which is the headroom a
+            # distribution this wide needs. timeout-minutes sits above it as the backstop.
+            #
+            # For contrast, the same step on the v1.3.1 pin ran 38m52s WITHOUT FINISHING.
+            # The cost is in the vendored library rather than here: mas-bandwidth/fixed
+            # v1.3.2 put fixMul back on native __int128 operators, worth ~40% of a plain
+            # Debug run and more than that under -fsanitize-memory-track-origins, which
+            # instruments exactly the per-call stack traffic that was being added.
+            # mas-bandwidth/fixed#18 stays open for the rest of it (the fixInt128
+            # reductions in fixed_vec.h); this limit can come down again when that lands.
+            timeout: 40
+            test-timeout: 35m
+            args: '-DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18 -DCMAKE_C_FLAGS="-fsanitize=memory -fsanitize-memory-track-origins=1 -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-fsanitize=memory -fsanitize-memory-track-origins=1 -fno-omit-frame-pointer" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=memory"'
+            test: ./bin/test
+            msan-options: abort_on_error=1:halt_on_error=1
+          - name: macos
+            os: macos-latest
+            # 1m56s on main, past the 4-minute default on the inverse-widening branch.
+            # The widening puts 256-bit arithmetic on solver paths, and ASan/UBSan
+            # instrument exactly that shape hardest -- an optimized build pays about 15%
+            # on the joint-heavy benchmarks, this one pays more than double. Raised so the
+            # job reports a result rather than a timeout; the cost itself is part of what
+            # that branch is being judged on, not something to hide behind a limit.
+            timeout: 12
+            args: -DBOX3D_SANITIZE=ON
+            test: ./bin/test
+          # Pure MSVC cannot build the fixed-point core (no __int128); all
+          # Windows coverage uses clang-cl. No Windows ASan: clang-cl rejects
+          # /MTd with -fsanitize=address, and macos/ubuntu cover sanitizers.
+          # Fixed3D is width-4 SIMD only, so this covers the clang-cl toolchain, not AVX2.
+          - name: windows-clang-cl
+            os: windows-latest
+            msvc: true
+            args: -T ClangCL
+            test: ./bin/Debug/test
+          - name: windows-arm64
+            os: windows-11-arm
+            # No ASan here: arm64 clang-cl rejects /MTd with -fsanitize=address
+            args: -A arm64 -T ClangCL -DBOX3D_DISABLE_SIMD=TRUE
+            test: ./bin/Debug/test
+          # GitHub runners are not guaranteed AVX-512 hardware, so this job
+          # promises compile coverage only and runs the suite opportunistically
+          # when the runner happens to support the ISA. RelWithDebInfo (the
+          # trailing -D wins over the env BUILD_TYPE) also exercises the LTO
+          # default on clang.
+          - name: ubuntu-clang-avx512
+            os: ubuntu-latest
+            args: '-DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18 -DBOX3D_AVX512=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo'
+            test: 'sh -c "if grep -q avx512dq /proc/cpuinfo; then ./bin/test; else echo runner lacks AVX-512, compile-only; fi"'
+          # 128-bit world positions: build the wide b3Pos path under Debug+VALIDATE
+          # and ASan/UBSan (the int128 boundary, wire, and lerp reformulation are
+          # exercised here) so it cannot silently regress as upstream ports land.
+          # Carries its own determinism golden; OFF coverage is every other job.
+          - name: ubuntu-wide-positions
+            os: ubuntu-latest
+            timeout: 10
+            args: '-DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18 -DBOX3D_LUDICROUS_MODE=ON -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"'
+            test: ./bin/test
+          # Optimized runs. The determinism golden hashes are otherwise only checked at -O0,
+          # and -O2 is where a codegen difference in the integer math would first show up.
+          # Upstream adds these against float contraction; here the value is the same job at
+          # a different optimization level, on the two toolchains that carry the goldens.
+          - name: windows-relwithdebinfo
+            os: windows-latest
+            msvc: true
+            config: RelWithDebInfo
+            args: -T ClangCL
+            test: ./bin/RelWithDebInfo/test
+          - name: macos-relwithdebinfo
+            os: macos-latest
+            config: RelWithDebInfo
+            test: ./bin/test
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Setup MSVC dev command prompt
+      if: ${{ matrix.msvc }}
+      uses: TheMrMilchmann/setup-msvc-dev@v4
+      with:
+        arch: x64
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{ matrix.config || env.BUILD_TYPE }} -DBOX3D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX3D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON ${{ matrix.args }}
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{ matrix.config || env.BUILD_TYPE }}
+
+    # `test-timeout`, where a matrix entry sets one, wraps the command in coreutils
+    # `timeout`. That is deliberately not the same thing as timeout-minutes: this one
+    # FAILS (exit 124) instead of cancelling, so a leg that cannot finish reports as a
+    # red X rather than as a grey run with no conclusion in it. --kill-after promotes
+    # the TERM to a KILL for a process that ignores it (a sanitizer mid-report can),
+    # and --verbose puts the reason in the log instead of leaving a bare 124.
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      env:
+        MSAN_OPTIONS: ${{ matrix['msan-options'] || '' }}
+        UBSAN_OPTIONS: print_stacktrace=1
+      run: ${{ matrix['test-timeout'] && format('timeout --verbose --kill-after=60s {0} ', matrix['test-timeout']) || '' }}${{ matrix.test }}
+
+  # mingw needs some extra setup so keeping it separate from the matrix.
+  # Debug -O0 copies whole structs and hid the b3SurfaceMaterial padding dedup bug.
+  # RelWithDebInfo tests -O2 codegen while B3_ENABLE_ASSERT keeps asserts alive,
+  # heavy validation stays Debug only.
+  build-windows-mingw:
+    name: extended / windows-mingw
+    runs-on: windows-latest
+    timeout-minutes: 4
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Setup MSYS2 UCRT64
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: UCRT64
+        update: true
+        install: >-
+          mingw-w64-ucrt-x86_64-gcc
+          mingw-w64-ucrt-x86_64-cmake
+          mingw-w64-ucrt-x86_64-ninja
+
+    - name: Configure CMake
+      run: cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBOX3D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX3D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+
+    - name: Build
+      run: cmake --build build --config RelWithDebInfo
+
+    - name: Test
+      working-directory: build
+      run: ./bin/test
+
+  # Build-only: running the wasm test needs a node + pthread/SharedArrayBuffer harness.
+  # This still catches compile breaks in the box3d library and the test target.
+  emscripten:
+    name: extended / emscripten
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+    - uses: actions/checkout@v6
+
+    - uses: mymindstorm/setup-emsdk@v14
+
+    - name: Configure CMake
+      run: emcmake cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBOX3D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX3D_VALIDATE=ON
+
+    - name: Build
+      run: cmake --build build --config Debug
+
+  samples:
+    name: extended / ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    # macOS runners: the Release sample build plus the 102-TU conversion audit runs
+    # ~8+ min and was intermittently killed at the old 8-minute cap (a 8m21s run
+    # tripped it). Headroom, not a hang — the audit is bounded and exits on findings.
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: samples-ubuntu-gcc-static
+            os: ubuntu-latest
+            linux-deps: true
+            args: -DBUILD_SHARED_LIBS=OFF
+          - name: samples-macos-static
+            os: macos-latest
+            # This entry also runs the fixed/float conversion audit: it needs a
+            # clang compile database (AppleClang here), which the export flag emits.
+            args: -DBUILD_SHARED_LIBS=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+            conversion-audit: true
+          - name: samples-macos-dynamic
+            os: macos-latest
+            args: -DBUILD_SHARED_LIBS=ON
+          - name: samples-windows-static
+            os: windows-latest
+            msvc: true
+            args: -T ClangCL -DBUILD_SHARED_LIBS=OFF
+          - name: samples-windows-dynamic
+            os: windows-latest
+            msvc: true
+            args: -T ClangCL -DBUILD_SHARED_LIBS=ON
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Setup MSVC dev command prompt
+      if: ${{ matrix.msvc }}
+      uses: TheMrMilchmann/setup-msvc-dev@v4
+      with:
+        arch: x64
+
+    # sokol_app needs X11/Xi/Xcursor + GL, the file dialog needs GTK3.
+    - name: Install Linux sample dependencies
+      if: ${{ matrix['linux-deps'] }}
+      run: sudo apt-get update && sudo apt-get install -y libgl1-mesa-dev libx11-dev libxi-dev libxcursor-dev libgtk-3-dev
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX3D_SAMPLES=ON -DBOX3D_UNIT_TESTS=OFF ${{ matrix.args }}
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config Release
+
+    # Type-aware audit of every b3Fixed<->float/int conversion in consumer code
+    # (exits 1 on findings). Catches the silent-truncation bug classes that
+    # -Wfloat-conversion cannot see; clang-only, hence the macos entry.
+    - name: Conversion audit
+      if: ${{ matrix['conversion-audit'] }}
+      run: python3 tools/fixed-point/conversion_audit.py --db ${{github.workspace}}/build/compile_commands.json
+
+  # THE FAILURE STATE FOR THIS WORKFLOW.
+  #
+  # Every job above carries a timeout-minutes, and a job killed by one finishes
+  # CANCELLED. Cancelled is not failure: the run reports conclusion "cancelled", the
+  # commit gets a grey mark rather than a red one, and anything reading for
+  # `conclusion == 'failure'` sees nothing at all. So the loudest symptom a CI leg can
+  # have -- it did not finish -- was the quietest thing this workflow could report, and
+  # ubuntu-clang-msan sat past its limit on main for several consecutive merges without
+  # a red X anywhere.
+  #
+  # This job is the reader. It needs every other job, runs even when they fail, and
+  # fails unless each one succeeded or was legitimately skipped (the draft-PR guard).
+  # A cancelled leg becomes a failing extended-workflow result here. If a HUMAN cancels the whole run, this job is cancelled with it
+  # and never runs, so that case stays what it is rather than turning into a false red.
+  result:
+    name: extended result
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    needs: [test, build-windows-mingw, emscripten, samples]
+    if: always()
+    steps:
+      - name: Every job finished, and finished green
+        run: |
+          set -euo pipefail
+          failed=0
+          for entry in \
+            "test=${{ needs.test.result }}" \
+            "build-windows-mingw=${{ needs['build-windows-mingw'].result }}" \
+            "emscripten=${{ needs.emscripten.result }}" \
+            "samples=${{ needs.samples.result }}"
+          do
+            name="${entry%%=*}"
+            result="${entry#*=}"
+            printf '%-22s %s\n' "$name" "$result"
+            case "$result" in
+              success) ;;
+              cancelled)
+                echo "::error::$name did not finish -- it hit its time limit and was cancelled. A leg that cannot finish is a failure, not a neutral result."
+                failed=1
+                ;;
+              *)
+                echo "::error::$name reported '$result'"
+                failed=1
+                ;;
+            esac
+          done
+          exit $failed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,11 +27,42 @@ architecture. A change that makes results depend on the compiler, the target
 architecture, or the optimization level defeats the reason this fork exists, and it will
 not be merged however fast it is.
 
-The test suite checks this and CI enforces it: gcc, clang, clang-cl, MinGW and emscripten,
-on Linux, macOS, and Windows x64 and ARM64, under thread, memory, address and
-undefined-behavior sanitizers, plus AVX-512 and 128-bit world position variants. If your
-change turns any of that red, it is not ready. Performance work is very welcome, but it
-has to produce the same bits.
+The full unit suite, including cross-worker and uncached-golden checks, runs on every
+pull request with GCC, Clang/ThreadSanitizer, clang-cl and ARM64 NEON, covering Linux,
+Windows, macOS and both position widths. The extended workflow adds the slower sanitizer,
+platform and sample coverage described below. A known failing check must be investigated;
+moving a check off the PR path does not make its findings optional. Performance work is
+very welcome, but it has to produce the same bits.
+
+## Fast and extended CI
+
+PR and main-branch checks target **1–2 minutes**, excluding runner queue time. The
+`build_test` workflow runs all 24 suites in five configurations: Linux GCC Debug,
+Linux Clang Debug with ThreadSanitizer, Linux wide-position Debug, Windows optimized
+clang-cl and macOS optimized NEON. `build_test result` fails if a job fails, times out
+or unexpectedly skips. The contributor-agreement and vendor-drift checks also remain
+on PRs. A three-minute job backstop allows runner variance; it is not a new timing target.
+
+The manually triggered **Extended checks** workflow preserves the complete previous
+matrix: MemorySanitizer, macOS ASan/UBSan, wide-position ASan/UBSan, Windows Debug and
+ARM64, MinGW, AVX-512, Emscripten compile coverage, every static/dynamic sample build,
+and the fixed/float conversion audit. It also reruns the common core configurations.
+Its aggregate result fails on failed, cancelled or skipped jobs; long sanitizer runs
+retain their existing explicit time limits.
+
+Run extended coverage when relevant to an arithmetic, concurrency, portability,
+sample or rendering change, and investigate any failures before calling the change
+validated. In GitHub Actions, select **Extended checks → Run workflow** and choose
+the branch, or use:
+
+```sh
+gh workflow run extended.yml --repo mas-bandwidth/fixed3d --ref <branch>
+```
+
+The split was based on measured execution times: the conversion audit job took 7m47s,
+wide-position sanitizers 3m29s, macOS sanitizers 3m09s, MinGW 3m01s and Windows sample
+builds 2m30s–2m41s. MemorySanitizer is substantially longer. Keep later slow additions
+in the extended workflow and measure PR time after changing the fast matrix.
 
 ## Opening a pull request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ architecture, or the optimization level defeats the reason this fork exists, and
 not be merged however fast it is.
 
 The full unit suite, including cross-worker and uncached-golden checks, runs on every
-pull request with GCC, Clang/ThreadSanitizer, clang-cl and ARM64 NEON, covering Linux,
+pull request with GCC, Clang, clang-cl and ARM64 NEON, covering Linux,
 Windows, macOS and both position widths. The extended workflow adds the slower sanitizer,
 platform and sample coverage described below. A known failing check must be investigated;
 moving a check off the PR path does not make its findings optional. Performance work is
@@ -38,13 +38,13 @@ very welcome, but it has to produce the same bits.
 
 PR and main-branch checks target **1–2 minutes**, excluding runner queue time. The
 `build_test` workflow runs all 24 suites in five configurations: Linux GCC Debug,
-Linux Clang Debug with ThreadSanitizer, Linux wide-position Debug, Windows optimized
+Linux Clang Debug, Linux wide-position Debug, Windows optimized
 clang-cl and macOS optimized NEON. `build_test result` fails if a job fails, times out
 or unexpectedly skips. The contributor-agreement and vendor-drift checks also remain
 on PRs. A three-minute job backstop allows runner variance; it is not a new timing target.
 
 The manually triggered **Extended checks** workflow preserves the complete previous
-matrix: MemorySanitizer, macOS ASan/UBSan, wide-position ASan/UBSan, Windows Debug and
+matrix: ThreadSanitizer, MemorySanitizer, macOS ASan/UBSan, wide-position ASan/UBSan, Windows Debug and
 ARM64, MinGW, AVX-512, Emscripten compile coverage, every static/dynamic sample build,
 and the fixed/float conversion audit. It also reruns the common core configurations.
 Its aggregate result fails on failed, cancelled or skipped jobs; long sanitizer runs
@@ -61,7 +61,8 @@ gh workflow run extended.yml --repo mas-bandwidth/fixed3d --ref <branch>
 
 The split was based on measured execution times: the conversion audit job took 7m47s,
 wide-position sanitizers 3m29s, macOS sanitizers 3m09s, MinGW 3m01s and Windows sample
-builds 2m30s–2m41s. MemorySanitizer is substantially longer. Keep later slow additions
+builds 2m30s–2m41s. MemorySanitizer is substantially longer; ThreadSanitizer also exceeded two
+minutes in the first fast-run trial and remains in extended coverage. Keep later slow additions
 in the extended workflow and measure PR time after changing the fast matrix.
 
 ## Opening a pull request

--- a/README.md
+++ b/README.md
@@ -86,6 +86,19 @@ linear-only motors, and 3.8–7.7% for rigid or rotation-locked welds. All 8,640
 additional before/after state-and-force hashes match, including runtime feature
 changes. The full-suite float ratio above has not been remeasured for this pass.
 
+A [spherical-joint pass](benchmark/2026-09-07-spherical-cache-performance.md)
+reuses rotated anchors between position updates and skips unused angular mass
+and limit-axis calculations. Joint Grid runtime falls **12.8%** in the final
+four-worker recheck. The cache adds 48 bytes per internal joint; broader timings
+were too noisy to establish a new overall float ratio.
+
+**Determinism across threads is a hard requirement.** Given the same initial
+state and ordered inputs, worker count and scheduling must not change the physics.
+Cache validity follows solver-stage generations, never timing or worker identity.
+The new regression checks workers 1–8 against uncached reference results, including
+parallel joint blocks, overflow joints and runtime changes. Wide arithmetic and
+the high-mass asteroid response remain intact.
+
 These are measurements on a shared workstation. Small scene differences are
 inconclusive; the library repair also changes trajectories and contact counts.
 The percentage improvements above measure separate changes and are not additive.

--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ Fixed3D is maintained by [Glenn Fiedler](https://github.com/gafferongames) and
 [Rowan](https://github.com/rowan-claude), Glenn's AI collaborator. New work
 landing in Box3D gets ported across.
 
+PR checks target 1–2 minutes and retain the full determinism suite. Slower
+sanitizer, platform and sample/audit jobs are available through the manually
+triggered **Extended checks** workflow; see [CI instructions](CONTRIBUTING.md#fast-and-extended-ci).
+
 Issues specific to Fixed3D are welcome
 [here](https://github.com/mas-bandwidth/fixed3d/issues). For issues with Box3D
 in general, please use the

--- a/benchmark/2026-09-07-spherical-cache-performance.json
+++ b/benchmark/2026-09-07-spherical-cache-performance.json
@@ -1,0 +1,993 @@
+{
+  "baseline": "8048b7844fd314b8fd7d6a65bfd32bf39c63886c",
+  "machine": "Apple M3 Ultra; macOS 26.6.2; Apple Clang 21; arm64 -O2 thin LTO; NEON; 4 workers, 4 substeps",
+  "internal_joint_bytes": {
+    "before": 864,
+    "after": 912,
+    "rejected_matrix_cache": 992
+  },
+  "note": "Four initial timing batches precede the all-sleeping tree-join repair; after-tree-fix measures the final code. No observations discarded. Shared-machine contention prevents an overall performance claim. See the accompanying report.",
+  "batches": {
+    "first": {
+      "diff": "diff --git a/src/joint.h b/src/joint.h\nindex 48520f0..fae9057 100644\n--- a/src/joint.h\n+++ b/src/joint.h\n@@ -262,6 +262,13 @@ typedef struct b3SphericalJoint\n \tb3Fixed twistMass;\n \tb3Softness springSoftness;\n \n+\t// Transient point-constraint geometry, invalidated each prepare/integration.\n+\tb3Vec3 cachedAnchorA;\n+\tb3Vec3 cachedAnchorB;\n+\tb3Matrix3 cachedPointMatrix;\n+\tint geometryGeneration;\n+\tint matrixGeneration;\n+\n \tbool enableSpring;\n \tbool enableMotor;\n \tbool enableConeLimit;\ndiff --git a/src/spherical_joint.c b/src/spherical_joint.c\nindex 785641d..f872bfc 100644\n--- a/src/spherical_joint.c\n+++ b/src/spherical_joint.c\n@@ -319,6 +319,8 @@ void b3PrepareSphericalJoint( b3JointSim* base, b3StepContext* context )\n \tbase->fixedRotation = invInertiaSum.cx.x + invInertiaSum.cy.y + invInertiaSum.cz.z == 0;\n \n \tb3SphericalJoint* joint = &base->sphericalJoint;\n+\tjoint->geometryGeneration = -1;\n+\tjoint->matrixGeneration = -1;\n \tjoint->indexA = bodyA->setIndex == b3_awakeSet ? localIndexA : B3_NULL_INDEX;\n \tjoint->indexB = bodyB->setIndex == b3_awakeSet ? localIndexB : B3_NULL_INDEX;\n \n@@ -359,7 +361,8 @@ void b3PrepareSphericalJoint( b3JointSim* base, b3StepContext* context )\n \t\tjoint->twistJacobian = twistJacobian;\n \t}\n \n-\tif ( base->fixedRotation == false )\n+\t// Only spring and motor constraints use the angular mass matrix.\n+\tif ( base->fixedRotation == false && ( joint->enableSpring || joint->enableMotor ) )\n \t{\n \t\tjoint->rotationMass = b3InvertAcrossScales( invInertiaSum );\n \t}\n@@ -381,6 +384,19 @@ void b3PrepareSphericalJoint( b3JointSim* base, b3StepContext* context )\n \t}\n }\n \n+// Only position integration changes these anchors within a step. The existing\n+// stage barriers publish positionGeneration before any joint uses the new poses.\n+static inline void b3UpdateSphericalAnchors( b3SphericalJoint* joint, const b3BodyState* stateA,\n+                                           const b3BodyState* stateB, int generation )\n+{\n+\tif ( joint->geometryGeneration != generation )\n+\t{\n+\t\tjoint->cachedAnchorA = b3RotateVector( stateA->deltaRotation, joint->frameA.p );\n+\t\tjoint->cachedAnchorB = b3RotateVector( stateB->deltaRotation, joint->frameB.p );\n+\t\tjoint->geometryGeneration = generation;\n+\t}\n+}\n+\n void b3WarmStartSphericalJoint( b3JointSim* base, b3StepContext* context )\n {\n \tB3_ASSERT( base->type == b3_sphericalJoint );\n@@ -403,8 +419,9 @@ void b3WarmStartSphericalJoint( b3JointSim* base, b3StepContext* context )\n \tb3Vec3 vB = stateB->linearVelocity;\n \tb3Vec3 wB = stateB->angularVelocity;\n \n-\tb3Vec3 rA = b3RotateVector( stateA->deltaRotation, joint->frameA.p );\n-\tb3Vec3 rB = b3RotateVector( stateB->deltaRotation, joint->frameB.p );\n+\tb3UpdateSphericalAnchors( joint, stateA, stateB, context->positionGeneration );\n+\tb3Vec3 rA = joint->cachedAnchorA;\n+\tb3Vec3 rB = joint->cachedAnchorB;\n \n \tb3Vec3 angularImpulse = b3Add( joint->springImpulse, joint->motorImpulse );\n \tangularImpulse = b3MulSub( angularImpulse, joint->swingImpulse, joint->swingAxis );\n@@ -609,8 +626,9 @@ void b3SolveSphericalJoint( b3JointSim* base, b3StepContext* context, bool useBi\n \n \t// Solve point-to-point constraint\n \t{\n-\t\tb3Vec3 rA = b3RotateVector( stateA->deltaRotation, joint->frameA.p );\n-\t\tb3Vec3 rB = b3RotateVector( stateB->deltaRotation, joint->frameB.p );\n+\t\tb3UpdateSphericalAnchors( joint, stateA, stateB, context->positionGeneration );\n+\t\tb3Vec3 rA = joint->cachedAnchorA;\n+\t\tb3Vec3 rB = joint->cachedAnchorB;\n \n \t\tb3Vec3 cdot = b3Sub( b3Sub( b3Add( vB, b3Cross( wB, rB ) ), vA ), b3Cross( wA, rA ) );\n \n@@ -635,15 +653,21 @@ void b3SolveSphericalJoint( b3JointSim* base, b3StepContext* context, bool useBi\n \t\t// Zero RHS has an exact zero solution; accumulated impulses still apply below.\n \t\tif ( rhs.x != 0 || rhs.y != 0 || rhs.z != 0 )\n \t\t{\n-\t\t\t//// K = [(1/m1 + 1/m2) * eye(2) - skew(r1) * invI1 * skew(r1) - skew(r2) * invI2 * skew(r2)]\n-\t\t\tb3Matrix3 kA = b3SkewSandwich( base->invIA, rA );\n-\t\t\tb3Matrix3 kB = b3SkewSandwich( base->invIB, rB );\n-\t\t\tb3Matrix3 k = b3NegateMat3( b3AddMM( kA, kB ) );\n-\t\t\tk.cx.x += mA + mB;\n-\t\t\tk.cy.y += mA + mB;\n-\t\t\tk.cz.z += mA + mB;\n-\n-\t\t\tb = b3Solve3AcrossScales( k, rhs );\n+\t\t\tif ( joint->matrixGeneration != context->positionGeneration )\n+\t\t\t{\n+\t\t\t\t//// K = [(1/m1 + 1/m2) * eye(2) - skew(r1) * invI1 * skew(r1) - skew(r2) * invI2 * skew(r2)]\n+\t\t\t\tb3Matrix3 kA = b3SkewSandwich( base->invIA, rA );\n+\t\t\t\tb3Matrix3 kB = b3SkewSandwich( base->invIB, rB );\n+\t\t\t\tb3Matrix3 k = b3NegateMat3( b3AddMM( kA, kB ) );\n+\t\t\t\tk.cx.x += mA + mB;\n+\t\t\t\tk.cy.y += mA + mB;\n+\t\t\t\tk.cz.z += mA + mB;\n+\n+\t\t\t\tjoint->cachedPointMatrix = k;\n+\t\t\t\tjoint->matrixGeneration = context->positionGeneration;\n+\t\t\t}\n+\n+\t\t\tb = b3Solve3AcrossScales( joint->cachedPointMatrix, rhs );\n \t\t}\n \n \t\tb3Vec3 impulse = b3MulSub( b3MulSV( -massScale, b ), impulseScale, joint->linearImpulse );\n",
+      "hashes": {
+        "before": "b1e391977be1d60781eaa88edd9fdad835d3734cb03e6617f4606706f54a2835",
+        "angular": "eba0f1f4afd81dcb4afdd60d422d564cb747ade56815673ed4f09f269f4e2609",
+        "cache": "640111f50f7639ad9699bab511cb6d6ee551cecc613f4771384dbe971f2a59c3"
+      },
+      "rows": [
+        {
+          "scene": "joint_grid",
+          "runs": [
+            {
+              "binary": "before",
+              "ms": 645.061,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "angular",
+              "ms": 601.92,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "cache",
+              "ms": 575.72,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "cache",
+              "ms": 588.448,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "angular",
+              "ms": 630.976,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "before",
+              "ms": 673.661,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            }
+          ],
+          "medians_ms": {
+            "before": 659.361,
+            "angular": 616.448,
+            "cache": 582.0840000000001
+          }
+        },
+        {
+          "scene": "rain",
+          "runs": [
+            {
+              "binary": "before",
+              "ms": 1451.59,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+            },
+            {
+              "binary": "angular",
+              "ms": 1435.36,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+            },
+            {
+              "binary": "cache",
+              "ms": 1837.97,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+            },
+            {
+              "binary": "cache",
+              "ms": 1787.54,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+            },
+            {
+              "binary": "angular",
+              "ms": 1394.12,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+            },
+            {
+              "binary": "before",
+              "ms": 1433.81,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+            }
+          ],
+          "medians_ms": {
+            "before": 1442.6999999999998,
+            "angular": 1414.7399999999998,
+            "cache": 1812.755
+          }
+        },
+        {
+          "scene": "large_pyramid",
+          "runs": [
+            {
+              "binary": "before",
+              "ms": 1599.49,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+            },
+            {
+              "binary": "angular",
+              "ms": 1593.83,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+            },
+            {
+              "binary": "cache",
+              "ms": 1614.12,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+            },
+            {
+              "binary": "cache",
+              "ms": 1607.48,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+            },
+            {
+              "binary": "angular",
+              "ms": 1585.92,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+            },
+            {
+              "binary": "before",
+              "ms": 1557.13,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+            }
+          ],
+          "medians_ms": {
+            "before": 1578.31,
+            "angular": 1589.875,
+            "cache": 1610.8
+          }
+        }
+      ]
+    },
+    "anchors": {
+      "diff": "diff --git a/src/joint.h b/src/joint.h\nindex 48520f0..957d733 100644\n--- a/src/joint.h\n+++ b/src/joint.h\n@@ -262,6 +262,11 @@ typedef struct b3SphericalJoint\n \tb3Fixed twistMass;\n \tb3Softness springSoftness;\n \n+\t// Transient point-constraint geometry, invalidated each prepare/integration.\n+\tb3Vec3 cachedAnchorA;\n+\tb3Vec3 cachedAnchorB;\n+\tint geometryGeneration;\n+\n \tbool enableSpring;\n \tbool enableMotor;\n \tbool enableConeLimit;\ndiff --git a/src/spherical_joint.c b/src/spherical_joint.c\nindex 785641d..e28df68 100644\n--- a/src/spherical_joint.c\n+++ b/src/spherical_joint.c\n@@ -319,6 +319,7 @@ void b3PrepareSphericalJoint( b3JointSim* base, b3StepContext* context )\n \tbase->fixedRotation = invInertiaSum.cx.x + invInertiaSum.cy.y + invInertiaSum.cz.z == 0;\n \n \tb3SphericalJoint* joint = &base->sphericalJoint;\n+\tjoint->geometryGeneration = -1;\n \tjoint->indexA = bodyA->setIndex == b3_awakeSet ? localIndexA : B3_NULL_INDEX;\n \tjoint->indexB = bodyB->setIndex == b3_awakeSet ? localIndexB : B3_NULL_INDEX;\n \n@@ -359,7 +360,8 @@ void b3PrepareSphericalJoint( b3JointSim* base, b3StepContext* context )\n \t\tjoint->twistJacobian = twistJacobian;\n \t}\n \n-\tif ( base->fixedRotation == false )\n+\t// Only spring and motor constraints use the angular mass matrix.\n+\tif ( base->fixedRotation == false && ( joint->enableSpring || joint->enableMotor ) )\n \t{\n \t\tjoint->rotationMass = b3InvertAcrossScales( invInertiaSum );\n \t}\n@@ -381,6 +383,19 @@ void b3PrepareSphericalJoint( b3JointSim* base, b3StepContext* context )\n \t}\n }\n \n+// Only position integration changes these anchors within a step. The existing\n+// stage barriers publish positionGeneration before any joint uses the new poses.\n+static inline void b3UpdateSphericalAnchors( b3SphericalJoint* joint, const b3BodyState* stateA,\n+                                           const b3BodyState* stateB, int generation )\n+{\n+\tif ( joint->geometryGeneration != generation )\n+\t{\n+\t\tjoint->cachedAnchorA = b3RotateVector( stateA->deltaRotation, joint->frameA.p );\n+\t\tjoint->cachedAnchorB = b3RotateVector( stateB->deltaRotation, joint->frameB.p );\n+\t\tjoint->geometryGeneration = generation;\n+\t}\n+}\n+\n void b3WarmStartSphericalJoint( b3JointSim* base, b3StepContext* context )\n {\n \tB3_ASSERT( base->type == b3_sphericalJoint );\n@@ -403,8 +418,9 @@ void b3WarmStartSphericalJoint( b3JointSim* base, b3StepContext* context )\n \tb3Vec3 vB = stateB->linearVelocity;\n \tb3Vec3 wB = stateB->angularVelocity;\n \n-\tb3Vec3 rA = b3RotateVector( stateA->deltaRotation, joint->frameA.p );\n-\tb3Vec3 rB = b3RotateVector( stateB->deltaRotation, joint->frameB.p );\n+\tb3UpdateSphericalAnchors( joint, stateA, stateB, context->positionGeneration );\n+\tb3Vec3 rA = joint->cachedAnchorA;\n+\tb3Vec3 rB = joint->cachedAnchorB;\n \n \tb3Vec3 angularImpulse = b3Add( joint->springImpulse, joint->motorImpulse );\n \tangularImpulse = b3MulSub( angularImpulse, joint->swingImpulse, joint->swingAxis );\n@@ -609,8 +625,9 @@ void b3SolveSphericalJoint( b3JointSim* base, b3StepContext* context, bool useBi\n \n \t// Solve point-to-point constraint\n \t{\n-\t\tb3Vec3 rA = b3RotateVector( stateA->deltaRotation, joint->frameA.p );\n-\t\tb3Vec3 rB = b3RotateVector( stateB->deltaRotation, joint->frameB.p );\n+\t\tb3UpdateSphericalAnchors( joint, stateA, stateB, context->positionGeneration );\n+\t\tb3Vec3 rA = joint->cachedAnchorA;\n+\t\tb3Vec3 rB = joint->cachedAnchorB;\n \n \t\tb3Vec3 cdot = b3Sub( b3Sub( b3Add( vB, b3Cross( wB, rB ) ), vA ), b3Cross( wA, rA ) );\n \n",
+      "hashes": {
+        "before": "b1e391977be1d60781eaa88edd9fdad835d3734cb03e6617f4606706f54a2835",
+        "angular": "eba0f1f4afd81dcb4afdd60d422d564cb747ade56815673ed4f09f269f4e2609",
+        "cache": "fd47054550027d2fe83ab98fbd5c27261283b89e6d4804aa361d9a64a641e1af"
+      },
+      "rows": [
+        {
+          "scene": "joint_grid",
+          "runs": [
+            {
+              "binary": "before",
+              "ms": 651.646,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "angular",
+              "ms": 615.268,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "cache",
+              "ms": 558.915,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "cache",
+              "ms": 557.414,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "angular",
+              "ms": 605.318,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "before",
+              "ms": 651.576,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            }
+          ],
+          "medians_ms": {
+            "before": 651.611,
+            "angular": 610.293,
+            "cache": 558.1645
+          }
+        },
+        {
+          "scene": "rain",
+          "runs": [
+            {
+              "binary": "before",
+              "ms": 1343.15,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+            },
+            {
+              "binary": "angular",
+              "ms": 1324.36,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+            },
+            {
+              "binary": "cache",
+              "ms": 1303.84,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+            },
+            {
+              "binary": "cache",
+              "ms": 1380.83,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+            },
+            {
+              "binary": "angular",
+              "ms": 1342.49,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+            },
+            {
+              "binary": "before",
+              "ms": 1326.12,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+            }
+          ],
+          "medians_ms": {
+            "before": 1334.635,
+            "angular": 1333.425,
+            "cache": 1342.335
+          }
+        },
+        {
+          "scene": "large_pyramid",
+          "runs": [
+            {
+              "binary": "before",
+              "ms": 1582.69,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+            },
+            {
+              "binary": "angular",
+              "ms": 1688.14,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+            },
+            {
+              "binary": "cache",
+              "ms": 1603.3,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+            },
+            {
+              "binary": "cache",
+              "ms": 1626.41,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+            },
+            {
+              "binary": "angular",
+              "ms": 1585.87,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+            },
+            {
+              "binary": "before",
+              "ms": 1603.55,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+            }
+          ],
+          "medians_ms": {
+            "before": 1593.12,
+            "angular": 1637.005,
+            "cache": 1614.855
+          }
+        }
+      ]
+    },
+    "final-recheck": {
+      "diff": "diff --git a/src/joint.h b/src/joint.h\nindex 48520f0..957d733 100644\n--- a/src/joint.h\n+++ b/src/joint.h\n@@ -262,6 +262,11 @@ typedef struct b3SphericalJoint\n \tb3Fixed twistMass;\n \tb3Softness springSoftness;\n \n+\t// Transient point-constraint geometry, invalidated each prepare/integration.\n+\tb3Vec3 cachedAnchorA;\n+\tb3Vec3 cachedAnchorB;\n+\tint geometryGeneration;\n+\n \tbool enableSpring;\n \tbool enableMotor;\n \tbool enableConeLimit;\ndiff --git a/src/spherical_joint.c b/src/spherical_joint.c\nindex 785641d..4ae643c 100644\n--- a/src/spherical_joint.c\n+++ b/src/spherical_joint.c\n@@ -319,6 +319,7 @@ void b3PrepareSphericalJoint( b3JointSim* base, b3StepContext* context )\n \tbase->fixedRotation = invInertiaSum.cx.x + invInertiaSum.cy.y + invInertiaSum.cz.z == 0;\n \n \tb3SphericalJoint* joint = &base->sphericalJoint;\n+\tjoint->geometryGeneration = -1;\n \tjoint->indexA = bodyA->setIndex == b3_awakeSet ? localIndexA : B3_NULL_INDEX;\n \tjoint->indexB = bodyB->setIndex == b3_awakeSet ? localIndexB : B3_NULL_INDEX;\n \n@@ -330,11 +331,14 @@ void b3PrepareSphericalJoint( b3JointSim* base, b3StepContext* context )\n \n \tjoint->deltaCenter = b3SubPos( bodySimB->center, bodySimA->center );\n \n-\t// Cone axis is the z-axis of body A.\n-\tb3Vec3 coneAxis = b3RotateVector( joint->frameA.q, b3Vec3_axisZ );\n-\n-\t// Twist axis is the z-axis of body B.\n-\tb3Vec3 twistAxis = b3RotateVector( joint->frameB.q, b3Vec3_axisZ );\n+\tb3Vec3 coneAxis = b3Vec3_zero;\n+\tb3Vec3 twistAxis = b3Vec3_zero;\n+\tif ( joint->enableConeLimit || joint->enableTwistLimit )\n+\t{\n+\t\t// Cone and twist axes are the z-axes of the two joint frames.\n+\t\tconeAxis = b3RotateVector( joint->frameA.q, b3Vec3_axisZ );\n+\t\ttwistAxis = b3RotateVector( joint->frameB.q, b3Vec3_axisZ );\n+\t}\n \n \tif ( joint->enableConeLimit )\n \t{\n@@ -359,7 +363,8 @@ void b3PrepareSphericalJoint( b3JointSim* base, b3StepContext* context )\n \t\tjoint->twistJacobian = twistJacobian;\n \t}\n \n-\tif ( base->fixedRotation == false )\n+\t// Only spring and motor constraints use the angular mass matrix.\n+\tif ( base->fixedRotation == false && ( joint->enableSpring || joint->enableMotor ) )\n \t{\n \t\tjoint->rotationMass = b3InvertAcrossScales( invInertiaSum );\n \t}\n@@ -381,6 +386,19 @@ void b3PrepareSphericalJoint( b3JointSim* base, b3StepContext* context )\n \t}\n }\n \n+// Only position integration changes these anchors within a step. The existing\n+// stage barriers publish positionGeneration before any joint uses the new poses.\n+static inline void b3UpdateSphericalAnchors( b3SphericalJoint* joint, const b3BodyState* stateA,\n+                                           const b3BodyState* stateB, int generation )\n+{\n+\tif ( joint->geometryGeneration != generation )\n+\t{\n+\t\tjoint->cachedAnchorA = b3RotateVector( stateA->deltaRotation, joint->frameA.p );\n+\t\tjoint->cachedAnchorB = b3RotateVector( stateB->deltaRotation, joint->frameB.p );\n+\t\tjoint->geometryGeneration = generation;\n+\t}\n+}\n+\n void b3WarmStartSphericalJoint( b3JointSim* base, b3StepContext* context )\n {\n \tB3_ASSERT( base->type == b3_sphericalJoint );\n@@ -403,8 +421,9 @@ void b3WarmStartSphericalJoint( b3JointSim* base, b3StepContext* context )\n \tb3Vec3 vB = stateB->linearVelocity;\n \tb3Vec3 wB = stateB->angularVelocity;\n \n-\tb3Vec3 rA = b3RotateVector( stateA->deltaRotation, joint->frameA.p );\n-\tb3Vec3 rB = b3RotateVector( stateB->deltaRotation, joint->frameB.p );\n+\tb3UpdateSphericalAnchors( joint, stateA, stateB, context->positionGeneration );\n+\tb3Vec3 rA = joint->cachedAnchorA;\n+\tb3Vec3 rB = joint->cachedAnchorB;\n \n \tb3Vec3 angularImpulse = b3Add( joint->springImpulse, joint->motorImpulse );\n \tangularImpulse = b3MulSub( angularImpulse, joint->swingImpulse, joint->swingAxis );\n@@ -609,8 +628,9 @@ void b3SolveSphericalJoint( b3JointSim* base, b3StepContext* context, bool useBi\n \n \t// Solve point-to-point constraint\n \t{\n-\t\tb3Vec3 rA = b3RotateVector( stateA->deltaRotation, joint->frameA.p );\n-\t\tb3Vec3 rB = b3RotateVector( stateB->deltaRotation, joint->frameB.p );\n+\t\tb3UpdateSphericalAnchors( joint, stateA, stateB, context->positionGeneration );\n+\t\tb3Vec3 rA = joint->cachedAnchorA;\n+\t\tb3Vec3 rB = joint->cachedAnchorB;\n \n \t\tb3Vec3 cdot = b3Sub( b3Sub( b3Add( vB, b3Cross( wB, rB ) ), vA ), b3Cross( wA, rA ) );\n \n",
+      "hashes": {
+        "before": "b1e391977be1d60781eaa88edd9fdad835d3734cb03e6617f4606706f54a2835",
+        "cache": "2d28c83ddc0338e05bdb9a7cf180641f7da5abdb6c2e881701e997fcaee8a5d1"
+      },
+      "rows": [
+        {
+          "scene": "joint_grid",
+          "runs": [
+            {
+              "binary": "before",
+              "ms": 660.766,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "cache",
+              "ms": 563.361,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "cache",
+              "ms": 560.029,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "before",
+              "ms": 693.046,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "before",
+              "ms": 703.513,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "cache",
+              "ms": 562.802,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "cache",
+              "ms": 551.9,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            },
+            {
+              "binary": "before",
+              "ms": 649.316,
+              "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+            }
+          ],
+          "medians_ms": {
+            "before": 676.906,
+            "cache": 561.4155000000001
+          }
+        },
+        {
+          "scene": "rain",
+          "runs": [
+            {
+              "binary": "before",
+              "ms": 1298.9,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+            },
+            {
+              "binary": "cache",
+              "ms": 1281.71,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+            },
+            {
+              "binary": "cache",
+              "ms": 1302.56,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+            },
+            {
+              "binary": "before",
+              "ms": 1349.63,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+            },
+            {
+              "binary": "before",
+              "ms": 1402.97,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+            },
+            {
+              "binary": "cache",
+              "ms": 2260.18,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+            },
+            {
+              "binary": "cache",
+              "ms": 1507.48,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+            },
+            {
+              "binary": "before",
+              "ms": 1339.13,
+              "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+            }
+          ],
+          "medians_ms": {
+            "before": 1344.38,
+            "cache": 1405.02
+          }
+        },
+        {
+          "scene": "large_pyramid",
+          "runs": [
+            {
+              "binary": "before",
+              "ms": 1581.89,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+            },
+            {
+              "binary": "cache",
+              "ms": 1592.54,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+            },
+            {
+              "binary": "cache",
+              "ms": 1610.64,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+            },
+            {
+              "binary": "before",
+              "ms": 1608.05,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+            },
+            {
+              "binary": "before",
+              "ms": 1570.38,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+            },
+            {
+              "binary": "cache",
+              "ms": 1627.67,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+            },
+            {
+              "binary": "cache",
+              "ms": 1720.02,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+            },
+            {
+              "binary": "before",
+              "ms": 1618.89,
+              "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+            }
+          ],
+          "medians_ms": {
+            "before": 1594.97,
+            "cache": 1619.1550000000002
+          }
+        }
+      ]
+    },
+    "broad": {
+      "workers": 4,
+      "substeps": 4,
+      "runs": [
+        {
+          "scene": "joint_grid",
+          "binary": "before",
+          "trial": 0,
+          "ms": 652.413,
+          "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+        },
+        {
+          "scene": "joint_grid",
+          "binary": "after",
+          "trial": 1,
+          "ms": 576.245,
+          "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+        },
+        {
+          "scene": "joint_grid",
+          "binary": "after",
+          "trial": 2,
+          "ms": 586.72,
+          "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+        },
+        {
+          "scene": "joint_grid",
+          "binary": "before",
+          "trial": 3,
+          "ms": 661.287,
+          "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+        },
+        {
+          "scene": "joint_grid",
+          "binary": "before",
+          "trial": 4,
+          "ms": 659.561,
+          "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+        },
+        {
+          "scene": "joint_grid",
+          "binary": "after",
+          "trial": 5,
+          "ms": 570.484,
+          "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+        },
+        {
+          "scene": "joint_grid",
+          "binary": "after",
+          "trial": 6,
+          "ms": 573.498,
+          "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+        },
+        {
+          "scene": "joint_grid",
+          "binary": "before",
+          "trial": 7,
+          "ms": 658.627,
+          "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+        },
+        {
+          "scene": "rain",
+          "binary": "before",
+          "trial": 0,
+          "ms": 1354.72,
+          "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+        },
+        {
+          "scene": "rain",
+          "binary": "after",
+          "trial": 1,
+          "ms": 1353.06,
+          "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+        },
+        {
+          "scene": "rain",
+          "binary": "after",
+          "trial": 2,
+          "ms": 1358.79,
+          "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+        },
+        {
+          "scene": "rain",
+          "binary": "before",
+          "trial": 3,
+          "ms": 1369.18,
+          "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+        },
+        {
+          "scene": "rain",
+          "binary": "before",
+          "trial": 4,
+          "ms": 1485.96,
+          "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+        },
+        {
+          "scene": "rain",
+          "binary": "after",
+          "trial": 5,
+          "ms": 1611.19,
+          "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+        },
+        {
+          "scene": "rain",
+          "binary": "after",
+          "trial": 6,
+          "ms": 1455.52,
+          "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+        },
+        {
+          "scene": "rain",
+          "binary": "before",
+          "trial": 7,
+          "ms": 1536.64,
+          "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+        },
+        {
+          "scene": "large_pyramid",
+          "binary": "before",
+          "trial": 0,
+          "ms": 1763.06,
+          "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+        },
+        {
+          "scene": "large_pyramid",
+          "binary": "after",
+          "trial": 1,
+          "ms": 1749.47,
+          "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+        },
+        {
+          "scene": "large_pyramid",
+          "binary": "after",
+          "trial": 2,
+          "ms": 1749.7,
+          "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+        },
+        {
+          "scene": "large_pyramid",
+          "binary": "before",
+          "trial": 3,
+          "ms": 1744.16,
+          "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+        },
+        {
+          "scene": "large_pyramid",
+          "binary": "before",
+          "trial": 4,
+          "ms": 1884.79,
+          "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+        },
+        {
+          "scene": "large_pyramid",
+          "binary": "after",
+          "trial": 5,
+          "ms": 4223.94,
+          "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+        },
+        {
+          "scene": "large_pyramid",
+          "binary": "after",
+          "trial": 6,
+          "ms": 2261.61,
+          "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+        },
+        {
+          "scene": "large_pyramid",
+          "binary": "before",
+          "trial": 7,
+          "ms": 1675.39,
+          "counters": "body 5051 / shape 5051 / contact 14950 / joint 0 / stack 16633104"
+        },
+        {
+          "scene": "many_pyramids",
+          "binary": "before",
+          "trial": 0,
+          "ms": 1610.11,
+          "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 31601072"
+        },
+        {
+          "scene": "many_pyramids",
+          "binary": "after",
+          "trial": 1,
+          "ms": 1630.71,
+          "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 31601072"
+        },
+        {
+          "scene": "many_pyramids",
+          "binary": "after",
+          "trial": 2,
+          "ms": 1651.17,
+          "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 31601072"
+        },
+        {
+          "scene": "many_pyramids",
+          "binary": "before",
+          "trial": 3,
+          "ms": 1645.26,
+          "counters": "body 10781 / shape 10781 / contact 28420 / joint 0 / stack 31601072"
+        },
+        {
+          "scene": "junkyard",
+          "binary": "before",
+          "trial": 0,
+          "ms": 9014.78,
+          "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 29608368"
+        },
+        {
+          "scene": "junkyard",
+          "binary": "after",
+          "trial": 1,
+          "ms": 9635.68,
+          "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 29608368"
+        },
+        {
+          "scene": "junkyard",
+          "binary": "after",
+          "trial": 2,
+          "ms": 9141.46,
+          "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 29608368"
+        },
+        {
+          "scene": "junkyard",
+          "binary": "before",
+          "trial": 3,
+          "ms": 9419.3,
+          "counters": "body 10586 / shape 10590 / contact 195788 / joint 0 / stack 29608368"
+        },
+        {
+          "scene": "washer",
+          "binary": "before",
+          "trial": 0,
+          "ms": 13448.7,
+          "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 19101392"
+        },
+        {
+          "scene": "washer",
+          "binary": "after",
+          "trial": 1,
+          "ms": 14050.5,
+          "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 19101392"
+        },
+        {
+          "scene": "washer",
+          "binary": "after",
+          "trial": 2,
+          "ms": 16087.2,
+          "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 19101392"
+        },
+        {
+          "scene": "washer",
+          "binary": "before",
+          "trial": 3,
+          "ms": 16286.9,
+          "counters": "body 8002 / shape 8041 / contact 40576 / joint 0 / stack 19101392"
+        },
+        {
+          "scene": "convex_pile",
+          "binary": "before",
+          "trial": 0,
+          "ms": 7635.37,
+          "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6403712"
+        },
+        {
+          "scene": "convex_pile",
+          "binary": "after",
+          "trial": 1,
+          "ms": 9865.01,
+          "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6403712"
+        },
+        {
+          "scene": "convex_pile",
+          "binary": "after",
+          "trial": 2,
+          "ms": 8083.09,
+          "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6403712"
+        },
+        {
+          "scene": "convex_pile",
+          "binary": "before",
+          "trial": 3,
+          "ms": 7406.23,
+          "counters": "body 5121 / shape 5121 / contact 51305 / joint 0 / stack 6403712"
+        },
+        {
+          "scene": "large_world",
+          "binary": "before",
+          "trial": 0,
+          "ms": 25.5541,
+          "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+        },
+        {
+          "scene": "large_world",
+          "binary": "after",
+          "trial": 1,
+          "ms": 26.553,
+          "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+        },
+        {
+          "scene": "large_world",
+          "binary": "after",
+          "trial": 2,
+          "ms": 23.2185,
+          "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+        },
+        {
+          "scene": "large_world",
+          "binary": "before",
+          "trial": 3,
+          "ms": 25.2208,
+          "counters": "body 1000099 / shape 1000099 / contact 380 / joint 0 / stack 520000000"
+        },
+        {
+          "scene": "trees100",
+          "binary": "before",
+          "trial": 0,
+          "ms": 158.725,
+          "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+        },
+        {
+          "scene": "trees100",
+          "binary": "after",
+          "trial": 1,
+          "ms": 156.566,
+          "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+        },
+        {
+          "scene": "trees100",
+          "binary": "after",
+          "trial": 2,
+          "ms": 160.899,
+          "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+        },
+        {
+          "scene": "trees100",
+          "binary": "before",
+          "trial": 3,
+          "ms": 195.071,
+          "counters": "body 51 / shape 1101 / contact 1100 / joint 0 / stack 572528"
+        },
+        {
+          "scene": "trees50",
+          "binary": "before",
+          "trial": 0,
+          "ms": 245.402,
+          "counters": "body 51 / shape 1101 / contact 1114 / joint 0 / stack 572528"
+        },
+        {
+          "scene": "trees50",
+          "binary": "after",
+          "trial": 1,
+          "ms": 728.244,
+          "counters": "body 51 / shape 1101 / contact 1114 / joint 0 / stack 572528"
+        },
+        {
+          "scene": "trees50",
+          "binary": "after",
+          "trial": 2,
+          "ms": 290.449,
+          "counters": "body 51 / shape 1101 / contact 1114 / joint 0 / stack 572528"
+        },
+        {
+          "scene": "trees50",
+          "binary": "before",
+          "trial": 3,
+          "ms": 333.837,
+          "counters": "body 51 / shape 1101 / contact 1114 / joint 0 / stack 572528"
+        },
+        {
+          "scene": "trees25",
+          "binary": "before",
+          "trial": 0,
+          "ms": 419.975,
+          "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+        },
+        {
+          "scene": "trees25",
+          "binary": "after",
+          "trial": 1,
+          "ms": 417.165,
+          "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+        },
+        {
+          "scene": "trees25",
+          "binary": "after",
+          "trial": 2,
+          "ms": 396.127,
+          "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+        },
+        {
+          "scene": "trees25",
+          "binary": "before",
+          "trial": 3,
+          "ms": 414.685,
+          "counters": "body 51 / shape 1101 / contact 1104 / joint 0 / stack 572528"
+        }
+      ],
+      "sha256": {
+        "before": "b1e391977be1d60781eaa88edd9fdad835d3734cb03e6617f4606706f54a2835",
+        "after": "c101e50610e9a8e1cee6666735c2117e4dab3e074cacaef52689b6b6699cd5a5"
+      }
+    },
+    "after-tree-fix": {
+      "workers": 4,
+      "substeps": 4,
+      "runs": [
+        {
+          "scene": "joint_grid",
+          "binary": "before",
+          "trial": 0,
+          "ms": 653.93,
+          "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+        },
+        {
+          "scene": "joint_grid",
+          "binary": "after",
+          "trial": 1,
+          "ms": 571.939,
+          "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+        },
+        {
+          "scene": "joint_grid",
+          "binary": "after",
+          "trial": 2,
+          "ms": 563.569,
+          "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+        },
+        {
+          "scene": "joint_grid",
+          "binary": "before",
+          "trial": 3,
+          "ms": 658.026,
+          "counters": "body 10000 / shape 10000 / contact 0 / joint 19800 / stack 5200000"
+        },
+        {
+          "scene": "rain",
+          "binary": "before",
+          "trial": 0,
+          "ms": 1346.48,
+          "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+        },
+        {
+          "scene": "rain",
+          "binary": "after",
+          "trial": 1,
+          "ms": 1345.54,
+          "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+        },
+        {
+          "scene": "rain",
+          "binary": "after",
+          "trial": 2,
+          "ms": 1565.02,
+          "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+        },
+        {
+          "scene": "rain",
+          "binary": "before",
+          "trial": 3,
+          "ms": 1394.06,
+          "counters": "body 4300 / shape 4400 / contact 7019 / joint 4200 / stack 1765344"
+        }
+      ],
+      "sha256": {
+        "before": "b1e391977be1d60781eaa88edd9fdad835d3734cb03e6617f4606706f54a2835",
+        "after": "5f9d57eb3dac3aedeafe90d9a09bd26fd162a7480703ec30c21ca65fb4c93053"
+      }
+    }
+  },
+  "cache_controls": {
+    "stale-integration": {
+      "exit_code": 1,
+      "output": "  spherical scale=0 hash=b1103838bd6228dc\ncondition false: hash == goldens[scale]\n"
+    },
+    "stale-step": {
+      "exit_code": 1,
+      "output": "  spherical scale=0 hash=061925199d57307f\ncondition false: hash == goldens[scale]\n"
+    },
+    "actual_joint_workers": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7
+    ]
+  },
+  "sleep_tree_control": {
+    "baseline_exit": -5,
+    "baseline_assertion": "BOX3D ASSERTION: ( node->flags & b3_enlargedNode ) == 0, src/dynamic_tree.c, line 1077",
+    "repair": "Join pending rebuild before validation when awakeBodyCount is zero; covered by SleepingWorldTreeJoinTest."
+  },
+  "source_files_sha256": {
+    "src/joint.h": "02c0294470b41d79a32c0a43e7d5cc18035f8e48b0b6bf99e050770b80786bd0",
+    "src/spherical_joint.c": "dbe7248aabe93aea326d97ea223de2b3ac026b883db4777f3395d232b29e145c",
+    "src/solver.c": "8d05b7da408d49f05c8c51065872f39b7b7fbe48acac3337ef2e2f8c220e778a",
+    "test/test_determinism.c": "60f7649bd4830abd9b0834cc532cd7ca246033a8d110bbd8f707f071bc4452c7",
+    "test/test_world.c": "839809e66139dcc17a7d5f392fc368812787c107b47616129b78f4a241129889",
+    "tools/benchmark/spherical_state_hash.c": "23167bc4bf61bd81516619629bce5077760dc4837e1b9d87866241838a7dda01"
+  },
+  "validation": {
+    "neon": {
+      "seconds": 3.7986338330083527,
+      "exit_code": 0,
+      "suites": 24
+    },
+    "release": {
+      "seconds": 3.441848125003162,
+      "exit_code": 0,
+      "suites": 24
+    },
+    "wide": {
+      "seconds": 3.700510624999879,
+      "exit_code": 0,
+      "suites": 24
+    },
+    "debug": {
+      "seconds": 27.361062041993137,
+      "exit_code": 0,
+      "suites": 24
+    },
+    "sanitize": {
+      "seconds": 75.82093754099333,
+      "exit_code": 0,
+      "suites": 24
+    },
+    "tsan": {
+      "seconds": 43.38627941699815,
+      "exit_code": 0,
+      "suites": 24
+    }
+  },
+  "parity": {
+    "before": {
+      "frames": 72000,
+      "cross_worker_comparisons": 63000,
+      "sha256": "4dd60c888a8ce04fd3c1b45b6ead865f57215532102cb27d0ab8a3684aff3c4c"
+    },
+    "after": {
+      "frames": 72000,
+      "cross_worker_comparisons": 63000,
+      "sha256": "4dd60c888a8ce04fd3c1b45b6ead865f57215532102cb27d0ab8a3684aff3c4c"
+    },
+    "scalar": {
+      "frames": 72000,
+      "cross_worker_comparisons": 63000,
+      "sha256": "4dd60c888a8ce04fd3c1b45b6ead865f57215532102cb27d0ab8a3684aff3c4c"
+    },
+    "wide-before": {
+      "frames": 72000,
+      "cross_worker_comparisons": 63000,
+      "sha256": "be8b4540c044fb8856b1d37486f404e9cfe7ce0f8edf6cd7847167de5fa35636"
+    },
+    "wide-after": {
+      "frames": 72000,
+      "cross_worker_comparisons": 63000,
+      "sha256": "be8b4540c044fb8856b1d37486f404e9cfe7ce0f8edf6cd7847167de5fa35636"
+    },
+    "debug": {
+      "frames": 72000,
+      "cross_worker_comparisons": 63000,
+      "sha256": "4dd60c888a8ce04fd3c1b45b6ead865f57215532102cb27d0ab8a3684aff3c4c"
+    }
+  }
+}

--- a/benchmark/2026-09-07-spherical-cache-performance.md
+++ b/benchmark/2026-09-07-spherical-cache-performance.md
@@ -1,0 +1,124 @@
+# Spherical joint geometry reuse
+
+This pass reuses the two rotated point-constraint anchors while body poses are
+unchanged. It also skips angular mass inversion when neither spring nor motor
+uses it, and skips cone/twist axes when both limits are disabled. Enabling a
+feature restores the original calculation on the next prepare stage. The point
+matrix, 40-bit inverse scale, 256-bit solve, rounding and stored impulses are
+unchanged.
+
+## Determinism contract
+
+Identical initial state and ordered simulation inputs must produce identical
+physics regardless of worker count or scheduling. The cache follows that rule:
+
+- Prepare invalidates every joint cache on every step, including after sleeping,
+  enabling bodies, changing transforms, locking rotation or changing substeps.
+- The existing `positionGeneration` changes at position integration. Reuse is an
+  exact integer generation comparison, with no timing or worker-dependent choice.
+- A joint belongs to one solver block per stage. Graph colors execute in order;
+  overflow joints execute serially. The stage completion/publication atomics
+  order cache writes, generation changes and body-pose updates before later stages.
+- A miss performs the same two rotations with the same inputs and rounding.
+
+At four substeps with warm starting, this reduces anchor-pair calculations from
+12 to 5 per joint per step. It adds 48 bytes to each internal `b3JointSim`
+(864 to 912 bytes on arm64), because spherical data shares the joint union. Public
+API and recording layouts are unchanged. An experimental full point-matrix cache
+added 128 bytes and regressed Rain substantially; it was rejected.
+
+## Measurements
+
+Apple M3 Ultra, macOS 26.6.2, Apple Clang 21, RelWithDebInfo (`-O2`, thin LTO),
+NEON enabled, four workers and four substeps. Baseline is PR60, main `8048b78`.
+Each trial runs a fresh process using `benchmark -t=4 -w=4 -r=1 -b=SCENE`.
+The final sweep uses balanced before/after ordering; Joint Grid, Rain and Large
+Pyramid have four observations per binary, and other scenes have two. Every
+observation is retained, and end-of-run body/shape/contact/joint/stack counters
+match exactly for each scene.
+
+| Scene | Before median (ms) | After median (ms) | Runtime reduction |
+|---|---:|---:|---:|
+| Joint Grid | 659.094 | 574.872 | **12.8%** |
+| Rain | 1427.570 | 1407.155 | 1.4%, inconclusive |
+
+Joint Grid is the supported gain: its final within-binary spread is 1.4% before
+and 2.8% after. Earlier independent anchor-cache batches also improve this scene.
+Rain's final spread is 13–19%, so its small median difference establishes neither
+a gain nor a regression. The cache footprint remains a cost worth watching.
+
+The shared workstation was busy with indexing, file synchronization and other
+compilers. No other work from this task ran during timing, but external contention
+remained uncontrolled. Several scenes with zero joints are especially unstable:
+Large Pyramid's median regresses 14.4%, Convex Pile 19.3%, and Trees50 75.9%; the
+Trees50 candidate trials themselves vary from 290 to 728 ms. These observations
+are preserved, not removed or presented as proof that unrelated scenes improved.
+They do not support an overall performance conclusion from this batch.
+
+The last measured full-suite float-throughput figures remain **44.6% scalar /
+47.0% NEON**. This targeted gain does not establish a new ratio. After the tree
+ordering repair below, an additional four-process recheck gives Joint Grid
+655.978 to 567.754 ms (13.4% reduction). Rain gives 1370.270 to 1455.280 ms
+(6.2% regression), with candidate observations 1345.54 and 1565.02 ms; its
+performance remains inconclusive. Raw trials from all five batches, including
+the rejected matrix cache, are in the
+[measurement record](2026-09-07-spherical-cache-performance.json).
+
+## Validation
+
+All 24 suites pass locally in Debug, optimized scalar, NEON, wide positions,
+ASan+UBSan and ThreadSanitizer. The existing physics goldens and asteroid-response
+tests are unchanged. The standalone runs match **144,000 before/after frame
+hashes** across the two position widths, with **63,000 cross-worker comparisons
+per build**. Optimized scalar, NEON and Debug output also match byte for byte.
+Cross-platform validation is tracked by the pull request's CI.
+
+The expanded checks also exposed a pre-existing scheduling bug: an all-sleeping
+world could validate its broad-phase tree while the queued rebuild was still
+writing it. The empty-solver path now joins that task before validation. A
+regression scheduler deliberately defers the rebuild until `finishTask`, reliably
+failing the old Debug build and passing the repair. The active solver path and
+physics calculations are unaffected; the tree task already had to finish before
+the world step returned.
+
+The permanent `SphericalGeometryTest` uses two chains and a dynamic star: 99
+bodies, 96 joints, parallel blocks and serial overflow constraints. It checks
+each frame across workers 1–8 and also checks goldens captured from the uncached
+solver. The latter catches a consistently stale cache even when every worker
+count produces the same wrong result. Numeric fields are hashed explicitly,
+including every position bit in the wide build, rather than structure padding.
+
+Coverage includes changing 1/2/4/8 substeps, a zero-duration step, warm-start
+toggles, spring/motor/limit toggles, body disable/enable and sleep/wake, rotation
+locks and an explicit transform change. Cubes have side length 1 or 250 and unit
+density, so the larger bodies have mass 15,625,000. The initial default-density
+fixture hit an impulse-range assertion in both old and new Debug solvers when
+locking its massive chain; the test density was reduced without changing the
+library's arithmetic or assertions.
+
+Separate negative controls deliberately omitted integration invalidation and
+step invalidation. Both fail the golden check. Temporary instrumentation confirmed
+that joint warm-start blocks executed on every worker index 0–7; this instrumentation
+is absent from the shipped library.
+
+The [standalone comparator](../tools/benchmark/spherical_state_hash.c) covers
+point-only, spring/motor, limit, runtime-change and overflow scenarios, at both
+sizes, workers 1–8, fixed substeps 1/2/4/8 and substeps varying by frame. Each build
+produces 72,000 frame hashes. It compares transforms, linear/angular velocities,
+awake flags and constraint forces/torques. Run it against preserved before/after
+libraries and compare stdout byte for byte:
+
+```sh
+cmake -S . -B build-perf -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DBOX3D_SAMPLES=OFF -DBOX3D_NEON=ON
+cmake --build build-perf
+cc -O2 -std=c17 -Iinclude -Iextern/fixed/include \
+  tools/benchmark/spherical_state_hash.c build-perf/src/libbox3d.a \
+  -lpthread -lm -o spherical_state_hash
+./spherical_state_hash > state-hashes.txt
+./build-perf/bin/test DeterminismTest
+```
+
+For wide positions, configure with `-DBOX3D_LUDICROUS_MODE=ON` and pass the same
+definition when compiling the comparator. Wide and narrow builds carry separate
+reference hashes because their position representations differ.

--- a/src/joint.h
+++ b/src/joint.h
@@ -262,6 +262,12 @@ typedef struct b3SphericalJoint
 	b3Fixed twistMass;
 	b3Softness springSoftness;
 
+	// Transient point-constraint geometry, invalidated each prepare/integration.
+	// Keep this small: also caching the point matrix regressed Rain on M3 Ultra.
+	b3Vec3 cachedAnchorA;
+	b3Vec3 cachedAnchorB;
+	int geometryGeneration;
+
 	bool enableSpring;
 	bool enableMotor;
 	bool enableConeLimit;

--- a/src/solver.c
+++ b/src/solver.c
@@ -1494,6 +1494,15 @@ void b3Solve( b3World* world, b3StepContext* stepContext )
 	int awakeBodyCount = awakeSet->bodySims.count;
 	if ( awakeBodyCount == 0 )
 	{
+		// Even an all-sleeping world can have a pending tree rebuild. Join it
+		// before validation reads the tree, just as the active-body path does.
+		// Otherwise Debug success depends on whether the background task won.
+		if ( world->userTreeTask != NULL )
+		{
+			world->finishTaskFcn( world->userTreeTask, world->userTaskContext );
+			world->userTreeTask = NULL;
+			world->activeTaskCount -= 1;
+		}
 		b3ValidateNoEnlarged( &world->broadPhase );
 		return;
 	}

--- a/src/spherical_joint.c
+++ b/src/spherical_joint.c
@@ -319,6 +319,7 @@ void b3PrepareSphericalJoint( b3JointSim* base, b3StepContext* context )
 	base->fixedRotation = invInertiaSum.cx.x + invInertiaSum.cy.y + invInertiaSum.cz.z == 0;
 
 	b3SphericalJoint* joint = &base->sphericalJoint;
+	joint->geometryGeneration = -1;
 	joint->indexA = bodyA->setIndex == b3_awakeSet ? localIndexA : B3_NULL_INDEX;
 	joint->indexB = bodyB->setIndex == b3_awakeSet ? localIndexB : B3_NULL_INDEX;
 
@@ -330,11 +331,14 @@ void b3PrepareSphericalJoint( b3JointSim* base, b3StepContext* context )
 
 	joint->deltaCenter = b3SubPos( bodySimB->center, bodySimA->center );
 
-	// Cone axis is the z-axis of body A.
-	b3Vec3 coneAxis = b3RotateVector( joint->frameA.q, b3Vec3_axisZ );
-
-	// Twist axis is the z-axis of body B.
-	b3Vec3 twistAxis = b3RotateVector( joint->frameB.q, b3Vec3_axisZ );
+	b3Vec3 coneAxis = b3Vec3_zero;
+	b3Vec3 twistAxis = b3Vec3_zero;
+	if ( joint->enableConeLimit || joint->enableTwistLimit )
+	{
+		// Cone and twist axes are the z-axes of the two joint frames.
+		coneAxis = b3RotateVector( joint->frameA.q, b3Vec3_axisZ );
+		twistAxis = b3RotateVector( joint->frameB.q, b3Vec3_axisZ );
+	}
 
 	if ( joint->enableConeLimit )
 	{
@@ -359,7 +363,8 @@ void b3PrepareSphericalJoint( b3JointSim* base, b3StepContext* context )
 		joint->twistJacobian = twistJacobian;
 	}
 
-	if ( base->fixedRotation == false )
+	// Only spring and motor constraints use the angular mass matrix.
+	if ( base->fixedRotation == false && ( joint->enableSpring || joint->enableMotor ) )
 	{
 		joint->rotationMass = b3InvertAcrossScales( invInertiaSum );
 	}
@@ -378,6 +383,22 @@ void b3PrepareSphericalJoint( b3JointSim* base, b3StepContext* context )
 		joint->swingImpulse = B3_FIX( 0.0f );
 		joint->lowerTwistImpulse = B3_FIX( 0.0f );
 		joint->upperTwistImpulse = B3_FIX( 0.0f );
+	}
+}
+
+// Determinism contract: one solver block owns a joint in each stage (overflow
+// joints run serially). Only position integration changes these anchors within
+// a step, and the existing stage barriers publish the generation and new poses
+// before the next joint stage. Cache validity must never depend on worker index,
+// timing, or scheduling; prepare invalidates it even when a step count repeats.
+static inline void b3UpdateSphericalAnchors( b3SphericalJoint* joint, const b3BodyState* stateA,
+                                           const b3BodyState* stateB, int generation )
+{
+	if ( joint->geometryGeneration != generation )
+	{
+		joint->cachedAnchorA = b3RotateVector( stateA->deltaRotation, joint->frameA.p );
+		joint->cachedAnchorB = b3RotateVector( stateB->deltaRotation, joint->frameB.p );
+		joint->geometryGeneration = generation;
 	}
 }
 
@@ -403,8 +424,9 @@ void b3WarmStartSphericalJoint( b3JointSim* base, b3StepContext* context )
 	b3Vec3 vB = stateB->linearVelocity;
 	b3Vec3 wB = stateB->angularVelocity;
 
-	b3Vec3 rA = b3RotateVector( stateA->deltaRotation, joint->frameA.p );
-	b3Vec3 rB = b3RotateVector( stateB->deltaRotation, joint->frameB.p );
+	b3UpdateSphericalAnchors( joint, stateA, stateB, context->positionGeneration );
+	b3Vec3 rA = joint->cachedAnchorA;
+	b3Vec3 rB = joint->cachedAnchorB;
 
 	b3Vec3 angularImpulse = b3Add( joint->springImpulse, joint->motorImpulse );
 	angularImpulse = b3MulSub( angularImpulse, joint->swingImpulse, joint->swingAxis );
@@ -609,8 +631,9 @@ void b3SolveSphericalJoint( b3JointSim* base, b3StepContext* context, bool useBi
 
 	// Solve point-to-point constraint
 	{
-		b3Vec3 rA = b3RotateVector( stateA->deltaRotation, joint->frameA.p );
-		b3Vec3 rB = b3RotateVector( stateB->deltaRotation, joint->frameB.p );
+		b3UpdateSphericalAnchors( joint, stateA, stateB, context->positionGeneration );
+		b3Vec3 rA = joint->cachedAnchorA;
+		b3Vec3 rB = joint->cachedAnchorB;
 
 		b3Vec3 cdot = b3Sub( b3Sub( b3Add( vB, b3Cross( wB, rB ) ), vA ), b3Cross( wA, rA ) );
 

--- a/test/test_determinism.c
+++ b/test/test_determinism.c
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: MIT
 
 #include "box3d/box3d.h"
+#include "box3d/constants.h"
 #include "determinism.h"
 #include "stability.h"
 #include "test_macros.h"
 
 #include <stdio.h>
+#include <inttypes.h>
 #include <stdlib.h>
 
 #ifdef BOX3D_PROFILE
@@ -300,6 +302,212 @@ static int MeshDropTest( void )
 	return 0;
 }
 
+// Hash numeric fields in a fixed byte order, excluding padding. Include all
+// position bits in the wide build, as well as velocities and joint impulses.
+static uint64_t SphericalHashValue( uint64_t hash, uint64_t value )
+{
+	for ( int i = 0; i < 8; ++i )
+	{
+		hash = ( hash ^ ( value & 255 ) ) * UINT64_C( 1099511628211 );
+		value >>= 8;
+	}
+	return hash;
+}
+
+static uint64_t SphericalHashVector( uint64_t hash, b3Vec3 v )
+{
+	return SphericalHashValue( SphericalHashValue( SphericalHashValue( hash, (uint64_t)v.x ), (uint64_t)v.y ), (uint64_t)v.z );
+}
+
+enum
+{
+	sphericalFrameCount = 120
+};
+
+static int RunSphericalGeometry( int workerCount, int scale, uint64_t* hashes )
+{
+	b3WorldDef worldDef = b3DefaultWorldDef();
+	worldDef.workerCount = workerCount;
+	worldDef.gravity = b3Vec3_zero;
+	b3WorldId world = b3CreateWorld( &worldDef );
+	b3Fixed size = b3FixFromInt( scale == 0 ? 1 : 250 );
+	b3BodyId bodies[99];
+	b3JointId joints[96];
+	b3ShapeDef shape = b3DefaultShapeDef();
+	shape.filter.maskBits = 0;
+	// At size 250 this still gives a mass of 15,625,000. The default density
+	// makes the locked chain exceed the uncached solver's impulse range.
+	shape.density = B3_FIXED_ONE;
+	b3BoxHull cube = b3MakeCubeHull( size / 2 );
+
+	// Two chains provide 32 joints per occupied color, spread over multiple
+	// solver blocks. The dynamic star also exercises serial overflow joints.
+	for ( int group = 0; group < 3; ++group )
+	{
+		for ( int i = 0; i < 33; ++i )
+		{
+			b3BodyDef body = b3DefaultBodyDef();
+			body.type = i == 0 && group != 2 ? b3_staticBody : b3_dynamicBody;
+			b3Vec3 offset = { size * i, 0, 0 };
+			if ( group == 2 && i > 0 )
+			{
+				offset = (b3Vec3){ size * ( i % 3 - 1 ), size * ( i / 3 % 3 - 1 ), size * ( i / 9 % 3 - 1 ) };
+			}
+			body.position = b3ToPos( b3Add( offset, (b3Vec3){ 0, size * group * 4, 0 } ) );
+			body.angularVelocity = (b3Vec3){ B3_FIX( 0.01f ), i % 2 ? B3_FIX( 0.02f ) : 0, B3_FIX( -0.01f ) };
+			body.linearVelocity.y = size / 100;
+			body.rotation.s = i % 3 == 0 ? -B3_FIXED_ONE : B3_FIXED_ONE;
+			int index = group * 33 + i;
+			bodies[index] = b3CreateBody( world, &body );
+			b3CreateHullShape( bodies[index], &shape, &cube.base );
+			if ( i == 0 )
+			{
+				continue;
+			}
+			b3SphericalJointDef joint = b3DefaultSphericalJointDef();
+			joint.base.bodyIdA = bodies[group == 2 ? group * 33 : index - 1];
+			joint.base.bodyIdB = bodies[index];
+			joint.base.localFrameA.p = group == 2 ? offset : (b3Vec3){ size / 2, 0, 0 };
+			joint.base.localFrameB.p.x = group == 2 ? 0 : -size / 2;
+			joint.enableSpring = group == 1;
+			joint.enableMotor = group == 1;
+			joint.hertz = B3_FIX( 2.0f );
+			joint.maxMotorTorque = B3_FIX( 100.0f );
+			joint.motorVelocity.y = B3_FIX( 0.01f );
+			joint.coneAngle = B3_FIX( 0.3f );
+			joint.lowerTwistAngle = B3_FIX( -0.2f );
+			joint.upperTwistAngle = B3_FIX( 0.2f );
+			joints[group * 32 + i - 1] = b3CreateSphericalJoint( world, &joint );
+		}
+	}
+
+	const int substeps[] = { 1, 2, 4, 8 };
+	for ( int frame = 0; frame < sphericalFrameCount; ++frame )
+	{
+		if ( frame == 15 || frame == 25 )
+		{
+			b3World_EnableWarmStarting( world, frame == 25 );
+		}
+		if ( frame == 30 || frame == 50 || frame == 70 )
+		{
+			for ( int i = 0; i < 96; ++i )
+			{
+				b3SphericalJoint_EnableSpring( joints[i], frame == 30 );
+				b3SphericalJoint_EnableMotor( joints[i], frame == 70 );
+				b3SphericalJoint_EnableConeLimit( joints[i], frame == 50 );
+				b3SphericalJoint_EnableTwistLimit( joints[i], frame == 50 );
+			}
+		}
+		if ( frame == 80 )
+		{
+			b3Body_Disable( bodies[16] );
+		}
+		if ( frame == 82 )
+		{
+			b3Body_Enable( bodies[16] );
+		}
+		if ( frame == 84 )
+		{
+			b3Body_SetAwake( bodies[8], false );
+		}
+		if ( frame == 86 )
+		{
+			b3Body_SetAwake( bodies[8], true );
+		}
+		if ( frame == 90 || frame == 100 )
+		{
+			b3MotionLocks locks = { 0 };
+			locks.angularX = locks.angularY = locks.angularZ = frame == 90;
+			for ( int i = 1; i < 33; ++i )
+			{
+				b3Body_SetMotionLocks( bodies[i], locks );
+			}
+		}
+		if ( frame == 110 )
+		{
+			b3WorldTransform t = b3Body_GetTransform( bodies[12] );
+			t.p.y += size / 10;
+			b3Body_SetTransform( bodies[12], t.p, b3Quat_identity );
+		}
+		b3Fixed dt = frame == 10 ? 0 : b3FixDiv( B3_FIXED_ONE, b3FixFromInt( 60 ) );
+		b3World_Step( world, dt, substeps[frame % 4] );
+		if ( frame == 0 )
+		{
+			b3Counters counters = b3World_GetCounters( world );
+			if ( counters.colorCounts[B3_GRAPH_COLOR_COUNT - 1] == 0 || counters.colorCounts[0] < 32 )
+			{
+				b3DestroyWorld( world );
+				ENSURE( false );
+			}
+		}
+		uint64_t hash = UINT64_C( 14695981039346656037 );
+		for ( int i = 0; i < 99; ++i )
+		{
+			b3WorldTransform t = b3Body_GetTransform( bodies[i] );
+			hash = SphericalHashValue( SphericalHashValue( SphericalHashValue( hash, (uint64_t)t.p.x ), (uint64_t)t.p.y ),
+									   (uint64_t)t.p.z );
+#if defined( BOX3D_LUDICROUS_MODE )
+			hash = SphericalHashValue( hash, (uint64_t)( (b3UInt128)t.p.x >> 64 ) );
+			hash = SphericalHashValue( hash, (uint64_t)( (b3UInt128)t.p.y >> 64 ) );
+			hash = SphericalHashValue( hash, (uint64_t)( (b3UInt128)t.p.z >> 64 ) );
+#endif
+			hash = SphericalHashVector( hash, t.q.v );
+			hash = SphericalHashValue( hash, (uint64_t)t.q.s );
+			hash = SphericalHashVector( hash, b3Body_GetLinearVelocity( bodies[i] ) );
+			hash = SphericalHashVector( hash, b3Body_GetAngularVelocity( bodies[i] ) );
+			hash = SphericalHashValue( hash, b3Body_IsAwake( bodies[i] ) );
+		}
+		for ( int i = 0; i < 96; ++i )
+		{
+			hash = SphericalHashVector( hash, b3Joint_GetConstraintForce( joints[i] ) );
+			hash = SphericalHashVector( hash, b3Joint_GetConstraintTorque( joints[i] ) );
+		}
+		hashes[frame] = hash;
+	}
+	b3DestroyWorld( world );
+	return 0;
+}
+
+static int SphericalGeometryTest( void )
+{
+	// Captured from the uncached solver. A stale but consistently wrong cache
+	// must fail too, even if its results happen to agree across worker counts.
+#if defined( BOX3D_LUDICROUS_MODE )
+	const uint64_t goldens[2] = { UINT64_C( 0xee343d0d530f22f1 ), UINT64_C( 0x46256d278ff09af2 ) };
+#else
+	const uint64_t goldens[2] = { UINT64_C( 0xccf165f88a73ebb7 ), UINT64_C( 0x2add50ab7852c3ce ) };
+#endif
+	for ( int scale = 0; scale < 2; ++scale )
+	{
+		uint64_t reference[sphericalFrameCount];
+		ENSURE( RunSphericalGeometry( 1, scale, reference ) == 0 );
+		uint64_t hash = UINT64_C( 14695981039346656037 );
+		for ( int frame = 0; frame < sphericalFrameCount; ++frame )
+		{
+			hash = SphericalHashValue( hash, reference[frame] );
+		}
+		if ( hash != goldens[scale] )
+		{
+			printf( "  spherical scale=%d hash=%016" PRIx64 "\n", scale, hash );
+		}
+		ENSURE( hash == goldens[scale] );
+		for ( int workers = 2; workers <= 8; ++workers )
+		{
+			uint64_t actual[sphericalFrameCount];
+			ENSURE( RunSphericalGeometry( workers, scale, actual ) == 0 );
+			for ( int frame = 0; frame < sphericalFrameCount; ++frame )
+			{
+				if ( actual[frame] != reference[frame] )
+				{
+					printf( "  spherical scale=%d workers=%d frame=%d\n", scale, workers, frame );
+				}
+				ENSURE( actual[frame] == reference[frame] );
+			}
+		}
+	}
+	return 0;
+}
+
 int DeterminismTest( void )
 {
 	RUN_SUBTEST( MultithreadingTest );
@@ -307,6 +515,7 @@ int DeterminismTest( void )
 	RUN_SUBTEST( WavePileTest );
 	RUN_SUBTEST( QuerySpawnTest );
 	RUN_SUBTEST( MeshDropTest );
+	RUN_SUBTEST( SphericalGeometryTest );
 
 	return 0;
 }

--- a/test/test_world.c
+++ b/test/test_world.c
@@ -3,6 +3,7 @@
 
 #include "benchmarks.h"
 #include "overflow_color.h"
+#include "physics_world.h"
 #include "test_macros.h"
 
 #include "box3d/box3d.h"
@@ -1354,10 +1355,86 @@ static int TestContinuousMoveEvent( void )
 	return 0;
 }
 
+typedef struct DeferredTreeTask
+{
+	b3TaskCallback* callback;
+	void* context;
+	int finished;
+} DeferredTreeTask;
+
+static void* DeferTreeRebuild( b3TaskCallback* callback, void* taskContext, void* userContext, const char* name )
+{
+	DeferredTreeTask* task = userContext;
+	if ( strcmp( name, "rebuild tree" ) == 0 )
+	{
+		B3_ASSERT( task->callback == NULL );
+		task->callback = callback;
+		task->context = taskContext;
+		return task;
+	}
+	callback( taskContext );
+	return NULL;
+}
+
+static void FinishDeferredTree( void* userTask, void* userContext )
+{
+	DeferredTreeTask* task = userTask;
+	B3_ASSERT( userTask == userContext && task->callback != NULL );
+	(void)userContext;
+	task->callback( task->context );
+	task->callback = NULL;
+	task->finished += 1;
+}
+
+static int SleepingWorldTreeJoinTest( void )
+{
+	// Hold the rebuild until finishTask: this deterministically reproduces the
+	// schedule where sleeping-world validation used to race the tree writer.
+	DeferredTreeTask task = { 0 };
+	b3WorldDef worldDef = b3DefaultWorldDef();
+	worldDef.workerCount = 2;
+	worldDef.gravity = b3Vec3_zero;
+	worldDef.enqueueTask = DeferTreeRebuild;
+	worldDef.finishTask = FinishDeferredTree;
+	worldDef.userTaskContext = &task;
+	b3WorldId worldId = b3CreateWorld( &worldDef );
+	b3BodyId bodies[2];
+	b3BodyDef bodyDef = b3DefaultBodyDef();
+	bodyDef.type = b3_dynamicBody;
+	bodyDef.linearVelocity.x = B3_FIX( 10.0f );
+	b3ShapeDef shapeDef = b3DefaultShapeDef();
+	shapeDef.filter.maskBits = 0;
+	b3BoxHull cube = b3MakeCubeHull( B3_FIX( 0.5f ) );
+	for ( int i = 0; i < 2; ++i )
+	{
+		bodyDef.position.y = b3FixFromInt( 4 * i );
+		bodies[i] = b3CreateBody( worldId, &bodyDef );
+		b3CreateHullShape( bodies[i], &shapeDef, &cube.base );
+	}
+	b3Fixed dt = b3FixDiv( B3_FIXED_ONE, b3FixFromInt( 60 ) );
+	b3World_Step( worldId, dt, 1 );
+	ENSURE( task.callback == NULL && task.finished == 1 );
+	b3World* world = b3GetWorldFromId( worldId );
+	b3DynamicTree* tree = world->broadPhase.trees + b3_dynamicBody;
+	ENSURE( ( tree->nodes[tree->root].flags & b3_enlargedNode ) != 0 );
+	for ( int i = 0; i < 2; ++i )
+	{
+		b3Body_SetAwake( bodies[i], false );
+	}
+	b3World_Step( worldId, dt, 1 );
+	ENSURE( task.callback == NULL && task.finished == 2 );
+	ENSURE( world->userTreeTask == NULL && world->activeTaskCount == 0 );
+	ENSURE( ( tree->nodes[tree->root].flags & b3_enlargedNode ) == 0 );
+	ENSURE( b3Body_IsAwake( bodies[0] ) == false && b3Body_IsAwake( bodies[1] ) == false );
+	b3DestroyWorld( worldId );
+	return 0;
+}
+
 int WorldTest( void )
 {
 	RUN_SUBTEST( HelloWorld );
 	RUN_SUBTEST( EmptyWorld );
+	RUN_SUBTEST( SleepingWorldTreeJoinTest );
 	RUN_SUBTEST( DestroyAllBodiesWorld );
 	RUN_SUBTEST( TestIsValid );
 	RUN_SUBTEST( TestWorldRecycle );

--- a/tools/benchmark/spherical_state_hash.c
+++ b/tools/benchmark/spherical_state_hash.c
@@ -1,0 +1,170 @@
+// Compare spherical-joint state across builds, substeps and worker counts.
+#include "box3d/box3d.h"
+#include "box3d/constants.h"
+
+#include <inttypes.h>
+#include <stdio.h>
+
+static uint64_t HashValue( uint64_t hash, int64_t value )
+{
+	uint64_t bits = (uint64_t)value;
+	for ( int i = 0; i < 8; ++i )
+	{
+		hash = ( hash ^ ( bits & 255 ) ) * UINT64_C( 1099511628211 );
+		bits >>= 8;
+	}
+	return hash;
+}
+
+static uint64_t HashVector( uint64_t hash, b3Vec3 v )
+{
+	return HashValue( HashValue( HashValue( hash, v.x ), v.y ), v.z );
+}
+
+int main( void )
+{
+	const int substeps[] = { 1, 2, 4, 8 };
+	for ( int scale = 0; scale < 2; ++scale )
+		for ( int workers = 1; workers <= 8; ++workers )
+			for ( int stepping = 0; stepping < 5; ++stepping )
+				for ( int mode = 0; mode < 5; ++mode )
+				{
+					b3Fixed size = b3FixFromInt( scale == 0 ? 1 : 250 );
+					b3WorldDef worldDef = b3DefaultWorldDef();
+					worldDef.workerCount = workers;
+					worldDef.gravity = b3Vec3_zero;
+					worldDef.enableSleep = mode == 3;
+					b3WorldId world = b3CreateWorld( &worldDef );
+					b3BodyId bodies[33];
+					b3JointId joints[32];
+					b3ShapeDef shape = b3DefaultShapeDef();
+					shape.filter.maskBits = 0;
+					shape.density = B3_FIXED_ONE;
+					b3BoxHull cube = b3MakeCubeHull( size / 2 );
+					for ( int i = 0; i < 33; ++i )
+					{
+						b3BodyDef body = b3DefaultBodyDef();
+						body.type = i == 0 && mode != 4 ? b3_staticBody : b3_dynamicBody;
+						b3Vec3 offset = { size * i, 0, 0 };
+						if ( mode == 4 && i > 0 )
+						{
+							offset = (b3Vec3){ size * ( i % 3 - 1 ), size * ( i / 3 % 3 - 1 ), size * ( i / 9 % 3 - 1 ) };
+						}
+						body.position = b3ToPos( offset );
+						body.angularVelocity = (b3Vec3){ B3_FIX( 0.01f ), i % 2 ? B3_FIX( 0.02f ) : 0, B3_FIX( -0.01f ) };
+						body.linearVelocity.y = size / 100;
+						body.rotation.s = i % 3 == 0 ? -B3_FIXED_ONE : B3_FIXED_ONE;
+						bodies[i] = b3CreateBody( world, &body );
+						b3CreateHullShape( bodies[i], &shape, &cube.base );
+						if ( i == 0 )
+						{
+							continue;
+						}
+						b3SphericalJointDef joint = b3DefaultSphericalJointDef();
+						// The dynamic star in mode 4 forces joints into the overflow color.
+						joint.base.bodyIdA = bodies[mode == 4 ? 0 : i - 1];
+						joint.base.bodyIdB = bodies[i];
+						joint.base.localFrameA.p = mode == 4 ? offset : (b3Vec3){ size / 2, 0, 0 };
+						joint.base.localFrameB.p.x = mode == 4 ? 0 : -size / 2;
+						joint.enableSpring = mode == 1;
+						joint.enableMotor = mode == 1;
+						joint.hertz = B3_FIX( 2.0f );
+						joint.maxMotorTorque = B3_FIX( 100.0f );
+						joint.motorVelocity.y = B3_FIX( 0.01f );
+						joint.enableConeLimit = mode == 2;
+						joint.enableTwistLimit = mode == 2;
+						joint.coneAngle = B3_FIX( 0.3f );
+						joint.lowerTwistAngle = B3_FIX( -0.2f );
+						joint.upperTwistAngle = B3_FIX( 0.2f );
+						joints[i - 1] = b3CreateSphericalJoint( world, &joint );
+					}
+					for ( int frame = 0; frame < 180; ++frame )
+					{
+						if ( frame == 35 )
+						{
+							b3World_EnableWarmStarting( world, false );
+						}
+						if ( frame == 55 )
+						{
+							b3World_EnableWarmStarting( world, true );
+						}
+						if ( mode == 3 )
+						{
+							if ( frame == 30 || frame == 60 || frame == 90 )
+							{
+								for ( int i = 0; i < 32; ++i )
+								{
+									b3SphericalJoint_EnableSpring( joints[i], frame == 30 );
+									b3SphericalJoint_EnableMotor( joints[i], frame == 90 );
+									b3SphericalJoint_EnableConeLimit( joints[i], frame == 60 );
+									b3SphericalJoint_EnableTwistLimit( joints[i], frame == 60 );
+								}
+							}
+							if ( frame == 100 )
+							{
+								b3Body_Disable( bodies[16] );
+							}
+							if ( frame == 105 )
+							{
+								b3Body_Enable( bodies[16] );
+							}
+							if ( frame == 110 )
+							{
+								b3Body_SetAwake( bodies[8], false );
+							}
+							if ( frame == 115 )
+							{
+								b3Body_SetAwake( bodies[8], true );
+							}
+							if ( frame == 120 || frame == 140 )
+							{
+								b3MotionLocks locks = { 0 };
+								locks.angularX = locks.angularY = locks.angularZ = frame == 120;
+								for ( int i = 1; i < 33; ++i )
+								{
+									b3Body_SetMotionLocks( bodies[i], locks );
+								}
+							}
+							if ( frame == 150 )
+							{
+								b3WorldTransform t = b3Body_GetTransform( bodies[12] );
+								t.p.y += size / 10;
+								b3Body_SetTransform( bodies[12], t.p, b3Quat_identity );
+							}
+						}
+						int count = substeps[stepping == 4 ? frame % 4 : stepping];
+						b3Fixed dt = frame == 25 ? 0 : b3FixDiv( B3_FIXED_ONE, b3FixFromInt( 60 ) );
+						b3World_Step( world, dt, count );
+						if ( mode == 4 && frame == 0 && b3World_GetCounters( world ).colorCounts[B3_GRAPH_COLOR_COUNT - 1] == 0 )
+						{
+							fprintf( stderr, "The star scenario did not exercise the overflow solver.\n" );
+							b3DestroyWorld( world );
+							return 1;
+						}
+						uint64_t hash = UINT64_C( 14695981039346656037 );
+						for ( int i = 0; i < 33; ++i )
+						{
+							b3WorldTransform t = b3Body_GetTransform( bodies[i] );
+							hash = HashValue( HashValue( HashValue( hash, t.p.x ), t.p.y ), t.p.z );
+#if defined( BOX3D_LUDICROUS_MODE )
+							hash = HashValue( hash, (int64_t)( (b3UInt128)t.p.x >> 64 ) );
+							hash = HashValue( hash, (int64_t)( (b3UInt128)t.p.y >> 64 ) );
+							hash = HashValue( hash, (int64_t)( (b3UInt128)t.p.z >> 64 ) );
+#endif
+							hash = HashVector( hash, t.q.v );
+							hash = HashValue( hash, t.q.s );
+							hash = HashVector( hash, b3Body_GetLinearVelocity( bodies[i] ) );
+							hash = HashVector( hash, b3Body_GetAngularVelocity( bodies[i] ) );
+							hash = HashValue( hash, b3Body_IsAwake( bodies[i] ) );
+						}
+						for ( int i = 0; i < 32; ++i )
+						{
+							hash = HashVector( hash, b3Joint_GetConstraintForce( joints[i] ) );
+							hash = HashVector( hash, b3Joint_GetConstraintTorque( joints[i] ) );
+						}
+						printf( "%d %d %d %d %d %016" PRIx64 "\n", scale, workers, stepping, mode, frame, hash );
+					}
+					b3DestroyWorld( world );
+				}
+	return 0;
+}


### PR DESCRIPTION
Spherical joints recompute the same rotated anchors during warm start and velocity solving while body poses are unchanged. Cache the two anchors using the existing position-integration generation, invalidate them every prepare stage, and skip angular mass/limit-axis calculations when no enabled feature consumes them. Preserve the exact rotations, rounding, 40-bit inverse scale, 256-bit point solve and stored impulses. Joint Grid improves 12.8% in the balanced four-worker batch and 13.4% in the final recheck; the cache adds 48 bytes per internal joint. Rain and broader controls remain inconclusive on this busy workstation, so the README retains the previous overall float ratio.

The expanded worker checks also exposed an existing race: when every body sleeps, the solver could validate the collision tree before its background rebuild finished. Join that task before validation. A regression scheduler deliberately holds the rebuild until finishTask, reproducing the old Debug assertion reliably and passing the repair. The active solver path is unchanged.

Determinism is a hard requirement. Each joint has one owner per solver stage, and cache validity depends only on synchronized stage generations. A permanent test checks workers 1–8 against uncached goldens and each other's per-frame state, with parallel blocks, serial overflow joints, changing substeps, sleep/wake, body enable/disable, transform changes, feature toggles and rotation locks. Both intentionally stale-cache variants fail the goldens; temporary instrumentation confirmed joint work on all eight workers.

Validation: all 24 suites pass in Debug, optimized scalar, NEON, wide positions, ASan/UBSan and ThreadSanitizer. The standalone comparator matches 144,000 before/after frame hashes across both position widths, 63,000 cross-worker comparisons per build, and identical Debug/scalar/NEON output. Existing physics goldens and asteroid-response tests are unchanged. The benchmark report preserves every timing trial, rejected matrix-cache measurements, binary hashes and the initial fixture's pre-existing impulse-range refusal.

CI now targets 1–2 minute PR feedback: five configurations run all 24 suites, including Linux GCC, Clang Debug, wide positions, Windows optimized clang-cl and macOS optimized NEON. The complete former matrix is preserved in a manually triggered Extended checks workflow, including ThreadSanitizer, MemorySanitizer, ASan/UBSan, MinGW, additional architectures and sample/conversion audits. The result checks still reject failures, cancellations and unexpected skips. Both workflows pass actionlint; a structural comparison confirms all old extended job steps are retained, and 21 result-gate cases verify the failure behavior. CONTRIBUTING.md documents when and how to run extended coverage.
